### PR TITLE
FEAT: [AdminBundle] #18994 extend orders grid in admin with indicator for guest or customer orders

### DIFF
--- a/features/admin/order/managing_orders/browsing_orders/browsing_orders_with_customer_type_indicator.feature
+++ b/features/admin/order/managing_orders/browsing_orders/browsing_orders_with_customer_type_indicator.feature
@@ -1,0 +1,25 @@
+@managing_orders
+Feature: Browsing orders with guest or customer type indicator
+    In order to distinguish guest orders from registered customer orders
+    As an Administrator
+    I want to see an indicator in the customer column of the orders grid
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Sylius T-Shirt"
+        And the store ships everywhere for Free
+        And the store allows paying with "Cash on Delivery"
+        And I am logged in as an administrator
+
+    @no-api @ui
+    Scenario: Seeing a guest order indicator for an order placed by a guest
+        Given the guest customer placed order with "Sylius T-Shirt" product for "guest@example.com" and "United States" based billing address with "Free" shipping method and "Cash on Delivery" payment
+        When I browse orders
+        Then the order placed by "guest@example.com" should be marked as a guest order
+
+    @no-api @ui
+    Scenario: Seeing a customer order indicator for an order placed by a registered customer
+        Given there is a customer account "customer@example.com"
+        And there is a customer "customer@example.com" that placed order with "Sylius T-Shirt" product to "United States" based billing address with "Free" shipping method and "Cash on Delivery" payment method
+        When I browse orders
+        Then the order placed by "customer@example.com" should be marked as a customer order

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -209,6 +209,24 @@ final readonly class ManagingOrdersContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['customer' => $customer->getEmail()]));
     }
 
+    #[Then('the order placed by :email should be marked as a guest order')]
+    public function theOrderPlacedByShouldBeMarkedAsGuestOrder(string $email): void
+    {
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['customer' => $email],
+            '[data-test-order-customer-type="guest"]',
+        ));
+    }
+
+    #[Then('the order placed by :email should be marked as a customer order')]
+    public function theOrderPlacedByShouldBeMarkedAsCustomerOrder(string $email): void
+    {
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['customer' => $email],
+            '[data-test-order-customer-type="customer"]',
+        ));
+    }
+
     #[Then('I should not be able to resend the shipment confirmation email')]
     public function iShouldNotBeAbleToResendTheShipmentConfirmationEmail(): void
     {

--- a/src/Sylius/Bundle/AdminBundle/Grid/OrderGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/OrderGrid.php
@@ -62,9 +62,10 @@ final class OrderGrid implements OrderGridInterface
                             'th_class' => 'w-1 text-center',
                         ],
                     ]),
-                TwigField::create('customer', '@SyliusAdmin/shared/grid/field/customer.html.twig')
+                TwigField::create('customer', '@SyliusAdmin/order/grid/field/customer.html.twig')
                     ->setLabel('sylius.ui.customer')
                     ->setSortable(true, 'customer.lastName')
+                    ->setPath('.')
                     ->withOptions([
                         'vars' => [
                             'th_class' => 'w-100',

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
@@ -34,8 +34,9 @@ sylius_grid:
                     type: twig
                     label: sylius.ui.customer
                     sortable: customer.lastName
+                    path: .
                     options:
-                        template: "@SyliusAdmin/shared/grid/field/customer.html.twig"
+                        template: "@SyliusAdmin/order/grid/field/customer.html.twig"
                         vars:
                             th_class: "w-100"
                 channel:

--- a/src/Sylius/Bundle/AdminBundle/templates/order/grid/field/customer.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/grid/field/customer.html.twig
@@ -1,0 +1,9 @@
+{% set customer = data.customer %}
+{% set created_by_guest = data.createdByGuest %}
+
+<span data-bs-toggle="tooltip" data-bs-title="{{ (created_by_guest ? 'sylius.ui.created_by_guest' : 'sylius.ui.created_by_logged_in')|trans }}" {{ sylius_test_html_attribute('order-customer-type', created_by_guest ? 'guest' : 'customer') }}>
+    {{ ux_icon(created_by_guest ? 'tabler:spy' : 'tabler:user-check', { class: 'icon' }) }}
+</span>
+
+<strong>{{ customer.firstName }} {{ customer.lastName }}</strong>
+<div class="fs-5 text-secondary">{{ customer.email }}</div>

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
@@ -203,6 +203,8 @@ sylius:
         create_zone: 'Gebiet hinzufügen'
         created: 'Erstellt'
         created_at: 'Erstellt am'
+        created_by_guest: 'Erstellt von einem Gast'
+        created_by_logged_in: 'Erstellt von einem angemeldeten Benutzer'
         creating_a_new_imagine_block: 'Neuen Bild-Block erstellen'
         creating_a_new_simple_block: 'Einfaches Element erstellen'
         creating_a_new_slideshow_block: 'Neues Slideshow–Element erstellen'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -214,6 +214,8 @@ sylius:
         create_zone: 'Create zone'
         created: 'Created'
         created_at: 'Created at'
+        created_by_guest: 'Created by guest'
+        created_by_logged_in: 'Created by logged-in'
         creating_a_new_imagine_block: 'Creating a new imagine block'
         creating_a_new_simple_block: 'Creating a new simple block'
         creating_a_new_slideshow_block: 'Creating a new slideshow block'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en_GB.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en_GB.yml
@@ -210,6 +210,8 @@ sylius:
         create_zone: 'Create zone'
         created: 'Created'
         created_at: 'Created at'
+        created_by_guest: 'Created by guest'
+        created_by_logged_in: 'Created by logged-in'
         creating_a_new_imagine_block: 'Creating a new imagine block'
         creating_a_new_simple_block: 'Creating a new simple block'
         creating_a_new_slideshow_block: 'Creating a new slideshow block'


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #18994
| License         | MIT

This small PR enhances the orders grid in the admin by adding an indicator (a icon in this case) to show the user which order is made by a guest (a non registerd user in the storefront), and by a registerd customer.

<img width="1328" height="1187" alt="image" src="https://github.com/user-attachments/assets/75387a2b-9280-4031-a6ad-a1529712df97" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Admin orders grid to display a guest vs. customer indicator (icon + tooltip) alongside the customer name and email.
* **Localization / Documentation**
  * Added UI translations for “customer order” and “guest order” in English, British English, and German.
* **Tests**
  * Added UI feature coverage (and step definitions) to verify the correct indicator is shown for guest-placed vs. registered-customer orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->