### PR TITLE
Resolve flash alert correctly without breaking translation

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/shared/flashes.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/flashes.html.twig
@@ -2,11 +2,9 @@
     {% for type in ['success', 'error', 'info', 'warning'] %}
         {% for flash in app.session.flashbag.get(type) %}
             {% set header = 'sylius.ui.'~type %}
-            {% if type == 'error' %}
-                {% set type = 'danger' %}
-            {% endif %}
+            {% set alert_class = type == 'error' ? 'danger' : type %}
 
-            <div class="alert alert-{{ type }} my-2" role="alert" data-test-sylius-flash-message>
+            <div class="alert alert-{{ alert_class }} my-2" role="alert" data-test-sylius-flash-message>
                 <div class="d-flex justify-content-between">
                     <div class="fw-bold">{{ header|trans }}</div>
                     <span class="close" data-bs-dismiss="alert" aria-label="Close">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<img width="552" height="422" alt="image" src="https://github.com/user-attachments/assets/4e4c0084-d99f-49da-9165-3772c5e2cd89" />

The core issue is that we are overwriting the type in the loop, to show correct alert, but it breaks the translation key when iterating on more than one error
