### PR TITLE
[ApiBundle] Fix "Undefined array key 0" in PathPrefixProvider when path equals API route

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Provider/PathPrefixProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/PathPrefixProvider.php
@@ -28,6 +28,10 @@ final readonly class PathPrefixProvider implements PathPrefixProviderInterface
         /** @var array<int, string> $pathElements */
         $pathElements = array_values(array_filter(explode('/', str_replace($this->apiRoute, '', $path))));
 
+        if ($pathElements === []) {
+            return null;
+        }
+
         if (in_array($pathElements[0], $this->pathPrefixes, true)) {
             return $pathElements[0];
         }

--- a/src/Sylius/Bundle/ApiBundle/tests/Provider/PathPrefixProviderTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Provider/PathPrefixProviderTest.php
@@ -46,6 +46,16 @@ final class PathPrefixProviderTest extends TestCase
         $this->assertNull($this->pathPrefixProvider->getPathPrefix('/api/v2/wrong/certain-route'));
     }
 
+    public function testReturnsNullIfTheGivenPathEqualsTheApiRoute(): void
+    {
+        $this->assertNull($this->pathPrefixProvider->getPathPrefix('/api/v2'));
+    }
+
+    public function testReturnsNullIfTheGivenPathEqualsTheApiRouteWithTrailingSlash(): void
+    {
+        $this->assertNull($this->pathPrefixProvider->getPathPrefix('/api/v2/'));
+    }
+
     public function testReturnsShopPrefixBasedOnTheGivenPath(): void
     {
         self::assertSame('shop', $this->pathPrefixProvider->getPathPrefix('/api/v2/shop/certain-route'));


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

## Description:

  When the request path equals the configured API route exactly (e.g. /api/v2 — the Swagger UI docs URL), PathPrefixProvider::getPathPrefix() produced an empty $pathElements array and
  triggered a PHP warning on $pathElements[0].

  This surfaced after upgrading api-platform/symfony to 4.3.x, where SwaggerUiProcessor normalizes the OpenAPI doc — which calls IriConverter::getIriFromResource() with request_uri = 
  /api/v2 and hits this code path.

  Fix: return null early when no path segments remain after stripping the API route prefix.

  Tests: added two regression tests covering path == apiRoute and path == apiRoute . '/'.
