### PR TITLE
Disable order by identifier by default

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,5 +1,17 @@
 # UPGRADE FROM `2.2` TO `2.3`
 
+## Configuration
+
+1. The default value of `sylius_core.order_by_identifier` has been changed from `true` to `false`. ([#18956](https://github.com/Sylius/Sylius/pull/18956))
+
+   The `OrderByIdentifierSqlWalker` is no longer enabled by default.
+   If your application relies on ordering by identifier, enable it explicitly in your configuration:
+
+   ```yaml
+   sylius_core:
+       order_by_identifier: true
+   ```
+
 ## Dependencies
 
 1. The `knplabs/gaufrette` and `knplabs/knp-gaufrette-bundle` packages have been removed.

--- a/config/packages/test/_sylius.yaml
+++ b/config/packages/test/_sylius.yaml
@@ -25,3 +25,6 @@ sylius_payment:
     encryption:
         disabled_for_factories:
             - online-disabled
+
+sylius_core:
+    order_by_identifier: true

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -57,7 +57,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
                 ->booleanNode('prepend_doctrine_migrations')->defaultTrue()->end()
                 ->booleanNode('shipping_address_based_taxation')->defaultFalse()->end()
-                ->booleanNode('order_by_identifier')->defaultTrue()->end()
+                ->booleanNode('order_by_identifier')->defaultFalse()->end()
                 ->booleanNode('process_shipments_before_recalculating_prices')
                     ->setDeprecated('sylius/sylius', '1.10', 'The "%path%.%node%" parameter is deprecated and will be removed in 2.0.')
                     ->defaultFalse()

--- a/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/ConfigurationTest.php
@@ -48,7 +48,7 @@ final class ConfigurationTest extends TestCase
     {
         $this->assertProcessedConfigurationEquals(
             [[]],
-            ['order_by_identifier' => true],
+            ['order_by_identifier' => false],
             'order_by_identifier',
         );
     }

--- a/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -92,7 +92,7 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
 
         $this->load();
 
-        $this->assertContainerBuilderHasParameter('sylius_core.order_by_identifier', true);
+        $this->assertContainerBuilderHasParameter('sylius_core.order_by_identifier', false);
     }
 
     #[Test]


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added upgrade notes describing the default query ordering change and how to restore prior behavior.

* **Configuration**
  * Default query ordering is now disabled by default; opt-in is required to re-enable ordering by identifier.
  * Test environment configuration updated to preserve previous ordering behavior for tests.

* **Tests**
  * Updated expectations to reflect the new default ordering setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->