### PR TITLE
FIX: [AdminBundle] add missing entry for ListAdminUsersCommand in services configuration

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\AdminBundle\Console\Command\ChangeAdminUserPasswordCommand;
 use Sylius\Bundle\AdminBundle\Console\Command\CreateAdminUserCommand;
 use Sylius\Bundle\AdminBundle\Console\Command\Factory\QuestionFactory;
 use Sylius\Bundle\AdminBundle\Console\Command\Factory\QuestionFactoryInterface;
+use Sylius\Bundle\AdminBundle\Console\Command\ListAdminUsersCommand;
 use Sylius\Bundle\AdminBundle\Context\AdminBasedLocaleContext;
 use Sylius\Bundle\AdminBundle\Form\Type\AttributeType\Configuration\SelectAttributeConfigurationType;
 use Sylius\Bundle\AdminBundle\Generator\TaxonSlugGenerator;
@@ -57,6 +58,16 @@ return static function (ContainerConfigurator $container) {
             service('sylius.repository.admin_user'),
             service('sylius.security.password_updater'),
             service('sylius_admin.console.command_factory.question'),
+        ])
+        ->public()
+        ->tag('console.command')
+    ;
+
+    $services
+        ->set('sylius_admin.console.command.list_admin_users', ListAdminUsersCommand::class)
+        ->args([
+            service('sylius.repository.admin_user'),
+            service('sylius.manager.admin_user'),
         ])
         ->public()
         ->tag('console.command')


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

I noticed that in the `src/Sylius/Bundle/AdminBundle/Resources/config/services.php` file the service entry for the `ListAdminUsersCommand` is missing. I could only imagine that this somehow got lost during the services config migration from xml to .php.

However, in the `2.2` branch the service was still there:

https://github.com/Sylius/Sylius/blob/11373d8bf96a87d52dd03ed6156051e97896e39b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml#L61

Without this service entry the command will not be recognised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new command-line utility to list administrator accounts.
  * The command is discoverable and runnable via the application's console.
  * Makes it easier for admins to view and audit admin user details from the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->