### PR TITLE
Change total taxon rule calculation

### DIFF
--- a/features/shop/promotion/applying_promotion_coupon/applying_coupon_with_total_of_items_from_taxon_rule.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_coupon_with_total_of_items_from_taxon_rule.feature
@@ -1,0 +1,92 @@
+@applying_promotion_coupon
+Feature: Applying coupon with "total price of items from taxon" rule based on original item prices
+    In order to correctly apply a coupon with a minimum total requirement from a specific taxon
+    As a Customer
+    I want the coupon eligibility to be checked against the original unit prices, not discounted totals
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store classifies its products as "T-Shirts" and "Mugs"
+        And the store has a product "PHP T-Shirt" priced at "$25.00"
+        And it belongs to "T-Shirts"
+        And the store has a product "PHP Mug" priced at "$15.00"
+        And it belongs to "Mugs"
+        And the store ships everywhere for Free
+        And the store allows paying "Cash on Delivery"
+        And I am a logged in customer
+
+    @api
+    Scenario: Coupon remains valid when its own discount brings the items total below the minimum value threshold
+        Given the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$70.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "TSHIRTS10"
+        When I use coupon with code "TSHIRTS10"
+        Then my cart total should be "$65.00"
+        And my discount should be "-$10.00"
+
+    @api
+    Scenario: Coupon with taxon total rule can be applied when an automatic promotion already discounts items from that taxon
+        Given there is a promotion "T-Shirts auto discount"
+        And it gives "10%" off every product classified as "T-Shirts"
+        And the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$5.00" off if order contains products classified as "T-Shirts" with a minimum value of "$70.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        When I use coupon with code "TSHIRTS10"
+        Then my cart total should be "$62.50"
+        And my discount should be "-$12.50"
+
+    @api
+    Scenario: Coupon remains valid after re-validation when cumulative discounts from overlapping promotions bring items total well below the threshold
+        Given there is a promotion "T-Shirts auto discount"
+        And it gives "10%" off every product classified as "T-Shirts"
+        And the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$65.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "TSHIRTS10"
+        When I use coupon with code "TSHIRTS10"
+        Then my cart total should be "$57.50"
+        And my discount should be "-$17.50"
+
+    @api
+    Scenario: Coupon with taxon total rule does not apply when items from the taxon genuinely do not meet the required minimum value
+        Given the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$70.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I use coupon with code "TSHIRTS10"
+        Then I should be notified that the coupon is invalid
+        And my cart total should be "$50.00"
+        And there should be no discount applied
+
+    @api
+    Scenario: Coupon with taxon total rule applies only to items from the specified taxon, ignoring items from other taxons when checking the minimum value
+        Given the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$5.00" off if order contains products classified as "T-Shirts" with a minimum value of "$70.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I added 3 products "PHP Mug" to the cart
+        When I use coupon with code "TSHIRTS10"
+        Then I should be notified that the coupon is invalid
+        And my cart total should be "$95.00"
+        And there should be no discount applied
+
+    @api @ui
+    Scenario: Discount is correctly applied when a coupon with taxon total rule is used
+        Given the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$70.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "TSHIRTS10"
+        When I check the details of my cart
+        Then my cart total should be "$65.00"
+        And my discount should be "-$10.00"
+
+    @api @ui
+    Scenario: Discount from overlapping automatic and coupon promotions is correctly applied when taxon items meet the threshold
+        Given there is a promotion "T-Shirts auto discount"
+        And it gives "10%" off every product classified as "T-Shirts"
+        And the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$5.00" off if order contains products classified as "T-Shirts" with a minimum value of "$70.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "TSHIRTS10"
+        When I check the details of my cart
+        Then my cart total should be "$62.50"
+        And my discount should be "-$12.50"

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
@@ -61,7 +61,7 @@ final class TotalOfItemsFromTaxonRuleChecker implements RuleCheckerInterface
         /** @var OrderItemInterface $item */
         foreach ($subject->getItems() as $item) {
             if ($item->getProduct()->hasTaxon($targetTaxon)) {
-                $itemsWithTaxonTotal += $item->getTotal();
+                $itemsWithTaxonTotal += $item->getQuantity() * $item->getUnitPrice();
             }
         }
 

--- a/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleCheckerTest.php
@@ -86,12 +86,14 @@ final class TotalOfItemsFromTaxonRuleCheckerTest extends TestCase
             ->willReturn($this->bows);
         $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
         $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
-        $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
+        $this->compositeBowItem->expects($this->once())->method('getQuantity')->willReturn(1);
+        $this->compositeBowItem->expects($this->once())->method('getUnitPrice')->willReturn(5000);
         $this->longswordItem->expects($this->once())->method('getProduct')->willReturn($this->longsword);
         $this->longsword->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(false);
         $this->reflexBowItem->expects($this->once())->method('getProduct')->willReturn($this->reflexBow);
         $this->reflexBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
-        $this->reflexBowItem->expects($this->once())->method('getTotal')->willReturn(9000);
+        $this->reflexBowItem->expects($this->once())->method('getQuantity')->willReturn(1);
+        $this->reflexBowItem->expects($this->once())->method('getUnitPrice')->willReturn(9000);
 
         $this->assertTrue(
             $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]]),
@@ -113,10 +115,12 @@ final class TotalOfItemsFromTaxonRuleCheckerTest extends TestCase
             ->willReturn($this->bows);
         $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
         $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
-        $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
+        $this->compositeBowItem->expects($this->once())->method('getQuantity')->willReturn(2);
+        $this->compositeBowItem->expects($this->once())->method('getUnitPrice')->willReturn(2500);
         $this->reflexBowItem->expects($this->once())->method('getProduct')->willReturn($this->reflexBow);
         $this->reflexBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
-        $this->reflexBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
+        $this->reflexBowItem->expects($this->once())->method('getQuantity')->willReturn(1);
+        $this->reflexBowItem->expects($this->once())->method('getUnitPrice')->willReturn(5000);
 
         $this->assertTrue(
             $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]]),
@@ -138,12 +142,35 @@ final class TotalOfItemsFromTaxonRuleCheckerTest extends TestCase
             ->willReturn($this->bows);
         $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
         $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
-        $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
+        $this->compositeBowItem->expects($this->once())->method('getQuantity')->willReturn(1);
+        $this->compositeBowItem->expects($this->once())->method('getUnitPrice')->willReturn(5000);
         $this->longswordItem->expects($this->once())->method('getProduct')->willReturn($this->longsword);
         $this->longsword->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(false);
 
         $this->assertFalse(
             $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]]),
+        );
+    }
+
+    public function testShouldRecognizeSubjectAsEligibleBasedOnOriginalUnitPriceEvenWhenDiscountsAreApplied(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->order->expects($this->once())->method('getItems')->willReturn(new ArrayCollection([
+            $this->compositeBowItem,
+        ]));
+        $this->taxonRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['code' => 'bows'])
+            ->willReturn($this->bows);
+        $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
+        $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
+        $this->compositeBowItem->expects($this->once())->method('getQuantity')->willReturn(3);
+        $this->compositeBowItem->expects($this->once())->method('getUnitPrice')->willReturn(2038);
+
+        $this->assertTrue(
+            $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 6000]]),
         );
     }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #16303
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed promotion coupon eligibility calculation for rules based on taxon item totals. Coupons now evaluate eligibility using original unit prices rather than discounted amounts, ensuring consistent validation when combined with other automatic promotions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->