### PR TITLE
fix memory footprint

### DIFF
--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -49,7 +49,11 @@ class ImageUploader implements ImageUploaderInterface
 
         $image->setPath($path);
 
-        $this->filesystem->write($image->getPath(), file_get_contents($file->getPathname()));
+        $stream = fopen($file->getPathname(), 'r');
+        $this->filesystem->writeStream($image->getPath(), $stream);
+        if (is_resource($stream)) {
+            fclose($stream);
+        }
     }
 
     public function remove(string $path): bool


### PR DESCRIPTION
### Description
Hi! 
This PR fixes the issue reported in #XXXX where images fail to upload to AWS S3 when using custom Doctrine Entity Listeners.

The problem comes from `upload()` using `file_get_contents()`. With remote Flysystem adapters like S3, loading the entire file content into `write()` often causes silent upload failures and high memory usage.

I updated the code to use `fopen()` and `writeStream()`. This streams the file directly to the cloud provider, which solves the S3 upload bug while remaining fully backward compatible with the local adapter.

### Disclaimer
*Disclaimer: this contribution is part of work carried out as a student at Université Paris-Cité. Apologies if this is inappropriate or if the contribution does not meet the project’s standards — any feedback is welcome.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload efficiency by implementing streaming-based file handling, reducing memory consumption during large file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->