### PR TITLE
[Context] Fixed context to work with frankenphp worker mode

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContext.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContext.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PayumBundle\PaymentRequest\Context;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /** @experimental */
-final class PaymentRequestContext implements PaymentRequestContextInterface
+final class PaymentRequestContext implements PaymentRequestContextInterface, ResetInterface
 {
     private ?PaymentRequestInterface $paymentRequest = null;
 
@@ -38,5 +39,10 @@ final class PaymentRequestContext implements PaymentRequestContextInterface
     public function disable(): void
     {
         $this->paymentRequest = null;
+    }
+
+    public function reset(): void
+    {
+        $this->disable();
     }
 }

--- a/src/Sylius/Component/Channel/Context/CachedPerRequestChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/CachedPerRequestChannelContext.php
@@ -15,8 +15,9 @@ namespace Sylius\Component\Channel\Context;
 
 use Sylius\Component\Channel\Model\ChannelInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\ResetInterface;
 
-final class CachedPerRequestChannelContext implements ChannelContextInterface
+final class CachedPerRequestChannelContext implements ChannelContextInterface, ResetInterface
 {
     private \SplObjectStorage $requestToChannelMap;
 
@@ -50,5 +51,11 @@ final class CachedPerRequestChannelContext implements ChannelContextInterface
 
             throw $exception;
         }
+    }
+
+    public function reset(): void
+    {
+        $this->requestToChannelMap = new \SplObjectStorage();
+        $this->requestToExceptionMap = new \SplObjectStorage();
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | pull request https://github.com/Sylius/Sylius/pull/17999
| License         | MIT

I tried to make Sylius working on Frankenphp with the worker mode (https://frankenphp.dev/docs/worker/) and a face an issue by trying to add a product to the cart. Doctrine failed to persist in database.
>ORMInvalidArgumentException
Doctrine\ORM\ORMInvalidArgumentException:
A new entity was found through the relationship 'App\Entity\Order\Order#channel' that was not configured to cascade persist operations for entity: Fashion Web Store. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example #[ORM\ManyToOne(..., cascade: ['persist'])].

I ran Claude (see mea culpa at the end) to see if he had an idea to solve this and he ended up with an explanation that was close to an already merged pull request (https://github.com/Sylius/Sylius/pull/17999) and it seems to be an stateful <> stateless problem.

Here is the Claude explanation : 

> This is a classic worker mode bug caused by Doctrine EntityManager state leaking between requests.
In classic mode (without worker): each HTTP request = a new PHP process = a new EntityManager = clean state. Everything is destroyed at the end of the request.
In worker mode: PHP stays in memory between requests. The problem:
>1. **Request 1** (product page load): Doctrine loads the `Channel` entity ("Fashion Web Store") into its Identity Map via the EntityManager
>2. **Request 2** (add to cart): The worker reuses the same PHP process. Symfony creates a new EntityManager (the kernel is reset), but the `Channel` object loaded in request 1 is still lingering in memory — it's a PHP reference that was never destroyed
>3. When Sylius creates the `Order` and associates it with this `Channel`, Doctrine sees a `Channel` object it doesn't recognize in its new UnitOfWork → it treats it as a new unpersisted entity → error

>**Root cause**
This is an incomplete service reset between worker requests. The `Channel` is likely stored in a singleton service or a channel context (`ChannelContext`) that survives the kernel reset between requests.

More Claude explanation : 

>1. This service uses an `SplObjectStorage` indexed by the `Request` object to cache the `Channel`
>2. In worker mode, this service is **the same PHP object between requests** (it doesn't implement Symfony's `ResetInterface`)
>3. The `SplObjectStorage` keeps in memory the `Channel` entity loaded by a **previous EntityManager**
>4. On the next request, Symfony resets the EntityManager (new UnitOfWork), but the `CachedPerRequestChannelContext` is **never cleared**
>5. In theory, it's indexed by the `Request` object (which changes on each request), so it should work... **except** that the `Channel` entity it returns was loaded by the old EntityManager
>6. When Doctrine persists the `Order` that references this "ghost" `Channel`, it can't find it in its current UnitOfWork → `ORMInvalidArgumentException`

>**Without worker**: PHP process destroyed after each request → everything is fresh, no leaks.

>**With worker**: the `Channel` entity survives in memory through the `CachedPerRequestChannelContext` cache (or a similar mechanism). The new EntityManager doesn't know about it → Doctrine thinks it's a new unpersisted entity.

>This is a **Sylius/worker mode compatibility issue** — Sylius hasn't yet marked all its stateful services with `#[AsTaggedItem]` / `ResetInterface` for resetting between worker requests.

Here is some related tickets : https://github.com/Sylius/Sylius/pulls?q=is%3Apr+ResetInterface+
It seems to have 2 approach : tag the service or implement the ResetInterface. I don't know which one is the best.


You can try Sylius with frankenphp with my project from sylius standard with docker compose modified to work -> https://github.com/AymLaf/test-sylius-franken
Once the containers were started, I modified the CachedPerRequestChannelContext to test it and it was working, I was able to add a product to my cart.


_Mea culpa : I'm not comfortable with the ResetInterface / stateful / stateless things and I know it's a bad thing to make a pull request without understanding everything but the fact it has already been done on the other pull request makes me think it's okay to open a PR to discuss about that. As Frankenphp is more and more important in the php ecosystem I think it's important to, make it work well._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Payment processing now includes enhanced reset functionality to properly clear stored data and ensure clean state transitions between different payment operations and user sessions.
  * Channel management caching now supports reset operations to clear and properly reinitialize cached data, enhancing system reliability and improving state management accuracy between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->