### PR TITLE
feat(fixtures): Allow translations on product attributes & values

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -62,6 +62,12 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
             $productAttribute->setName($options['name']);
         }
 
+        foreach ($options['translations'] as $localeCode => $translation) {
+            $productAttribute->setCurrentLocale($localeCode);
+            $productAttribute->setFallbackLocale($localeCode);
+            $productAttribute->setName($translation['name'] ?? $productAttribute->getName());
+        }
+
         $productAttribute->setConfiguration($options['configuration']);
 
         return $productAttribute;
@@ -74,8 +80,10 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
             ->setDefault('translatable', true)
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('type', fn (Options $options): string => $this->faker->randomElement(array_keys($this->attributeTypes)))
-            ->setDefault('configuration', fn (Options $options): array => [])
             ->setAllowedValues('type', array_keys($this->attributeTypes))
+            ->setDefault('configuration', fn (Options $options): array => [])
+            ->setDefault('translations', [])
+            ->setAllowedTypes('translations', ['array'])
         ;
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -107,6 +107,10 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
                     $values[sprintf('%s-option#%d', $options['code'], $i)] = sprintf('%s #i%d', $options['name'], $i);
                 }
 
+                if (!empty($options['translations'])) {
+                    return [];
+                }
+
                 return $values;
             })
             ->setAllowedTypes('values', 'array')
@@ -120,13 +124,32 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
      */
     private function updateValuesTranslations(ProductOptionInterface $productOption, string $localeCode, array $values): void
     {
-        foreach ($productOption->getValues() as $value) {
-            $localizedName = $values[$value->getCode()];
+        foreach ($values as $code => $value) {
+            $productOptionValue = $this->findOptionValueWithCode($productOption, $code);
 
-            $value->setCurrentLocale($localeCode);
-            $value->setFallbackLocale($localeCode);
-            $value->setValue($localizedName);
+            if (null === $productOptionValue) {
+                /** @var ProductOptionValueInterface $productOptionValue */
+                $productOptionValue = $this->productOptionValueFactory->createNew();
+                $productOptionValue->setCode($code);
+            }
+
+            $productOptionValue->setCurrentLocale($localeCode);
+            $productOptionValue->setFallbackLocale($localeCode);
+            $productOptionValue->setValue($value);
+
+            $productOption->addValue($productOptionValue);
         }
+    }
+
+    private function findOptionValueWithCode(ProductOptionInterface $productOption, string $code): ?ProductOptionValueInterface
+    {
+        foreach ($productOption->getValues() as $value) {
+            if ($value->getCode() === $code) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 
     /** @return iterable<string> */

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -77,6 +77,17 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
             $productOption->addValue($productOptionValue);
         }
 
+        foreach ($options['translations'] as $localeCode => $translation) {
+            $productOption->setCurrentLocale($localeCode);
+            $productOption->setFallbackLocale($localeCode);
+
+            $productOption->setName($translation['name'] ?? $productOption->getName());
+
+            if (isset($translation['values'])) {
+                $this->updateValuesTranslations($productOption, $localeCode, $translation['values']);
+            }
+        }
+
         return $productOption;
     }
 
@@ -99,7 +110,23 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
                 return $values;
             })
             ->setAllowedTypes('values', 'array')
+            ->setDefault('translations', [])
+            ->setAllowedTypes('translations', ['array'])
         ;
+    }
+
+    /**
+     * @param array<string, string> $values
+     */
+    private function updateValuesTranslations(ProductOptionInterface $productOption, string $localeCode, array $values): void
+    {
+        foreach ($productOption->getValues() as $value) {
+            $localizedName = $values[$value->getCode()];
+
+            $value->setCurrentLocale($localeCode);
+            $value->setFallbackLocale($localeCode);
+            $value->setValue($localizedName);
+        }
     }
 
     /** @return iterable<string> */

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
@@ -44,6 +44,7 @@ class ProductAttributeFixture extends AbstractResourceFixture
                 ->booleanNode('translatable')->defaultTrue()->end()
                 ->enumNode('type')->values($this->attributeTypes)->cannotBeEmpty()->end()
                 ->variableNode('configuration')->end()
+                ->variableNode('translations')->cannotBeEmpty()->defaultValue([])->end()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductOptionFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductOptionFixture.php
@@ -28,6 +28,7 @@ class ProductOptionFixture extends AbstractResourceFixture
             ->children()
                 ->scalarNode('name')->cannotBeEmpty()->end()
                 ->scalarNode('code')->cannotBeEmpty()->end()
+                ->variableNode('translations')->cannotBeEmpty()->defaultValue([])->end()
                 ->arrayNode('values')
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('code')

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/dress.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/dress.yaml
@@ -45,6 +45,11 @@ sylius_fixtures:
                                 code: 'length'
                                 type: 'integer'
                                 translatable: false
+                                translations:
+                                    en_US:
+                                        name: 'Length'
+                                    fr_FR:
+                                        name: 'Longueur'
 
                 dress_option:
                     name: product_option
@@ -65,6 +70,12 @@ sylius_fixtures:
                                     dress_height_petite: 'Petite'
                                     dress_height_regular: 'Regular'
                                     dress_height_tall: 'Tall'
+                                translations:
+                                    fr_FR:
+                                        values:
+                                            dress_height_petite: 'Petite'
+                                            dress_height_regular: 'Moyenne'
+                                            dress_height_tall: 'Grande'
 
                 dress_product:
                     name: product

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/dress.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/dress.yaml
@@ -66,11 +66,12 @@ sylius_fixtures:
 
                             -   name: 'Dress height'
                                 code: 'dress_height'
-                                values:
-                                    dress_height_petite: 'Petite'
-                                    dress_height_regular: 'Regular'
-                                    dress_height_tall: 'Tall'
                                 translations:
+                                    en_US:
+                                        values:
+                                            dress_height_petite: 'Petite'
+                                            dress_height_regular: 'Regular'
+                                            dress_height_tall: 'Tall'
                                     fr_FR:
                                         values:
                                             dress_height_petite: 'Petite'

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/jeans.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/jeans.yaml
@@ -52,6 +52,11 @@ sylius_fixtures:
                             -   name: 'Jeans brand'
                                 code: 'jeans_brand'
                                 type: 'text'
+                                translations:
+                                    en_US:
+                                        name: 'Jeans brand'
+                                    fr_FR:
+                                        name: 'Marque de Jeans'
 
                             -   name: 'Jeans collection'
                                 code: 'jeans_collection'

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/tshirt.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/tshirt.yaml
@@ -52,6 +52,11 @@ sylius_fixtures:
                             -   name: 'T-shirt brand'
                                 code: 't_shirt_brand'
                                 type: 'text'
+                                translations:
+                                    en_US: 
+                                        name: 'T-shirt brand'
+                                    fr_FR:
+                                        name: 'Marque de t-shirts'
 
                             -   name: 'T-shirt collection'
                                 code: 't_shirt_collection'
@@ -78,6 +83,11 @@ sylius_fixtures:
                                     t_shirt_size_l: 'L'
                                     t_shirt_size_xl: 'XL'
                                     t_shirt_size_xxl: 'XXL'
+                                translations:
+                                    en_US: 
+                                        name: 'T-shirt size'
+                                    fr_FR:
+                                        name: 'Taille de t-shirt'
 
                 tshirt_product:
                     name: product

--- a/tests/Fixture/ProductAttributeFixturesTest.php
+++ b/tests/Fixture/ProductAttributeFixturesTest.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\FixturesBundle\Listener\ListenerRegistryInterface;
 use Sylius\Bundle\FixturesBundle\Loader\SuiteLoaderInterface;
 use Sylius\Bundle\FixturesBundle\Suite\Suite;
 use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Product\Model\ProductAttributeInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -32,6 +33,7 @@ final class ProductAttributeFixturesTest extends KernelTestCase
 
         $fixtureRegistry = $container->get(FixtureRegistryInterface::class);
         $listenerRegistry = $container->get(ListenerRegistryInterface::class);
+        /** @var SuiteLoaderInterface $suiteLoader */
         $suiteLoader = $container->get(SuiteLoaderInterface::class);
 
         $suite = new Suite('test');
@@ -51,6 +53,14 @@ final class ProductAttributeFixturesTest extends KernelTestCase
                     'choices' => [
                         'SOFT' => ['en_US' => 'Soft'],
                         'HARD' => ['en_US' => 'Hard'],
+                    ],
+                ],
+                'translations' => [
+                    'en_US' => [
+                        'name' => 'Cover',
+                    ],
+                    'fr_FR' => [
+                        'name' => 'Couverture',
                     ],
                 ],
             ],
@@ -81,6 +91,17 @@ final class ProductAttributeFixturesTest extends KernelTestCase
         $this->assertValueOfAttributeWithCode($product, 'ADULT', false);
         $this->assertValueOfAttributeWithCode($product, 'PAGES', 448);
         $this->assertValueOfAttributeWithCode($product, 'COVER', ['SOFT']);
+
+        $productAttributeRepository = $container->get('sylius.repository.product_attribute');
+
+        /** @var ProductAttributeInterface $productAttribute */
+        $productAttribute = $productAttributeRepository->findOneByCode('COVER');
+
+        $productAttribute->setCurrentLocale('en_US');
+        $this->assertSame('Cover', $productAttribute->getName());
+
+        $productAttribute->setCurrentLocale('fr_FR');
+        $this->assertSame('Couverture', $productAttribute->getName());
     }
 
     private function assertValueOfAttributeWithCode(ProductInterface $product, string $code, $value): void

--- a/tests/Fixture/ProductOptionFixturesTest.php
+++ b/tests/Fixture/ProductOptionFixturesTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fixture;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureRegistryInterface;
+use Sylius\Bundle\FixturesBundle\Listener\ListenerRegistryInterface;
+use Sylius\Bundle\FixturesBundle\Loader\SuiteLoaderInterface;
+use Sylius\Bundle\FixturesBundle\Suite\Suite;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Product\Model\ProductOptionInterface;
+use Sylius\Component\Product\Model\ProductOptionValueInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class ProductOptionFixturesTest extends KernelTestCase
+{
+    #[Test]
+    public function fixtures_are_loaded_properly(): void
+    {
+        $kernel = static::bootKernel();
+        $container = $kernel->getContainer()->get('test.service_container', ContainerInterface::NULL_ON_INVALID_REFERENCE) ?? $kernel->getContainer();
+
+        $fixtureRegistry = $container->get(FixtureRegistryInterface::class);
+        $listenerRegistry = $container->get(ListenerRegistryInterface::class);
+        /** @var SuiteLoaderInterface $suiteLoader */
+        $suiteLoader = $container->get(SuiteLoaderInterface::class);
+
+        $suite = new Suite('test');
+        $suite->addListener($listenerRegistry->getListener('orm_purger'), ['mode' => 'delete', 'exclude' => [], 'managers' => [null]]);
+        $suite->addFixture($fixtureRegistry->getFixture('locale'), ['locales' => [], 'load_default_locale' => true]);
+        $suite->addFixture($fixtureRegistry->getFixture('taxon'), ['custom' => ['books' => ['name' => 'Books', 'code' => 'BOOKS']]]);
+        $suite->addFixture($fixtureRegistry->getFixture('product_option'), ['custom' => [
+            'dress_size' => [
+                'name' => 'Dress height',
+                'code' => 'dress_height',
+                'translations' => [
+                    'fr_FR' => [
+                        'name' => 'Taille de robe',
+                        'values' => [
+                            'dress_height_petite' => 'Petite',
+                            'dress_height_regular' => 'Moyenne',
+                            'dress_height_tall' => 'Grande',
+                        ],
+                    ],
+                ],
+                'values' => [
+                    'dress_height_petite' => 'Petite',
+                    'dress_height_regular' => 'Regular',
+                    'dress_height_tall' => 'Tall',
+                ],
+            ],
+        ]]);
+        $suite->addFixture($fixtureRegistry->getFixture('product'), ['custom' => [
+            'sunshine_strappy_delight' => [
+                'name' => 'Sunshine Strappy Delight',
+                'code' => 'sunshine_strappy_delight',
+                'product_options' => [
+                    'dress_height',
+                ],
+            ],
+        ]]);
+
+        $suiteLoader->load($suite);
+
+        $productRepository = $container->get('sylius.repository.product');
+
+        /** @var ProductInterface $product */
+        $product = $productRepository->findOneByCode('sunshine_strappy_delight');
+        $this->assertNotNull($product);
+
+        $productOptionRepository = $container->get('sylius.repository.product_option');
+
+        /** @var ProductOptionInterface $productOption */
+        $productOption = $productOptionRepository->findOneByCode('dress_height');
+
+        $productOption->setCurrentLocale('en_US');
+        $this->assertSame('Dress height', $productOption->getName());
+
+        $productOption->setCurrentLocale('fr_FR');
+        $this->assertSame('Taille de robe', $productOption->getName());
+
+        $this->assertValuesOfOptionWithCode($product, 'dress_height', 'en_US', [
+            'dress_height_petite' => 'Petite',
+            'dress_height_regular' => 'Regular',
+            'dress_height_tall' => 'Tall',
+        ]);
+
+        $this->assertValuesOfOptionWithCode($product, 'dress_height', 'fr_FR', [
+            'dress_height_petite' => 'Petite',
+            'dress_height_regular' => 'Moyenne',
+            'dress_height_tall' => 'Grande',
+        ]);
+    }
+
+    private function assertValuesOfOptionWithCode(ProductInterface $product, string $code, string $locale, array $expectedValues): void
+    {
+        foreach ($product->getOptions() as $productOption) {
+            if ($code !== $productOption->getCode()) {
+                continue;
+            }
+
+            $values = [];
+            foreach ($productOption->getValues() as $productOptionValue) {
+                $productOptionValue->setCurrentLocale($locale);
+                $values[$productOptionValue->getCode()] = $productOptionValue->getValue();
+            }
+
+            $this->assertSame($expectedValues, $values);
+        }
+    }
+}

--- a/tests/Fixture/ProductOptionFixturesTest.php
+++ b/tests/Fixture/ProductOptionFixturesTest.php
@@ -46,6 +46,13 @@ final class ProductOptionFixturesTest extends KernelTestCase
                 'name' => 'Dress height',
                 'code' => 'dress_height',
                 'translations' => [
+                    'en_US' => [
+                        'values' => [
+                            'dress_height_petite' => 'Petite',
+                            'dress_height_regular' => 'Regular',
+                            'dress_height_tall' => 'Tall',
+                        ],
+                    ],
                     'fr_FR' => [
                         'name' => 'Taille de robe',
                         'values' => [
@@ -54,11 +61,6 @@ final class ProductOptionFixturesTest extends KernelTestCase
                             'dress_height_tall' => 'Grande',
                         ],
                     ],
-                ],
-                'values' => [
-                    'dress_height_petite' => 'Petite',
-                    'dress_height_regular' => 'Regular',
-                    'dress_height_tall' => 'Tall',
                 ],
             ],
         ]]);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Currently, we are not able to define product attributes and product options in several locales.
This PR allows us to use the same system we already defined in Taxon fixtures.

Example:
```yaml
dress_option:
    name: product_option
    options:
        custom:
            -   name: 'Dress height'
                code: 'dress_height'
                values:
                    dress_height_petite: 'Petite'
                    dress_height_regular: 'Regular'
                    dress_height_tall: 'Tall'
                translations:
                    fr_FR:
                        values:
                            dress_height_petite: 'Petite'
                            dress_height_regular: 'Moyenne'
                            dress_height_tall: 'Grande'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product attributes and options now support per-locale display names and per-locale option value labels via a translations configuration.

* **Fixtures**
  * Fixture schemas accept a translations section for attributes and options.
  * Sample fixtures updated with en_US/fr_FR translations for attributes and option values.

* **Tests**
  * Added/updated tests verifying locale-dependent names and locale-specific option value labels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sylius/Sylius/pull/19004)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->