### PR TITLE
Fix attribute card style for product show

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes.html.twig
@@ -6,37 +6,35 @@
             {{ 'sylius.ui.attributes'|trans }}
         </div>
     </div>
-    <div {{ sylius_test_html_attribute('attributes') }}>
-        <div class="bg-white mb-3">
-            <div class="accordion accordion-flush" id="attribute-translations">
-                {% set set_locale_codes = [] %}
-                {% if product.attributes|length == 0 %}
-                    {{ 'sylius.ui.there_are_no_attributes_configured'|trans }}
-                {% else %}
-                    {% for attribute in product.attributes %}
-                        {% if attribute.localeCode not in set_locale_codes %}
-                            {% set locale_code = attribute.localeCode %}
-                                <div class="accordion-item">
-                                    {% if locale_code %}
-                                        {% hook 'attributes#head' with { locale_code, loop } %}
-                                    {% else %}
-                                        {% hook 'attributes#head' with { loop } %}
-                                    {% endif %}
-                                    {% if locale_code %}
-                                        <div {{ sylius_test_html_attribute('translatable-attribute') }}>
-                                            {% hook 'attributes#body' with { 'attributes': product.attributes, locale_code } %}
-                                        </div>
-                                    {% else %}
-                                        <div {{ sylius_test_html_attribute('non-translatable-attribute') }}>
-                                            {% hook 'attributes#body' with { 'attributes': product.attributes } %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                                {%  set set_locale_codes = set_locale_codes|merge([locale_code]) %}
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
-            </div>
+    <div class="card-body" {{ sylius_test_html_attribute('attributes') }}>
+        <div class="accordion accordion-flush" id="attribute-translations">
+            {% set set_locale_codes = [] %}
+            {% if product.attributes|length == 0 %}
+                {{ 'sylius.ui.there_are_no_attributes_configured'|trans }}
+            {% else %}
+                {% for attribute in product.attributes %}
+                    {% if attribute.localeCode not in set_locale_codes %}
+                        {% set locale_code = attribute.localeCode %}
+                            <div class="accordion-item">
+                                {% if locale_code %}
+                                    {% hook 'attributes#head' with { locale_code, loop } %}
+                                {% else %}
+                                    {% hook 'attributes#head' with { loop } %}
+                                {% endif %}
+                                {% if locale_code %}
+                                    <div {{ sylius_test_html_attribute('translatable-attribute') }}>
+                                        {% hook 'attributes#body' with { 'attributes': product.attributes, locale_code } %}
+                                    </div>
+                                {% else %}
+                                    <div {{ sylius_test_html_attribute('non-translatable-attribute') }}>
+                                        {% hook 'attributes#body' with { 'attributes': product.attributes } %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                            {%  set set_locale_codes = set_locale_codes|merge([locale_code]) %}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Fixes UI glitch in product show in Admin Ui. The attribute card is missing the card-body class and thus renders "wrong", see the screenshot:
<img width="682" height="275" alt="Screenshot 2026-04-25 103400" src="https://github.com/user-attachments/assets/566e5388-fc28-4647-a6e6-0d272f92c716" />

With the change applied, it looks like this:
<img width="769" height="316" alt="Screenshot 2026-04-25 103511" src="https://github.com/user-attachments/assets/4397f113-531d-49fb-9a25-37a403125c49" />

I've also removed the `<div class="bg-white mb-3"></div>` which I don't think is needed here.