### PR TITLE
  [Bugfix] Make security firewall CSRF parameter and token id configurable in login templates

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -31,8 +31,8 @@ security:
                 use_forward: false
                 use_referer: true
                 enable_csrf: true
-                csrf_parameter: _csrf_admin_security_token
-                csrf_token_id: admin_authenticate
+                csrf_parameter: '%sylius_admin.security.csrf_parameter%'
+                csrf_token_id: '%sylius_admin.security.csrf_token_id%'
             remember_me:
                 secret: "%env(APP_SECRET)%"
                 path: "/%sylius_admin.path_name%"
@@ -88,8 +88,8 @@ security:
                 use_forward: false
                 use_referer: true
                 enable_csrf: true
-                csrf_parameter: _csrf_shop_security_token
-                csrf_token_id: shop_authenticate
+                csrf_parameter: '%sylius_shop.security.csrf_parameter%'
+                csrf_token_id: '%sylius_shop.security.csrf_token_id%'
             json_login:
                 check_path: sylius_shop_json_login_check
                 username_path: _username

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -8,6 +8,8 @@ parameters:
     env(SYLIUS_ADMIN_ROUTING_PATH_NAME): admin
     sylius_admin.path_name: '%env(resolve:SYLIUS_ADMIN_ROUTING_PATH_NAME)%'
     sylius.security.admin_regex: "^/%sylius_admin.path_name%"
+    sylius_admin.security.csrf_parameter: '_csrf_admin_security_token'
+    sylius_admin.security.csrf_token_id: 'admin_authenticate'
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
@@ -5,6 +5,6 @@
 {{ form_start(form, {'action': path('sylius_admin_login_check'), 'attr': {'class': 'ui large loadable form', 'novalidate': 'novalidate'}}) }}
     {% hook 'form' with { form } %}
     {% if sylius_csrf_protection_enabled() %}
-        <input type="hidden" name="_csrf_admin_security_token" value="{{ csrf_token('admin_authenticate') }}">
+        <input type="hidden" name="{{ sylius_security_csrf_parameter('admin') }}" value="{{ csrf_token(sylius_security_csrf_token_id('admin')) }}">
     {% endif %}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -63,6 +63,7 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
         $loader->load(sprintf('services/integrations/%s.xml', $config['driver']));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
+        $this->setDefaultSecurityCsrfParameters($container);
 
         $loader->load('services.xml');
 
@@ -123,6 +124,22 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
     protected function getNamespacesOfMigrationsExecutedBefore(): array
     {
         return [];
+    }
+
+    private function setDefaultSecurityCsrfParameters(ContainerBuilder $container): void
+    {
+        foreach ([
+            'sylius_admin.security.csrf_parameter' => '_csrf_admin_security_token',
+            'sylius_admin.security.csrf_token_id' => 'admin_authenticate',
+            'sylius_shop.security.csrf_parameter' => '_csrf_shop_security_token',
+            'sylius_shop.security.csrf_token_id' => 'shop_authenticate',
+        ] as $parameter => $defaultValue) {
+            if ($container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $container->setParameter($parameter, $defaultValue);
+        }
     }
 
     private function prependDefaultDriver(ContainerBuilder $container, string $driver): void

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -48,5 +48,10 @@
             <argument type="service" id="service_container" />
             <tag name="twig.extension" />
         </service>
+
+        <service id="sylius.twig.extension.security_csrf" class="Sylius\Bundle\CoreBundle\Twig\SecurityCsrfExtension" public="false">
+            <argument type="service" id="service_container" />
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -50,7 +50,10 @@
         </service>
 
         <service id="sylius.twig.extension.security_csrf" class="Sylius\Bundle\CoreBundle\Twig\SecurityCsrfExtension" public="false">
-            <argument type="service" id="service_container" />
+            <argument>%sylius_admin.security.csrf_parameter%</argument>
+            <argument>%sylius_admin.security.csrf_token_id%</argument>
+            <argument>%sylius_shop.security.csrf_parameter%</argument>
+            <argument>%sylius_shop.security.csrf_token_id%</argument>
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SecurityCsrfExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_security_csrf_parameter', [$this, 'getCsrfParameter']),
+            new TwigFunction('sylius_security_csrf_token_id', [$this, 'getCsrfTokenId']),
+        ];
+    }
+
+    public function getCsrfParameter(string $section): string
+    {
+        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_parameter', $section));
+    }
+
+    public function getCsrfTokenId(string $section): string
+    {
+        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_token_id', $section));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
@@ -13,14 +13,16 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Twig;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class SecurityCsrfExtension extends AbstractExtension
 {
     public function __construct(
-        private readonly ContainerInterface $container,
+        private readonly string $adminCsrfParameter,
+        private readonly string $adminCsrfTokenId,
+        private readonly string $shopCsrfParameter,
+        private readonly string $shopCsrfTokenId,
     ) {
     }
 
@@ -34,11 +36,19 @@ final class SecurityCsrfExtension extends AbstractExtension
 
     public function getCsrfParameter(string $section): string
     {
-        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_parameter', $section));
+        return match ($section) {
+            'admin' => $this->adminCsrfParameter,
+            'shop' => $this->shopCsrfParameter,
+            default => throw new \InvalidArgumentException(sprintf('Unknown section "%s". Expected "admin" or "shop".', $section)),
+        };
     }
 
     public function getCsrfTokenId(string $section): string
     {
-        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_token_id', $section));
+        return match ($section) {
+            'admin' => $this->adminCsrfTokenId,
+            'shop' => $this->shopCsrfTokenId,
+            default => throw new \InvalidArgumentException(sprintf('Unknown section "%s". Expected "admin" or "shop".', $section)),
+        };
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -138,6 +138,36 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
     }
 
     #[Test]
+    public function it_loads_default_security_csrf_parameters_properly(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('sylius_admin.security.csrf_parameter', '_csrf_admin_security_token');
+        $this->assertContainerBuilderHasParameter('sylius_admin.security.csrf_token_id', 'admin_authenticate');
+        $this->assertContainerBuilderHasParameter('sylius_shop.security.csrf_parameter', '_csrf_shop_security_token');
+        $this->assertContainerBuilderHasParameter('sylius_shop.security.csrf_token_id', 'shop_authenticate');
+    }
+
+    #[Test]
+    public function it_does_not_override_configured_security_csrf_parameters(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+        $this->container->setParameter('sylius_admin.security.csrf_parameter', '_custom_admin_csrf');
+        $this->container->setParameter('sylius_admin.security.csrf_token_id', 'custom_admin_authenticate');
+        $this->container->setParameter('sylius_shop.security.csrf_parameter', '_custom_shop_csrf');
+        $this->container->setParameter('sylius_shop.security.csrf_token_id', 'custom_shop_authenticate');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('sylius_admin.security.csrf_parameter', '_custom_admin_csrf');
+        $this->assertContainerBuilderHasParameter('sylius_admin.security.csrf_token_id', 'custom_admin_authenticate');
+        $this->assertContainerBuilderHasParameter('sylius_shop.security.csrf_parameter', '_custom_shop_csrf');
+        $this->assertContainerBuilderHasParameter('sylius_shop.security.csrf_token_id', 'custom_shop_authenticate');
+    }
+
+    #[Test]
     public function it_aliases_default_filesystem_adapter_properly(): void
     {
         $this->container->setParameter('kernel.environment', 'dev');

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -11,6 +11,8 @@ imports:
 
 parameters:
     sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius_shop.security.csrf_parameter: '_csrf_shop_security_token'
+    sylius_shop.security.csrf_token_id: 'shop_authenticate'
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
@@ -1,3 +1,3 @@
 {% if sylius_csrf_protection_enabled() %}
-    <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}">
+    <input type="hidden" name="{{ sylius_security_csrf_parameter('shop') }}" value="{{ csrf_token(sylius_security_csrf_token_id('shop')) }}">
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
@@ -12,7 +12,7 @@
                 <button class="btn btn-primary" type="button" {{ stimulus_action('@sylius/shop-bundle/api-login', 'login') }} {{ sylius_test_html_attribute('login-button') }}>{{ 'sylius.ui.sign_in'|trans }}</button>
             </div>
             {% if sylius_csrf_protection_enabled() %}
-                <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
+                <input type="hidden" name="{{ sylius_security_csrf_parameter('shop') }}" value="{{ csrf_token(sylius_security_csrf_token_id('shop')) }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
             {% endif %}
             <div {{ stimulus_target('@sylius/shop-bundle/api-login', 'error') }} {{ sylius_test_html_attribute('login-validation-error') }}></div>
         {% endif %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/pull/19001
| License         | MIT

# Fix hardcoded security firewall CSRF parameter in login templates

  ## Problem

  Login templates hardcoded `_csrf_admin_security_token` / `_csrf_shop_security_token`
  and `admin_authenticate` / `shop_authenticate` strings. When a user changes
  `csrf_parameter` or `csrf_token_id` in `security.yaml` (supported by Symfony),
  login breaks — HTML posts the old field name while Symfony validates against
  the new one.

  Companion to PR #19001 (Symfony Form CSRF); this PR covers Security firewall CSRF.

  ### Affected files

  - `AdminBundle/templates/security/login/page/content/form.html.twig`
  - `ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig`
  - `ShopBundle/templates/checkout/address/content/form/user.html.twig`

  ## Solution

  Single source of truth via container parameters; `security.yaml` and templates
  both read from them.

  1. New parameters with current defaults:
     - `sylius_admin.security.csrf_parameter`, `sylius_admin.security.csrf_token_id`
     - `sylius_shop.security.csrf_parameter`, `sylius_shop.security.csrf_token_id`

  2. `security.yaml` references parameters via `%...%`.

  3. New Twig functions:
     - `sylius_security_csrf_parameter('admin'|'shop')`
     - `sylius_security_csrf_token_id('admin'|'shop')`

  4. Templates use the functions instead of literals.

