### PR TITLE
(Maintenance) Update @symfony/webpack-encore to ~6.0.0 in Shop and Admin bundles

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -222,6 +222,44 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    | `ShippingBundle\...\ShippingMethodCalculatorExists` | `invalidShippingCalculator` | `invalidShippingCalculatorMessage` |
    | `ShippingBundle\...\ShippingMethodRule` | `invalidType` | `invalidTypeMessage` |
 
+## Frontend
+
+1. The `@symfony/webpack-encore` package has been upgraded from `^5.0.1` to `^6.0.0`, and `webpack-cli` from `^5.1.4` to `^6.0.0`.
+
+   Webpack Encore 6 requires Node.js `^22.13.0 || >=24.0` — the `engines` constraints in the `package.json` files have been updated accordingly.
+
+   The `@sylius-ui/admin` and `@sylius-ui/shop` packages are now ES modules (`"type": "module"`), and their
+   `getWebpackConfig()` / `getBaseWebpackConfig()` methods have become **asynchronous** — they now return a `Promise`
+   and must be awaited.
+
+   In your application, update `@symfony/webpack-encore` to `^6.0.0` and `webpack-cli` to `^6.0.0` in `package.json`,
+   and add `"type": "module"` to it (or rename `webpack.config.js` to `webpack.config.mjs`), so that Node.js treats
+   the config file as an ES module.
+
+   Then update your application's `webpack.config.js` to use ESM syntax and an async config factory:
+
+   ```diff
+   -const path = require('path');
+   -const SyliusAdmin = require('@sylius-ui/admin');
+   -const SyliusShop = require('@sylius-ui/shop');
+   +import path from 'path';
+   +import { fileURLToPath } from 'url';
+   +import SyliusAdmin from '@sylius-ui/admin';
+   +import SyliusShop from '@sylius-ui/shop';
+
+   -const adminConfig = SyliusAdmin.getWebpackConfig(path.resolve(__dirname));
+   -const shopConfig = SyliusShop.getWebpackConfig(path.resolve(__dirname));
+   +const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+   -module.exports = [adminConfig, shopConfig];
+   +export default async () => {
+   +    const adminConfig = await SyliusAdmin.getWebpackConfig(path.resolve(__dirname));
+   +    const shopConfig = await SyliusShop.getWebpackConfig(path.resolve(__dirname));
+   +
+   +    return [adminConfig, shopConfig];
+   +};
+   ```
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/Sylius/Sylius.git"
   },
+  "type": "module",
   "license": "MIT",
   "author": "Sylius Sp. z o.o.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tom-select": "^2.2.2"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^22.13.0 || >=24.0"
   },
   "engineStrict": true
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/Sylius/SyliusAdminBundle.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^22.13.0 || >=24.0"
   },
   "engineStrict": true,
   "symfony": {

--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -7,21 +7,24 @@
  * file that was distributed with this source code.
  */
 
-const path = require('path');
-const Encore = require('@symfony/webpack-encore');
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Encore from '@symfony/webpack-encore';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 class SyliusAdmin {
     /**
      * Provide a light Webpack configuration for Sylius Admin
      * All the stimulus stuff should be handled by the app.admin entrypoint
      */
-    static getBaseWebpackConfig(rootDir) {
+    static async getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
 
         Encore
             .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'));
 
-        const adminConfig = Encore.getWebpackConfig();
+        const adminConfig = await Encore.getWebpackConfig();
 
         adminConfig.externals = { ...adminConfig.externals, window: 'window', document: 'document' };
         adminConfig.name = 'admin';
@@ -36,14 +39,14 @@ class SyliusAdmin {
      * For instances started with Sylius-Standard < 2.0.4, it'll still be used unless upgrading webpack.config.js
      * to use the method above getBaseWebpackConfig()
      */
-    static getWebpackConfig(rootDir) {
+    static async getWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
 
         Encore
             .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/app.js'))
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
-        const adminConfig = Encore.getWebpackConfig();
+        const adminConfig = await Encore.getWebpackConfig();
 
         adminConfig.externals = { ...adminConfig.externals, window: 'window', document: 'document' };
         adminConfig.name = 'admin';
@@ -69,4 +72,4 @@ class SyliusAdmin {
     }
 }
 
-module.exports = SyliusAdmin;
+export default SyliusAdmin;

--- a/src/Sylius/Bundle/AdminBundle/package.json
+++ b/src/Sylius/Bundle/AdminBundle/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/Sylius/SyliusAdminBundle.git"
   },
+  "type": "module",
   "license": "MIT",
   "author": "Sylius Sp. z o.o.",
   "dependencies": {
@@ -16,7 +17,7 @@
     "@popperjs/core": "^2.11.8",
     "@sylius/admin-bundle": "file:Resources/assets/",
     "@symfony/stimulus-bridge": "^3.2.0",
-    "@symfony/webpack-encore": "^5.0.1",
+    "@symfony/webpack-encore": "^6.0.0",
     "@tabler/core": "~1.3.0",
     "apexcharts": "^3.41.0",
     "bootstrap": "^5.3.3",

--- a/src/Sylius/Bundle/AdminBundle/package.json
+++ b/src/Sylius/Bundle/AdminBundle/package.json
@@ -29,10 +29,10 @@
     "stimulus-use": "^0.52",
     "tom-select": "^2.2.2",
     "webpack": "^5.72",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^6.0.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^22.13.0 || >=24.0"
   },
   "engineStrict": true,
   "files": [

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/Sylius/SyliusShopBundle.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^22.13.0 || >=24.0"
   },
   "engineStrict": true,
   "symfony": {

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -7,20 +7,23 @@
  * file that was distributed with this source code.
  */
 
-const path = require('path');
-const Encore = require('@symfony/webpack-encore');
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Encore from '@symfony/webpack-encore';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 class SyliusShop {
     /**
      * Provide a light Webpack configuration for Sylius Admin
      * All the stimulus stuff should be handled by the app.shop entrypoint
      */
-    static getBaseWebpackConfig(rootDir) {
+    static async getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         Encore
             .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'));
 
-        const shopConfig = Encore.getWebpackConfig();
+        const shopConfig = await Encore.getWebpackConfig();
 
         shopConfig.externals = { ...shopConfig.externals, window: 'window', document: 'document' };
         shopConfig.name = 'shop';
@@ -35,13 +38,13 @@ class SyliusShop {
      * For instances started with Sylius-Standard < 2.0.4, it'll still be used unless upgrading webpack.config.js
      * to use the method above getBaseWebpackConfig()
      */
-    static getWebpackConfig(rootDir) {
+    static async getWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         // For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
         Encore
             .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/app.js'))
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
-        const shopConfig = Encore.getWebpackConfig();
+        const shopConfig = await Encore.getWebpackConfig();
 
         shopConfig.externals = { ...shopConfig.externals, window: 'window', document: 'document' };
         shopConfig.name = 'shop';
@@ -66,4 +69,4 @@ class SyliusShop {
     }
 }
 
-module.exports = SyliusShop;
+export default SyliusShop;

--- a/src/Sylius/Bundle/ShopBundle/package.json
+++ b/src/Sylius/Bundle/ShopBundle/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/Sylius/SyliusShopBundle.git"
   },
+  "type": "module",
   "license": "MIT",
   "author": "Sylius Sp. z o.o.",
   "dependencies": {
@@ -16,7 +17,7 @@
     "@popperjs/core": "^2.11.8",
     "@sylius/shop-bundle": "file:Resources/assets/",
     "@symfony/stimulus-bridge": "^3.2.0",
-    "@symfony/webpack-encore": "^5.0.1",
+    "@symfony/webpack-encore": "^6.0.0",
     "bootstrap": "^5.3.3",
     "sass": "~1.64.2",
     "sass-loader": "^16.0.1",

--- a/src/Sylius/Bundle/ShopBundle/package.json
+++ b/src/Sylius/Bundle/ShopBundle/package.json
@@ -23,10 +23,10 @@
     "sass-loader": "^16.0.1",
     "spotlight.js": "^0.7.8",
     "webpack": "^5.72",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^6.0.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^22.13.0 || >=24.0"
   },
   "engineStrict": true,
   "files": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,13 @@
-const path = require('path');
+import path from 'path';
+import { fileURLToPath } from 'url';
+import SyliusAdmin from '@sylius-ui/admin';
+import SyliusShop from '@sylius-ui/shop';
 
-const SyliusAdmin = require('@sylius-ui/admin');
-const SyliusShop = require('@sylius-ui/shop');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const adminConfig = SyliusAdmin.getWebpackConfig(path.resolve(__dirname));
-const shopConfig = SyliusShop.getWebpackConfig(path.resolve(__dirname));
+export default async () => {
+    const adminConfig = await SyliusAdmin.getWebpackConfig(path.resolve(__dirname));
+    const shopConfig = await SyliusShop.getWebpackConfig(path.resolve(__dirname));
 
-module.exports = [adminConfig, shopConfig];
+    return [adminConfig, shopConfig];
+};


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | #18927
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded `@symfony/webpack-encore` to v6.
  * Updated supported Node.js versions to `^22.13.0 || >=24.0`.
* **Refactor**
  * Migrated frontend packages and webpack configuration to ECMAScript modules (`type: module`).
  * Made webpack config generation asynchronous, requiring async/await when retrieving configs.
* **Documentation**
  * Updated the 2.3 upgrade notes with a new Frontend section, including an ESM + async webpack config migration example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->