### PR TITLE
Relax version constraint for sylius-labs/doctrine-migrations-extra-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "ramsey/uuid": "^4.7",
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius-labs/association-hydrator": "^1.2",
-        "sylius-labs/doctrine-migrations-extra-bundle": "^0.3",
+        "sylius-labs/doctrine-migrations-extra-bundle": "^0.2 || ^0.3",
         "sylius/fixtures-bundle": "^1.9",
         "sylius/grid": "^1.13",
         "sylius/grid-bundle": "^1.13",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -34,7 +34,7 @@
         "league/flysystem-bundle": "^3.3",
         "liip/imagine-bundle": "^2.15",
         "sylius-labs/association-hydrator": "^1.2",
-        "sylius-labs/doctrine-migrations-extra-bundle": "^0.3",
+        "sylius-labs/doctrine-migrations-extra-bundle": "^0.2 || ^0.3",
         "sylius/addressing-bundle": "^2.0",
         "sylius/attribute-bundle": "^2.0",
         "sylius/channel-bundle": "^2.0",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened dependency compatibility to support multiple versions of the database migration bundle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sylius/Sylius/pull/19007)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->