### PR TITLE
FEAT: [AdminBundle] adjust customer autocomplete filter to display guest customers

### DIFF
--- a/features/admin/order/managing_orders/order_filtration/filtering_orders_by_customer.feature
+++ b/features/admin/order/managing_orders/order_filtration/filtering_orders_by_customer.feature
@@ -12,6 +12,8 @@ Feature: Filtering orders by a customer
         And this customer has also placed an order "#00000002" at "2016-12-05 09:00"
         And the store has customer "Ghastly Bespoke" with email "ghastly@suits.com"
         And this customer has also placed an order "#00000003" at "2016-12-06 10:00"
+        And the store has customer "guest@example.com"
+        And this customer has also placed an order "#00000004" at "2016-12-07 11:00"
         And I am logged in as an administrator
 
     @api @ui @mink:chromedriver
@@ -27,3 +29,10 @@ Feature: Filtering orders by a customer
         And I filter by customer "ghastly@suits.com"
         Then I should see a single order in the list
         And I should see an order with "#00000003" number
+
+    @api @ui @mink:chromedriver
+    Scenario: Filtering orders by a guest customer without a name
+        When I browse orders
+        And I filter by customer "guest@example.com"
+        Then I should see a single order in the list
+        And I should see an order with "#00000004" number

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -177,7 +177,7 @@ final readonly class ManagingOrdersContext implements Context
     #[When('I filter by customer :customer')]
     public function iFilterByCustomer(CustomerInterface $customer): void
     {
-        $this->indexPage->specifyFilterCustomer($customer->getFullName());
+        $this->indexPage->specifyFilterCustomer($customer->getNameOrEmail());
         $this->iFilter();
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Grid/OrderGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/OrderGrid.php
@@ -135,7 +135,7 @@ final class OrderGrid implements OrderGridInterface
                     ->setFormOptions([
                         'extra_options' => [
                             'class' => $this->customerClass,
-                            'choice_label' => 'fullname',
+                            'choice_label' => 'nameOrEmail',
                         ],
                     ]),
                 Filter::create('date', 'date')

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
@@ -115,7 +115,7 @@ sylius_grid:
                     form_options:
                         extra_options:
                             class: '%sylius.model.customer.class%'
-                            choice_label: fullname
+                            choice_label: nameOrEmail
                 date:
                     type: date
                     label: sylius.ui.date

--- a/src/Sylius/Component/Customer/Model/Customer.php
+++ b/src/Sylius/Component/Customer/Model/Customer.php
@@ -93,8 +93,12 @@ class Customer implements CustomerInterface, \Stringable
     {
         $fullName = $this->getFullName();
 
-        if ('' !== $fullName) {
+        if ('' !== $fullName && null !== $this->email) {
             return sprintf('%s (%s)', $fullName, $this->email);
+        }
+
+        if ('' !== $fullName) {
+            return $fullName;
         }
 
         return (string) $this->email;

--- a/src/Sylius/Component/Customer/Model/Customer.php
+++ b/src/Sylius/Component/Customer/Model/Customer.php
@@ -89,6 +89,17 @@ class Customer implements CustomerInterface, \Stringable
         return trim(sprintf('%s %s', $this->firstName, $this->lastName));
     }
 
+    public function getNameOrEmail(): string
+    {
+        $fullName = $this->getFullName();
+
+        if ('' !== $fullName) {
+            return sprintf('%s (%s)', $fullName, $this->email);
+        }
+
+        return (string) $this->email;
+    }
+
     public function getFirstName(): ?string
     {
         return $this->firstName;

--- a/src/Sylius/Component/Customer/Model/CustomerInterface.php
+++ b/src/Sylius/Component/Customer/Model/CustomerInterface.php
@@ -37,6 +37,8 @@ interface CustomerInterface extends TimestampableInterface, ResourceInterface
 
     public function getFullName(): string;
 
+    public function getNameOrEmail(): string;
+
     public function getFirstName(): ?string;
 
     public function setFirstName(?string $firstName): void;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | #18980

## Summary

- Guest customers (without first/last name, only email) appeared as **blank entries** in the order grid's customer autocomplete filter, making them impossible to find and select
- Added `getNameOrEmail()` to `CustomerInterface` / `Customer` which displays:
  - `"Full Name (email)"` when both are present
  - `"Full Name"` when email is null
  - `"email"` when name is empty (guest customers)
- Updated the order grid customer filter `choice_label` from `fullname` to `nameOrEmail`

## Test plan

- [ ] Create a guest order (checkout without registering, only providing email)
- [ ] Go to Admin > Orders > Filter by Customer
- [ ] Type the guest's email — the guest customer should appear in the autocomplete dropdown with their email as the label
- [ ] Registered customers should appear as `"Full Name (email@example.com)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin order grid now displays customer as "Name (email)" or fallback to name/email, improving identification in filters and selection.
* **Chores**
  * Added support across the customer model and admin configuration for the new display option used by the order grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->