### PR TITLE
Allow choosing different payment method with skip payment step when it gets disabled

### DIFF
--- a/features/shop/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/shop/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -45,3 +45,35 @@ Feature: Skipping payment step when only one payment method is available
         When I complete addressing step with email "guest@example.com" and "United States" based billing address
         And I complete the shipping step with the first shipping method
         Then I should be on the checkout payment step
+
+    @api @ui
+    Scenario: Being able to recover after the auto-selected payment method gets disabled
+        Given the payment method "Bank transfer" is disabled
+        And the store allows paying with "Offline"
+        And I added product "Guards! Guards!" to the cart
+        And I complete addressing step with email "guest@example.com" and "United States" based billing address
+        And I complete the shipping step with the first shipping method
+        And the payment method "Offline" is disabled
+        And the payment method "Bank transfer" is enabled
+        When I try to confirm my order
+        Then I should be informed that this payment method has been disabled
+        When I go back to payment step of the checkout
+        And I choose "Bank transfer" payment method
+        And I confirm my order
+        Then I should see the thank you page
+
+    @api @ui
+    Scenario: Being able to recover after the auto-selected payment method gets removed from channel
+        Given the payment method "Bank transfer" is disabled
+        And the store allows paying with "Offline"
+        And I added product "Guards! Guards!" to the cart
+        And I complete addressing step with email "guest@example.com" and "United States" based billing address
+        And I complete the shipping step with the first shipping method
+        And the payment method "Offline" has been disabled in "United States" channel
+        And the payment method "Bank transfer" is enabled
+        When I try to confirm my order
+        Then I should be informed that this payment method has been disabled
+        When I go back to payment step of the checkout
+        And I choose "Bank transfer" payment method
+        And I confirm my order
+        Then I should see the thank you page

--- a/features/shop/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/shop/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -55,8 +55,8 @@ Feature: Skipping payment step when only one payment method is available
         And I complete the shipping step with the first shipping method
         And the payment method "Offline" is disabled
         And the payment method "Bank transfer" is enabled
-        When I try to confirm my order
-        Then I should be informed that this payment method has been disabled
+        And I have tried to confirm my order
+        And I have been informed that this payment method has been disabled
         When I go back to payment step of the checkout
         And I choose "Bank transfer" payment method
         And I confirm my order
@@ -71,8 +71,8 @@ Feature: Skipping payment step when only one payment method is available
         And I complete the shipping step with the first shipping method
         And the payment method "Offline" has been disabled in "United States" channel
         And the payment method "Bank transfer" is enabled
-        When I try to confirm my order
-        Then I should be informed that this payment method has been disabled
+        And I have tried to confirm my order
+        And I have been informed that this payment method has been disabled
         When I go back to payment step of the checkout
         And I choose "Bank transfer" payment method
         And I confirm my order

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -444,9 +444,8 @@ final class CheckoutContext implements Context
         $this->sharedStorage->set('order', $this->orderRepository->findOneByNumber($this->sharedStorage->get('order_number')));
     }
 
-    /**
-     * @When I try to confirm my order
-     */
+    #[Given('I have tried to confirm my order')]
+    #[When('I try to confirm my order')]
     public function iTryToConfirmMyOrder(): void
     {
         $response = $this->completeOrder();
@@ -1152,9 +1151,8 @@ final class CheckoutContext implements Context
         $this->hasProvinceNameInAddress($provinceName, $addressType);
     }
 
-    /**
-     * @Then /^I should be informed that (this payment method) has been disabled$/
-     */
+    #[Given('/^I have been informed that (this payment method) has been disabled$/')]
+    #[Then('/^I should be informed that (this payment method) has been disabled$/')]
     public function iShouldBeInformedThatThisPaymentMethodHasBeenDisabled(PaymentMethodInterface $paymentMethod): void
     {
         $response = $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -110,6 +110,7 @@ final class CheckoutContext implements Context
     }
 
     #[When('the customer is at the checkout payment step')]
+    #[When('I go back to payment step of the checkout')]
     public function theCustomerIsAtTheCheckoutPaymentStep(): void
     {
         // Intentionally left blank, as this is a UI-specific action.

--- a/src/Sylius/Behat/Context/Setup/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentContext.php
@@ -123,6 +123,15 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
+    #[Given('the payment method :paymentMethod is enabled')]
+    #[Given('the payment method :paymentMethod gets enabled')]
+    public function theStoreHasAPaymentMethodEnabled(PaymentMethodInterface $paymentMethod): void
+    {
+        $paymentMethod->enable();
+
+        $this->paymentMethodManager->flush();
+    }
+
     /**
      * @Given /^(it) has instructions "([^"]+)"$/
      */

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Context\Ui\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
 use Doctrine\ORM\EntityManagerInterface;
@@ -100,6 +101,7 @@ final readonly class CheckoutCompleteContext implements Context
      * @Given the customer confirmed the order
      * @When I try to confirm my order
      */
+    #[Given('I have tried to confirm my order')]
     #[When('I confirm my order')]
     public function iConfirmMyOrder(): void
     {
@@ -325,9 +327,8 @@ final readonly class CheckoutCompleteContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be informed that (this payment method) has been disabled$/
-     */
+    #[Given('/^I have been informed that (this payment method) has been disabled$/')]
+    #[Then('/^I should be informed that (this payment method) has been disabled$/')]
     public function iShouldBeInformedThatThisPaymentMethodHasBeenDisabled(PaymentMethodInterface $paymentMethod): void
     {
         Assert::same(

--- a/src/Sylius/Bundle/CoreBundle/EventListener/Workflow/OrderCheckout/BlockSelectPaymentFromPaymentSkippedListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/Workflow/OrderCheckout/BlockSelectPaymentFromPaymentSkippedListener.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\EventListener\Workflow\OrderCheckout;
+
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionAvailabilityCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Webmozart\Assert\Assert;
+
+final readonly class BlockSelectPaymentFromPaymentSkippedListener
+{
+    public function __construct(
+        private OrderPaymentMethodSelectionAvailabilityCheckerInterface $orderPaymentMethodSelectionAvailabilityChecker,
+    ) {
+    }
+
+    public function __invoke(GuardEvent $event): void
+    {
+        if (!$event->getMarking()->has(OrderCheckoutStates::STATE_PAYMENT_SKIPPED)) {
+            return;
+        }
+
+        $order = $event->getSubject();
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        if (!$this->orderPaymentMethodSelectionAvailabilityChecker->isPaymentMethodSelectionAvailable($order)) {
+            $event->setBlocked(true, 'Payment method selection is not allowed for an order with zero total.');
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_order_checkout.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_order_checkout.yml
@@ -32,6 +32,12 @@ winzou_state_machine:
                 from: [payment_selected, payment_skipped]
                 to: completed
         callbacks:
+            guard:
+                sylius_block_select_payment_from_payment_skipped:
+                    on: ["select_payment"]
+                    from: ["payment_skipped"]
+                    do: ["@sylius.checker.order_payment_method_selection_availability", "isPaymentMethodSelectionAvailable"]
+                    args: ["object"]
             after:
                 sylius_process_cart:
                     on: ["select_shipping", "address", "select_payment", "skip_shipping", "skip_payment"]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_order_checkout.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_order_checkout.yml
@@ -26,7 +26,7 @@ winzou_state_machine:
                 from: [shipping_selected, shipping_skipped]
                 to: payment_skipped
             select_payment:
-                from: [payment_selected, shipping_skipped, shipping_selected]
+                from: [payment_selected, payment_skipped, shipping_skipped, shipping_selected]
                 to: payment_selected
             complete:
                 from: [payment_selected, payment_skipped]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/workflow/sylius_order_checkout.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/workflow/sylius_order_checkout.yaml
@@ -45,6 +45,7 @@ framework:
                 !php/const Sylius\Component\Core\OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT:
                     from:
                         - !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_PAYMENT_SELECTED
+                        - !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_PAYMENT_SKIPPED
                         - !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_SHIPPING_SKIPPED
                         - !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_SHIPPING_SELECTED
                     to: !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_PAYMENT_SELECTED

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
@@ -27,6 +27,9 @@
         </service>
         <service id="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface" alias="sylius.checker.order_payment_method_selection_requirement" />
 
+        <service id="sylius.checker.order_payment_method_selection_availability" class="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionAvailabilityChecker" public="true" />
+        <service id="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionAvailabilityCheckerInterface" alias="sylius.checker.order_payment_method_selection_availability" />
+
         <service id="sylius.checker.cli_context" class="Sylius\Component\Core\Checker\CLIContextChecker">
             <argument type="service" id="request_stack" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners/workflow/order_checkout.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners/workflow/order_checkout.xml
@@ -50,5 +50,10 @@
             <argument type="service" id="sylius.state_resolver.order_shipping" />
             <tag name="kernel.event_listener" event="workflow.sylius_order_checkout.completed.complete" priority="100"/>
         </service>
+
+        <service id="sylius.listener.workflow.order_checkout.block_select_payment_from_payment_skipped" class="Sylius\Bundle\CoreBundle\EventListener\Workflow\OrderCheckout\BlockSelectPaymentFromPaymentSkippedListener">
+            <argument type="service" id="sylius.checker.order_payment_method_selection_availability" />
+            <tag name="kernel.event_listener" event="workflow.sylius_order_checkout.guard.select_payment" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/tests/EventListener/Workflow/OrderCheckout/BlockSelectPaymentFromPaymentSkippedListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/EventListener/Workflow/OrderCheckout/BlockSelectPaymentFromPaymentSkippedListenerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\CoreBundle\EventListener\Workflow\OrderCheckout;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\EventListener\Workflow\OrderCheckout\BlockSelectPaymentFromPaymentSkippedListener;
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionAvailabilityCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+
+final class BlockSelectPaymentFromPaymentSkippedListenerTest extends TestCase
+{
+    private MockObject&OrderPaymentMethodSelectionAvailabilityCheckerInterface $availabilityChecker;
+
+    private BlockSelectPaymentFromPaymentSkippedListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->availabilityChecker = $this->createMock(OrderPaymentMethodSelectionAvailabilityCheckerInterface::class);
+        $this->listener = new BlockSelectPaymentFromPaymentSkippedListener($this->availabilityChecker);
+    }
+
+    public function testItDoesNothingWhenMarkingIsNotPaymentSkipped(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $event = $this->createGuardEvent($order, ['shipping_selected' => 1]);
+
+        $this->availabilityChecker->expects($this->never())->method('isPaymentMethodSelectionAvailable');
+
+        ($this->listener)($event);
+
+        $this->assertFalse($event->isBlocked());
+    }
+
+    public function testItBlocksTransitionWhenSelectingPaymentIsNotAvailable(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $event = $this->createGuardEvent($order, [OrderCheckoutStates::STATE_PAYMENT_SKIPPED => 1]);
+
+        $this->availabilityChecker
+            ->expects($this->once())
+            ->method('isPaymentMethodSelectionAvailable')
+            ->with($order)
+            ->willReturn(false)
+        ;
+
+        ($this->listener)($event);
+
+        $this->assertTrue($event->isBlocked());
+    }
+
+    public function testItDoesNotBlockTransitionWhenSelectingPaymentIsAvailable(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $event = $this->createGuardEvent($order, [OrderCheckoutStates::STATE_PAYMENT_SKIPPED => 1]);
+
+        $this->availabilityChecker
+            ->expects($this->once())
+            ->method('isPaymentMethodSelectionAvailable')
+            ->with($order)
+            ->willReturn(true)
+        ;
+
+        ($this->listener)($event);
+
+        $this->assertFalse($event->isBlocked());
+    }
+
+    public function testItThrowsAnExceptionOnNonSupportedSubject(): void
+    {
+        $event = $this->createGuardEvent(new \stdClass(), [OrderCheckoutStates::STATE_PAYMENT_SKIPPED => 1]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        ($this->listener)($event);
+    }
+
+    private function createGuardEvent(object $subject, array $places): GuardEvent
+    {
+        return new GuardEvent(
+            $subject,
+            new Marking($places),
+            new Transition('select_payment', OrderCheckoutStates::STATE_PAYMENT_SKIPPED, 'payment_selected'),
+        );
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/OrderCheckoutWorkflowTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/OrderCheckoutWorkflowTest.php
@@ -180,6 +180,7 @@ final class OrderCheckoutWorkflowTest extends KernelTestCase
     {
         yield ['address', 'addressed'];
         yield ['select_shipping', 'shipping_selected'];
+        yield ['select_payment', 'payment_selected'];
         yield ['complete', 'completed'];
     }
 

--- a/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/OrderCheckoutWorkflowTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/OrderCheckoutWorkflowTest.php
@@ -180,7 +180,6 @@ final class OrderCheckoutWorkflowTest extends KernelTestCase
     {
         yield ['address', 'addressed'];
         yield ['select_shipping', 'shipping_selected'];
-        yield ['select_payment', 'payment_selected'];
         yield ['complete', 'completed'];
     }
 

--- a/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionAvailabilityChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionAvailabilityChecker.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+final class OrderPaymentMethodSelectionAvailabilityChecker implements OrderPaymentMethodSelectionAvailabilityCheckerInterface
+{
+    public function isPaymentMethodSelectionAvailable(OrderInterface $order): bool
+    {
+        return $order->getTotal() > 0;
+    }
+}

--- a/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionAvailabilityCheckerInterface.php
+++ b/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionAvailabilityCheckerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+interface OrderPaymentMethodSelectionAvailabilityCheckerInterface
+{
+    public function isPaymentMethodSelectionAvailable(OrderInterface $order): bool;
+}

--- a/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementChecker.php
@@ -33,7 +33,14 @@ final class OrderPaymentMethodSelectionRequirementChecker implements OrderPaymen
         }
 
         foreach ($order->getPayments() as $payment) {
-            if (count($this->paymentMethodsResolver->getSupportedMethods($payment)) !== 1) {
+            $supportedMethods = $this->paymentMethodsResolver->getSupportedMethods($payment);
+
+            if (count($supportedMethods) !== 1) {
+                return true;
+            }
+
+            $currentMethod = $payment->getMethod();
+            if (null !== $currentMethod && !in_array($currentMethod, $supportedMethods, true)) {
                 return true;
             }
         }

--- a/src/Sylius/Component/Core/tests/Checker/OrderPaymentMethodSelectionRequirementCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Checker/OrderPaymentMethodSelectionRequirementCheckerTest.php
@@ -88,9 +88,44 @@ final class OrderPaymentMethodSelectionRequirementCheckerTest extends TestCase
             ->method('getSupportedMethods')
             ->with($this->payment)
             ->willReturn([$this->paymentMethod]);
+        $this->payment->expects($this->once())->method('getMethod')->willReturn(null);
         $this->channel->expects($this->once())->method('isSkippingPaymentStepAllowed')->willReturn(true);
 
         $this->assertFalse($this->checker->isPaymentMethodSelectionRequired($this->order));
+    }
+
+    public function testShouldSayThatPaymentMethodDoesNotHaveToBeSelectedIfCurrentlySetMethodIsAmongSupportedMethods(): void
+    {
+        $this->order->expects($this->once())->method('getTotal')->willReturn(1000);
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->order->expects($this->exactly(2))->method('getPayments')->willReturn(new ArrayCollection([$this->payment]));
+        $this->paymentMethodsResolver
+            ->expects($this->once())
+            ->method('getSupportedMethods')
+            ->with($this->payment)
+            ->willReturn([$this->paymentMethod]);
+        $this->payment->expects($this->once())->method('getMethod')->willReturn($this->paymentMethod);
+        $this->channel->expects($this->once())->method('isSkippingPaymentStepAllowed')->willReturn(true);
+
+        $this->assertFalse($this->checker->isPaymentMethodSelectionRequired($this->order));
+    }
+
+    public function testShouldSayThatPaymentMethodHasToBeSelectedIfCurrentlySetMethodIsNotAmongSupportedMethods(): void
+    {
+        $disabledPaymentMethod = $this->createMock(PaymentMethodInterface::class);
+
+        $this->order->expects($this->once())->method('getTotal')->willReturn(1000);
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->order->expects($this->exactly(2))->method('getPayments')->willReturn(new ArrayCollection([$this->payment]));
+        $this->paymentMethodsResolver
+            ->expects($this->once())
+            ->method('getSupportedMethods')
+            ->with($this->payment)
+            ->willReturn([$this->paymentMethod]);
+        $this->payment->expects($this->once())->method('getMethod')->willReturn($disabledPaymentMethod);
+        $this->channel->expects($this->once())->method('isSkippingPaymentStepAllowed')->willReturn(true);
+
+        $this->assertTrue($this->checker->isPaymentMethodSelectionRequired($this->order));
     }
 
     public function testShouldSayThatPaymentMethodHasToBeSelectedIfSkippingPaymentStepIsEnabledAndThereAreMoreThanOnePaymentMethodsAvailable(): void


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #11678
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The new transition needs to be added to state machine to allow to come back to payment select step, example - we've proceeded to order complete:
<img width="768" height="227" alt="image" src="https://github.com/user-attachments/assets/37e3d011-ebd3-4815-9a5e-ce284905b5b9" />

Then the payment method have been disabled and other one enabled:
<img width="1287" height="496" alt="image" src="https://github.com/user-attachments/assets/f15c2fe2-609e-49cf-949f-85d32251a112" />

The changes brings back the payment select step, but its non possible to go back there becouse of the state machine transition being in skip payment state, the only way in this case is to come back to shipping:
<img width="1602" height="724" alt="image" src="https://github.com/user-attachments/assets/d95bd393-bf4c-4627-b78a-4249a4566110" />


