### PR TITLE
Do not eagerly load filtered productTaxons in findByTaxon

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -250,7 +250,6 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
         return $this
             ->createQueryBuilder('product')
             ->distinct()
-            ->addSelect('productTaxon')
             ->innerJoin('product.productTaxons', 'productTaxon')
             ->andWhere('productTaxon.taxon = :taxon')
             ->setParameter('taxon', $taxon)


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/16683
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
