### PR TITLE
Remove lower filter for the review translation

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/average_rating/number_of_reviews.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/average_rating/number_of_reviews.html.twig
@@ -1,3 +1,3 @@
 <div class="col-md-auto" >
-    {{ reviews_count }} {{ 'sylius.ui.reviews'|trans|lower }}
+    {{ reviews_count }} {{ 'sylius.ui.reviews'|trans }}
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

I realized the template uses a `lower` filter for the translation. For the German language this results in a "weird" output as "0 rezensionen" looks wrong, it should be "0 Rezensionen".

Maybe this was added because of issues with a different language. In that case PR could probably be seen as a BC break.

Also, I think the string should actually support proper pluralized translations, because again in German we use different forms, e.g. "0 Rezensionen", "1 Rezension", "2 Rezensionen". Currently, the implementation would output "1 Rezensionen" which is wrong.

Moving towards pluralized translations might be considered as a BC break. Not sure how this would be treated in general. WDTY?