### PR TITLE
[Bugfix] Make resource CSRF parameter name configurable to 2.3v

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -31,8 +31,8 @@ security:
                 use_forward: false
                 use_referer: true
                 enable_csrf: true
-                csrf_parameter: _csrf_admin_security_token
-                csrf_token_id: admin_authenticate
+                csrf_parameter: '%sylius_admin.security.csrf_parameter%'
+                csrf_token_id: '%sylius_admin.security.csrf_token_id%'
             remember_me:
                 secret: "%env(APP_SECRET)%"
                 path: "/%sylius_admin.path_name%"
@@ -88,8 +88,8 @@ security:
                 use_forward: false
                 use_referer: true
                 enable_csrf: true
-                csrf_parameter: _csrf_shop_security_token
-                csrf_token_id: shop_authenticate
+                csrf_parameter: '%sylius_shop.security.csrf_parameter%'
+                csrf_token_id: '%sylius_shop.security.csrf_token_id%'
             json_login:
                 check_path: sylius_shop_json_login_check
                 username_path: _username

--- a/src/Sylius/Bundle/AdminBundle/Action/RemoveAvatarAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/RemoveAvatarAction.php
@@ -29,6 +29,7 @@ final class RemoveAvatarAction
         private AvatarImageRepositoryInterface $avatarRepository,
         private RouterInterface $router,
         private ?CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly string $csrfParameter = '_csrf_token',
     ) {
     }
 
@@ -37,7 +38,7 @@ final class RemoveAvatarAction
         $userId = $request->attributes->get('id', '');
 
         if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
-            new CsrfToken($userId, (string) $request->query->get('_csrf_token', '')),
+            new CsrfToken($userId, (string) $request->query->get($this->csrfParameter, '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
         }

--- a/src/Sylius/Bundle/AdminBundle/Action/RemoveAvatarAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/RemoveAvatarAction.php
@@ -28,7 +28,7 @@ final class RemoveAvatarAction
     public function __construct(
         private AvatarImageRepositoryInterface $avatarRepository,
         private RouterInterface $router,
-        private CsrfTokenManagerInterface $csrfTokenManager,
+        private ?CsrfTokenManagerInterface $csrfTokenManager,
     ) {
     }
 
@@ -36,7 +36,7 @@ final class RemoveAvatarAction
     {
         $userId = $request->attributes->get('id', '');
 
-        if (!$this->csrfTokenManager->isTokenValid(
+        if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
             new CsrfToken($userId, (string) $request->query->get('_csrf_token', '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
@@ -32,7 +32,7 @@ final readonly class ResendOrderConfirmationEmailAction
     public function __construct(
         private OrderRepositoryInterface $orderRepository,
         private ResendOrderConfirmationEmailDispatcherInterface $resendOrderConfirmationEmailDispatcher,
-        private CsrfTokenManagerInterface $csrfTokenManager,
+        private ?CsrfTokenManagerInterface $csrfTokenManager,
         private RequestStack $requestStack,
         private RouterInterface $router,
     ) {
@@ -42,7 +42,7 @@ final readonly class ResendOrderConfirmationEmailAction
     {
         $orderId = $request->attributes->get('id', '');
 
-        if (!$this->csrfTokenManager->isTokenValid(
+        if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
             new CsrfToken($orderId, (string) $request->query->get('_csrf_token', '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
@@ -35,6 +35,7 @@ final readonly class ResendOrderConfirmationEmailAction
         private ?CsrfTokenManagerInterface $csrfTokenManager,
         private RequestStack $requestStack,
         private RouterInterface $router,
+        private string $csrfParameter = '_csrf_token',
     ) {
     }
 
@@ -43,7 +44,7 @@ final readonly class ResendOrderConfirmationEmailAction
         $orderId = $request->attributes->get('id', '');
 
         if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
-            new CsrfToken($orderId, (string) $request->query->get('_csrf_token', '')),
+            new CsrfToken($orderId, (string) $request->query->get($this->csrfParameter, '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
         }

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -33,6 +33,7 @@ final readonly class ResendShipmentConfirmationEmailAction
         private ResendShipmentConfirmationEmailDispatcherInterface $resendShipmentConfirmationDispatcher,
         private ?CsrfTokenManagerInterface $csrfTokenManager,
         private RequestStack $requestStack,
+        private string $csrfParameter = '_csrf_token',
     ) {
     }
 
@@ -41,7 +42,7 @@ final readonly class ResendShipmentConfirmationEmailAction
         $shipmentId = $request->attributes->get('id', '');
 
         if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
-            new CsrfToken($shipmentId, (string) $request->query->get('_csrf_token', '')),
+            new CsrfToken($shipmentId, (string) $request->query->get($this->csrfParameter, '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
         }

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -31,7 +31,7 @@ final readonly class ResendShipmentConfirmationEmailAction
     public function __construct(
         private ShipmentRepositoryInterface $shipmentRepository,
         private ResendShipmentConfirmationEmailDispatcherInterface $resendShipmentConfirmationDispatcher,
-        private CsrfTokenManagerInterface $csrfTokenManager,
+        private ?CsrfTokenManagerInterface $csrfTokenManager,
         private RequestStack $requestStack,
     ) {
     }
@@ -40,7 +40,7 @@ final readonly class ResendShipmentConfirmationEmailAction
     {
         $shipmentId = $request->attributes->get('id', '');
 
-        if (!$this->csrfTokenManager->isTokenValid(
+        if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
             new CsrfToken($shipmentId, (string) $request->query->get('_csrf_token', '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -8,6 +8,8 @@ parameters:
     env(SYLIUS_ADMIN_ROUTING_PATH_NAME): admin
     sylius_admin.path_name: '%env(resolve:SYLIUS_ADMIN_ROUTING_PATH_NAME)%'
     sylius.security.admin_regex: "^/%sylius_admin.path_name%"
+    sylius_admin.security.csrf_parameter: '_csrf_admin_security_token'
+    sylius_admin.security.csrf_token_id: 'admin_authenticate'
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.php
@@ -62,6 +62,7 @@ return static function (ContainerConfigurator $container) {
             service('sylius.repository.avatar_image'),
             service('router'),
             service('security.csrf.token_manager')->nullOnInvalid(),
+            param('sylius.resource.csrf_parameter'),
         ])
     ;
 
@@ -73,6 +74,7 @@ return static function (ContainerConfigurator $container) {
             service('security.csrf.token_manager')->nullOnInvalid(),
             service('request_stack'),
             service('router'),
+            param('sylius.resource.csrf_parameter'),
         ])
     ;
 
@@ -83,6 +85,7 @@ return static function (ContainerConfigurator $container) {
             service('sylius.command_dispatcher.resend_shipment_confirmation_email'),
             service('security.csrf.token_manager')->nullOnInvalid(),
             service('request_stack'),
+            param('sylius.resource.csrf_parameter'),
         ])
     ;
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.php
@@ -61,7 +61,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('sylius.repository.avatar_image'),
             service('router'),
-            service('security.csrf.token_manager'),
+            service('security.csrf.token_manager')->nullOnInvalid(),
         ])
     ;
 
@@ -70,7 +70,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('sylius.repository.order'),
             service('sylius.command_dispatcher.resend_order_confirmation_email'),
-            service('security.csrf.token_manager'),
+            service('security.csrf.token_manager')->nullOnInvalid(),
             service('request_stack'),
             service('router'),
         ])
@@ -81,7 +81,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('sylius.repository.shipment'),
             service('sylius.command_dispatcher.resend_shipment_confirmation_email'),
-            service('security.csrf.token_manager'),
+            service('security.csrf.token_manager')->nullOnInvalid(),
             service('request_stack'),
         ])
     ;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component/taxon.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component/taxon.php
@@ -23,7 +23,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius_admin.twig.component.taxon.delete', DeleteComponent::class)
-        ->args([service('security.csrf.token_manager')])
+        ->args([service('security.csrf.token_manager')->nullOnInvalid()])
         ->call('setLiveResponder', [service('ux.live_component.live_responder')])
         ->tag('sylius.live_component.admin', ['key' => 'sylius_admin:taxon:delete'])
     ;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/DeleteComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/DeleteComponent.php
@@ -37,7 +37,7 @@ final class DeleteComponent
     public string $taxonId = '';
 
     public function __construct(
-        protected readonly CsrfTokenManagerInterface $csrfTokenManager,
+        protected readonly ?CsrfTokenManagerInterface $csrfTokenManager,
     ) {
     }
 
@@ -47,7 +47,7 @@ final class DeleteComponent
         $this->taxonId = $taxonId;
         $this->dispatchBrowserEvent(
             self::OPEN_DELETE_MODAL_EVENT,
-            ['csrfToken' => $this->csrfTokenManager->getToken($taxonId)->getValue()],
+            ['csrfToken' => $this->csrfTokenManager?->getToken($taxonId)->getValue()],
         );
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
@@ -18,7 +18,7 @@
         {{ form_widget(hookable_metadata.context.form.avatar) }}
         {% if admin_user.id is not null and admin_user.avatar is not null and admin_user.avatar.path is not empty %}
             <button
-                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, '_csrf_token': csrf_token(admin_user.id)}) }}"
+                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(admin_user.id) : null}) }}"
                 type="submit"
                 class="btn btn-danger"
                 {{ sylius_test_html_attribute('delete-avatar-button') }}

--- a/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
@@ -18,7 +18,7 @@
         {{ form_widget(hookable_metadata.context.form.avatar) }}
         {% if admin_user.id is not null and admin_user.avatar is not null and admin_user.avatar.path is not empty %}
             <button
-                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(admin_user.id) : null}) }}"
+                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(admin_user.id) : null}) }}"
                 type="submit"
                 class="btn btn-danger"
                 {{ sylius_test_html_attribute('delete-avatar-button') }}

--- a/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/channel/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/channel/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
     {{ form_end(form, {render_rest: false}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/country/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/country/form.html.twig
@@ -6,7 +6,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
@@ -4,7 +4,9 @@
 {% if user != null %}
     <form action="{{ path('sylius_admin_shop_user_delete', {'id': user.id, 'customerId': customer.id}) }}" method="POST">
         <input type="hidden" name="_method" value="DELETE" />
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(user.id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(user.id) }}" />
+        {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('customer-actions-delete') }}>
             {{ ux_icon('tabler:trash-x', {'class': 'icon dropdown-item-icon'}) }}
             {{ 'sylius.ui.delete'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
@@ -5,7 +5,7 @@
     <form action="{{ path('sylius_admin_shop_user_delete', {'id': user.id, 'customerId': customer.id}) }}" method="POST">
         <input type="hidden" name="_method" value="DELETE" />
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(user.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(user.id) }}" />
         {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('customer-actions-delete') }}>
             {{ ux_icon('tabler:trash-x', {'class': 'icon dropdown-item-icon'}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/cancel.html.twig
@@ -5,7 +5,9 @@
 {% if sylius_sm_can(order, constant('Sylius\\Component\\Order\\OrderTransitions::GRAPH'), constant('Sylius\\Component\\Order\\OrderTransitions::TRANSITION_CANCEL')) %}
     <form action="{{ path('sylius_admin_order_cancel', {'id': order.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+        {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('cancel-order') }}>
             {{ ux_icon('tabler:circle-check', {'class': 'icon dropdown-item-icon'}) }}
             {{ 'sylius.ui.cancel'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/cancel.html.twig
@@ -6,7 +6,7 @@
     <form action="{{ path('sylius_admin_order_cancel', {'id': order.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(order.id) }}" />
         {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('cancel-order') }}>
             {{ ux_icon('tabler:circle-check', {'class': 'icon dropdown-item-icon'}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/cancel.html.twig
@@ -4,7 +4,7 @@
     <form action="{{ path('sylius_admin_order_cancel', {'id': order.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(order.id) }}" />
         {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('cancel-order') }}>
             {{ ux_icon('tabler:circle-check', {'class': 'icon dropdown-item-icon'}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/cancel.html.twig
@@ -3,7 +3,9 @@
 {% if sylius_sm_can(order, constant('Sylius\\Component\\Order\\OrderTransitions::GRAPH'), constant('Sylius\\Component\\Order\\OrderTransitions::TRANSITION_CANCEL')) %}
     <form action="{{ path('sylius_admin_order_cancel', {'id': order.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+        {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('cancel-order') }}>
             {{ ux_icon('tabler:circle-check', {'class': 'icon dropdown-item-icon'}) }}
             {{ 'sylius.ui.cancel'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/resend_confirmation_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/resend_confirmation_email.html.twig
@@ -1,7 +1,7 @@
 {% set order = hookable_metadata.context.resource %}
 
 {% if order.state in sylius_order_states_that_allows_to_resend_order_confirmation_email %}
-    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
+    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
     <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('resend-order-confirmation-email') }}>
         {{ ux_icon('tabler:send', {'class': 'icon dropdown-item-icon flex-shrink-0'}) }}
         <div class="pe-6">{{ 'sylius.ui.resend_the_order_confirmation_email'|trans }}</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/resend_confirmation_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/resend_confirmation_email.html.twig
@@ -1,7 +1,7 @@
 {% set order = hookable_metadata.context.resource %}
 
 {% if order.state in sylius_order_states_that_allows_to_resend_order_confirmation_email %}
-    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': csrf_token(order.id)}) %}
+    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
     <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('resend-order-confirmation-email') }}>
         {{ ux_icon('tabler:send', {'class': 'icon dropdown-item-icon flex-shrink-0'}) }}
         <div class="pe-6">{{ 'sylius.ui.resend_the_order_confirmation_email'|trans }}</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/resend_confirmation_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/resend_confirmation_email.html.twig
@@ -3,7 +3,7 @@
 {% set order = hookable_metadata.context.resource %}
 
 {% if order.state in sylius_order_states_that_allows_to_resend_order_confirmation_email %}
-    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': csrf_token(order.id)}) %}
+    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
     <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('resend-order-confirmation-email') }}>
         {{ ux_icon('tabler:send', {'class': 'icon dropdown-item-icon flex-shrink-0'}) }}
         <div class="pe-6">{{ 'sylius.ui.resend_the_order_confirmation_email'|trans }}</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/resend_confirmation_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/resend_confirmation_email.html.twig
@@ -3,7 +3,7 @@
 {% set order = hookable_metadata.context.resource %}
 
 {% if order.state in sylius_order_states_that_allows_to_resend_order_confirmation_email %}
-    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
+    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
     <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('resend-order-confirmation-email') }}>
         {{ ux_icon('tabler:send', {'class': 'icon dropdown-item-icon flex-shrink-0'}) }}
         <div class="pe-6">{{ 'sylius.ui.resend_the_order_confirmation_email'|trans }}</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/complete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/complete.html.twig
@@ -4,7 +4,9 @@
 {% if sylius_sm_can(payment, constant('Sylius\\Component\\Payment\\PaymentTransitions::GRAPH'), constant('Sylius\\Component\\Payment\\PaymentTransitions::TRANSITION_COMPLETE')) %}
     <form action="{{ path('sylius_admin_order_payment_complete', {'orderId': order.id, 'id': payment.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+        {% endif %}
         <button type="submit" class="btn" {{ sylius_test_html_attribute('complete-payment', payment.id) }}>
             {{ ux_icon('tabler:check') }} {{ 'sylius.ui.complete'|trans }}
         </button>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/complete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/complete.html.twig
@@ -5,7 +5,7 @@
     <form action="{{ path('sylius_admin_order_payment_complete', {'orderId': order.id, 'id': payment.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(payment.id) }}" />
         {% endif %}
         <button type="submit" class="btn" {{ sylius_test_html_attribute('complete-payment', payment.id) }}>
             {{ ux_icon('tabler:check') }} {{ 'sylius.ui.complete'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/refund.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/refund.html.twig
@@ -5,7 +5,7 @@
     <form action="{{ path('sylius_admin_order_payment_refund', {'orderId': order.id, 'id': payment.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(payment.id) }}" />
         {% endif %}
         <button type="submit" class="btn" {{ sylius_test_html_attribute('refund-payment', payment.id) }}>
             {{ ux_icon('tabler:arrow-back-up-double') }} {{ 'sylius.ui.refund'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/refund.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/refund.html.twig
@@ -4,7 +4,9 @@
 {% if sylius_sm_can(payment, constant('Sylius\\Component\\Payment\\PaymentTransitions::GRAPH'), constant('Sylius\\Component\\Payment\\PaymentTransitions::TRANSITION_REFUND')) %}
     <form action="{{ path('sylius_admin_order_payment_refund', {'orderId': order.id, 'id': payment.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+        {% endif %}
         <button type="submit" class="btn" {{ sylius_test_html_attribute('refund-payment', payment.id) }}>
             {{ ux_icon('tabler:arrow-back-up-double') }} {{ 'sylius.ui.refund'|trans }}
         </button>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/shipments/item/actions/resend_confirmation.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/shipments/item/actions/resend_confirmation.html.twig
@@ -1,7 +1,7 @@
 {% set shipment = hookable_metadata.context.shipment %}
 
 {% if shipment.state == 'shipped' %}
-    {% set resend_path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, '_csrf_token': csrf_token(shipment.id)}) %}
+    {% set resend_path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, '_csrf_token': sylius_csrf_protection_enabled () ? csrf_token(shipment.id) : null}) %}
     <a href="{{ resend_path }}" class="btn btn-icon" data-bs-toggle="tooltip" data-bs-title="{{ 'sylius.ui.resend_the_shipment_confirmation_email'|trans }}" {{ sylius_test_html_attribute('resend-shipment-confirmation-email') }}>
         {{ ux_icon('tabler:send') }}
     </a>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/shipments/item/actions/resend_confirmation.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/shipments/item/actions/resend_confirmation.html.twig
@@ -1,7 +1,7 @@
 {% set shipment = hookable_metadata.context.shipment %}
 
 {% if shipment.state == 'shipped' %}
-    {% set resend_path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, '_csrf_token': sylius_csrf_protection_enabled () ? csrf_token(shipment.id) : null}) %}
+    {% set resend_path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(shipment.id) : null}) %}
     <a href="{{ resend_path }}" class="btn btn-icon" data-bs-toggle="tooltip" data-bs-title="{{ 'sylius.ui.resend_the_shipment_confirmation_email'|trans }}" {{ sylius_test_html_attribute('resend-shipment-confirmation-email') }}>
         {{ ux_icon('tabler:send') }}
     </a>

--- a/src/Sylius/Bundle/AdminBundle/templates/payment_method/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/payment_method/form.html.twig
@@ -10,7 +10,6 @@
         <input type="hidden" name="_method" value="{{ configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form.html.twig
@@ -9,7 +9,6 @@
                 <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
             {% endif %}
             {{ form_errors(form) }}
-            {{ form_widget(form._token) }}
 
             {% hook 'form' with {
                 mapped_product_attributes,

--- a/src/Sylius/Bundle/AdminBundle/templates/product/generate_variants/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/generate_variants/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/product_attribute/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_attribute/form.html.twig
@@ -9,7 +9,6 @@
         {% if hookable_metadata.configuration.method is defined %}
             <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
         {% endif %}
-        {{ form_widget(form._token) }}
 
         {% hook 'form' with { form } %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product_option/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_option/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
@@ -1,7 +1,7 @@
 <button class="btn primary"
     {{ stimulus_controller('@sylius/admin-bundle/save-positions', {
         url: path('sylius_admin_ajax_product_taxons_update_position', {taxonId: app.request.get('taxonId')}),
-        csrfToken: csrf_token('update-product-taxon-position'),
+        csrfToken: sylius_csrf_protection_enabled() ? csrf_token('update-product-taxon-position') : null,
         inputSelector: '.sylius-product-taxon-position',
         dataKey: 'productTaxons',
     }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/form.html.twig
@@ -7,7 +7,6 @@
             <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
         {% endif %}
         {{ form_errors(form, sylius_test_form_attribute('form-validation-errors')) }}
-        {{ form_widget(form._token) }}
 
         {% hook 'form' with { form, resource } %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/action/update_positions.html.twig
@@ -1,7 +1,7 @@
 <button class="btn primary"
     {{ stimulus_controller('@sylius/admin-bundle/save-positions', {
         url: path('sylius_admin_ajax_product_variants_update_position'),
-        csrfToken: csrf_token('update-product-variant-position'),
+        csrfToken: sylius_csrf_protection_enabled() ? csrf_token('update-product-variant-position') : null,
         inputSelector: '.sylius-product-variant-position',
         dataKey: 'productVariants',
     }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion_coupon/generate/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion_coupon/generate/form.html.twig
@@ -4,7 +4,6 @@
     {{ form_start(form, {'attr': {'novalidate': 'novalidate', 'id': form.vars.id}}) }}
     <div class="row">
         {{ form_errors(form) }}
-        {{ form_widget(form._token) }}
 
         {% hook 'form' with { form } %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
@@ -4,5 +4,7 @@
 
 {{ form_start(form, {'action': path('sylius_admin_login_check'), 'attr': {'class': 'ui large loadable form', 'novalidate': 'novalidate'}}) }}
     {% hook 'form' with { form } %}
-    <input type="hidden" name="_csrf_admin_security_token" value="{{ csrf_token('admin_authenticate') }}">
+    {% if sylius sylius_csrf_protection_enabled() %}
+        <input type="hidden" name="_csrf_admin_security_token" value="{{ csrf_token('admin_authenticate') }}">
+    {% endif %}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
@@ -4,7 +4,7 @@
 
 {{ form_start(form, {'action': path('sylius_admin_login_check'), 'attr': {'class': 'ui large loadable form', 'novalidate': 'novalidate'}}) }}
     {% hook 'form' with { form } %}
-    {% if sylius sylius_csrf_protection_enabled() %}
-        <input type="hidden" name="_csrf_admin_security_token" value="{{ csrf_token('admin_authenticate') }}">
+    {% if sylius_csrf_protection_enabled() %}
+        <input type="hidden" name="{{ sylius_security_csrf_parameter('admin') }}" value="{{ csrf_token(sylius_security_csrf_token_id('admin')) }}">
     {% endif %}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/security/request_password_reset/page/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/request_password_reset/page/content/form.html.twig
@@ -4,5 +4,4 @@
 
 {{ form_start(form, {'action': path('sylius_admin_request_password_reset'), 'attr': {'class': 'ui large loadable form', 'novalidate': 'novalidate'}}) }}
     {% hook 'form' with { form } %}
-    {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/security/reset_password/page/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/reset_password/page/content/form.html.twig
@@ -4,5 +4,4 @@
 
 {{ form_start(form, {'action': path('sylius_admin_password_reset', {'token': app.request.attributes.get('token')}), 'attr': {'class': 'ui large loadable form', 'novalidate': 'novalidate'}}) }}
     {% hook 'form' with { form } %}
-    {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/components/delete_modal.html.twig
@@ -13,7 +13,9 @@
 {% block footer %}
     <form action="{{ path }}" method="post" {{ form_attr }}>
         <input type="hidden" name="_method" value="DELETE">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+        {% endif %}
 
         {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}
         {{ button.default({ text: label|trans, type: 'submit', class: 'btn-danger', attr: sylius_test_html_attribute('confirm-button') }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/components/delete_modal.html.twig
@@ -14,7 +14,7 @@
     <form action="{{ path }}" method="post" {{ form_attr }}>
         <input type="hidden" name="_method" value="DELETE">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(id) }}" />
         {% endif %}
 
         {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
@@ -17,7 +17,6 @@
             <input type="hidden" name="_method" value="PUT"/>
         {% endif %}
         {{ form_errors(form) }}
-        {{ form_widget(form._token) }}
 
         {% hook 'form' with { form, resource } %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
@@ -87,3 +87,12 @@
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' btn btn-outline-primary')|trim}) %}
     {{ parent() }}
 {%- endblock -%}
+
+{%- block form_end -%}
+        {% for child in form %}
+            {% if 'csrf_token' in child.vars.block_prefixes and child.rendered == false %}
+                {{ form_row(child) }}
+            {% endif %}
+        {% endfor %}
+    </form>
+{%- endblock form_end -%}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/apply_transition.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/apply_transition.html.twig
@@ -4,7 +4,7 @@
 {% if sylius_sm_can(data, options.graph, options.transition) %}
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post" {{ sylius_test_html_attribute('action', action.name) }}>
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(data.id) }}">
         {% endif %}
         <input type="hidden" name="_method" value="PUT">
         <button class="btn {{ options.class|default }}" {% if labeled and 'btn-icon' in options.class|default %}data-bs-toggle="tooltip" data-bs-title="{{ action.label|trans }}"{% endif %}>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/apply_transition.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/apply_transition.html.twig
@@ -3,7 +3,9 @@
 
 {% if sylius_sm_can(data, options.graph, options.transition) %}
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post" {{ sylius_test_html_attribute('action', action.name) }}>
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
+        {% endif %}
         <input type="hidden" name="_method" value="PUT">
         <button class="btn {{ options.class|default }}" {% if labeled and 'btn-icon' in options.class|default %}data-bs-toggle="tooltip" data-bs-title="{{ action.label|trans }}"{% endif %}>
             {% if action.icon %}{{ ux_icon(action.icon) }}{% endif %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/archive.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/archive.html.twig
@@ -17,7 +17,9 @@
     {% block footer %}
         <form action="{{ path }}" method="POST" name="sylius_archivable">
             <input type="hidden" name="_method" value="PATCH">
-            <input type="hidden" name="sylius_archivable[_token]" value="{{ csrf_token('sylius_archivable') }}" />
+            {% if sylius_csrf_protection_enabled() %}
+                <input type="hidden" name="sylius_archivable[_token]" value="{{ csrf_token('sylius_archivable') }}" />
+            {% endif %}
 
             {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}
             {{ button.default({ text: label, type: 'submit', class: 'btn-primary', attr: sylius_test_html_attribute('confirm-button') }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shipment/component/ship.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipment/component/ship.html.twig
@@ -16,7 +16,6 @@
                 {{ 'sylius.ui.ship'|trans }}
             </button>
         </div>
-        {{ form_row(form._token) }}
         {{ form_end(form, {'render_rest': false}) }}
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form.html.twig
@@ -9,7 +9,6 @@
             <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
         {% endif %}
         {{ form_errors(form) }}
-        {{ form_widget(form._token) }}
 
         {% hook 'form' with { form } %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
@@ -25,7 +25,7 @@
                     <div class="modal-footer">
                         <form action="{{ path('sylius_admin_taxon_delete', {id: id}) }}" method="post">
                             <input type="hidden" name="_method" value="DELETE">
-                            <input type="hidden" name="_csrf_token" {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'csrfToken') }}/>
+                            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'csrfToken') }}/>
 
                             {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}
                             {{ button.default({ text: 'sylius.ui.delete'|trans, type: 'submit', class: 'btn-danger', attr: sylius_test_html_attribute('confirm-button') }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/zone/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/zone/form.html.twig
@@ -8,7 +8,6 @@
         <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}" />
     {% endif %}
     {{ form_errors(form) }}
-    {{ form_widget(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/Symfony6PrivateServicesPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/Symfony6PrivateServicesPass.php
@@ -33,6 +33,10 @@ final class Symfony6PrivateServicesPass implements CompilerPassInterface
 
     private function makeServicePublic(string $serviceId, ContainerBuilder $container): void
     {
+        if (!$container->hasDefinition($serviceId)) {
+            return;
+        }
+
         $service = $container->getDefinition($serviceId);
         $service->setPublic(true);
         $container->setDefinition($serviceId, $service);

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/DisabledCsrfProtectionFormExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/DisabledCsrfProtectionFormExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Extension;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DisabledCsrfProtectionFormExtension extends AbstractTypeExtension
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [FormType::class];
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $csrfEnabled = $this->container->hasParameter('form.type_extension.csrf.enabled')
+            ? $this->container->getParameter('form.type_extension.csrf.enabled')
+            : true;
+
+        if (!$csrfEnabled) {
+            $resolver->setDefault('csrf_protection', false);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.php
@@ -26,6 +26,7 @@ use Sylius\Bundle\CoreBundle\Form\Extension\CartItemTypeExtension;
 use Sylius\Bundle\CoreBundle\Form\Extension\CartTypeExtension;
 use Sylius\Bundle\CoreBundle\Form\Extension\CatalogPromotionTypeExtension;
 use Sylius\Bundle\CoreBundle\Form\Extension\ChannelTypeExtension;
+use Sylius\Bundle\CoreBundle\Form\Extension\DisabledCsrfProtectionFormExtension;
 use Sylius\Bundle\CoreBundle\Form\Extension\OrderTypeExtension;
 use Sylius\Bundle\CoreBundle\Form\Extension\PaymentMethodTypeExtension;
 use Sylius\Bundle\CoreBundle\Form\Extension\ProductTranslationTypeExtension;
@@ -178,6 +179,12 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.form.extension.type.product_variant_generation', ProductVariantGenerationTypeExtension::class)
+        ->tag('form.type_extension', ['priority' => 100])
+    ;
+
+    $services
+        ->set('sylius.form.extension.type.disabled_csrf_protection', DisabledCsrfProtectionFormExtension::class)
+        ->args([service('service_container')])
         ->tag('form.type_extension', ['priority' => 100])
     ;
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sylius\Bundle\CoreBundle\Twig\BundleLoadedCheckerExtension;
 use Sylius\Bundle\CoreBundle\Twig\ChannelUrlExtension;
+use Sylius\Bundle\CoreBundle\Twig\CsrfProtectionEnabledExtension;
 use Sylius\Bundle\CoreBundle\Twig\PriceExtension;
 use Sylius\Bundle\CoreBundle\Twig\ProductTranslationExtension;
 use Sylius\Bundle\CoreBundle\Twig\VariantResolverExtension;
@@ -56,6 +57,13 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius.twig.extension.product_translation', ProductTranslationExtension::class)
         ->args([service('sylius.provider.channel_based_product_translation')])
+        ->private()
+        ->tag('twig.extension')
+    ;
+
+    $services
+        ->set('sylius.twig.extension.csrf_protection', CsrfProtectionEnabledExtension::class)
+        ->args([service('service_container')])
         ->private()
         ->tag('twig.extension')
     ;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\CoreBundle\Twig\ChannelUrlExtension;
 use Sylius\Bundle\CoreBundle\Twig\CsrfProtectionEnabledExtension;
 use Sylius\Bundle\CoreBundle\Twig\PriceExtension;
 use Sylius\Bundle\CoreBundle\Twig\ProductTranslationExtension;
+use Sylius\Bundle\CoreBundle\Twig\SecurityCsrfExtension;
 use Sylius\Bundle\CoreBundle\Twig\VariantResolverExtension;
 
 return static function (ContainerConfigurator $container) {
@@ -63,6 +64,13 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.twig.extension.csrf_protection', CsrfProtectionEnabledExtension::class)
+        ->args([service('service_container')])
+        ->private()
+        ->tag('twig.extension')
+    ;
+
+    $services
+        ->set('sylius.twig.extension.security_csrf', SecurityCsrfExtension::class)
         ->args([service('service_container')])
         ->private()
         ->tag('twig.extension')

--- a/src/Sylius/Bundle/CoreBundle/Twig/CsrfProtectionEnabledExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/CsrfProtectionEnabledExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class CsrfProtectionEnabledExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_csrf_protection_enabled', [$this, 'isCsrfProtectionEnabled']),
+        ];
+    }
+
+    public function isCsrfProtectionEnabled(): bool
+    {
+        return $this->container->has('security.csrf.token_manager');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SecurityCsrfExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_security_csrf_parameter', [$this, 'getCsrfParameter']),
+            new TwigFunction('sylius_security_csrf_token_id', [$this, 'getCsrfTokenId']),
+        ];
+    }
+
+    public function getCsrfParameter(string $section): string
+    {
+        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_parameter', $section));
+    }
+
+    public function getCsrfTokenId(string $section): string
+    {
+        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_token_id', $section));
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -11,6 +11,8 @@ imports:
 
 parameters:
     sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius_shop.security.csrf_parameter: '_csrf_shop_security_token'
+    sylius_shop.security.csrf_token_id: 'shop_authenticate'
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/common/main/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/common/main/form.html.twig
@@ -10,6 +10,5 @@
 
     {% hook 'form' with { form } %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/set_as_default.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/set_as_default.html.twig
@@ -1,9 +1,11 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
+
+{% form_theme form '@SyliusShop/form/theme.html.twig' %}
+
 <div {{ attributes }}>
     {{ form_start(form, {'action': path('sylius_shop_account_address_book_set_as_default', {'id': hookable_metadata.context.address.id})}) }}
     <input type="hidden" name="_method" value="PATCH" />
     <input type="hidden" name={{ form.defaultAddress.vars['full_name'] }} value={{ hookable_metadata.context.address.id }} />
     {{ buttons.submit('sylius.ui.set_as_default'|trans, 'set-as-default-button', null, 'btn-sm btn-icon btn-outline-gray w-full') }}
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/change_password/update/content/main/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/change_password/update/content/main/form.html.twig
@@ -10,6 +10,5 @@
 
     {% hook 'form' with { form } %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/forgotten_password/content/form_container/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/forgotten_password/content/form_container/form.html.twig
@@ -5,6 +5,5 @@
 <div>
     {{ form_start(form, {'action': path('sylius_shop_request_password_reset_token'), 'attr': {'novalidate': 'novalidate'}}) }}
     {% hook 'form' %}
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
@@ -1,3 +1,3 @@
 {% if sylius_csrf_protection_enabled() %}
-    <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}">
+    <input type="hidden" name="{{ sylius_security_csrf_parameter('shop') }}" value="{{ csrf_token(sylius_security_csrf_token_id('shop')) }}">
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
@@ -1,1 +1,3 @@
-<input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}">
+{% if sylius_csrf_protection_enabled() %}
+    <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}">
+{% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/profile_update/update/content/main/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/profile_update/update/content/main/form.html.twig
@@ -3,7 +3,6 @@
 <div {{ attributes }}>
     {{ form_start(form, {'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
     {{ form_errors(form) }}
-    {{ form_row(form._token) }}
     <input type="hidden" name="_method" value="PUT" />
 
     {% hook 'form' with { form } %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/register/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/register/content/form.html.twig
@@ -2,7 +2,6 @@
 
 <div {{ attributes }}>
     {{ form_start(form, {'action': path('sylius_shop_register'), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate', 'id': form.vars.id}}) }}
-    {{ form_row(form._token) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/ShopBundle/templates/account/reset_password/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/reset_password/content/form.html.twig
@@ -7,5 +7,4 @@
 
 {% hook 'form' %}
 
-{{ form_row(form._token) }}
 {{ form_end(form, {render_rest: hookable.configuration.render_rest|default(false)}) }}

--- a/src/Sylius/Bundle/ShopBundle/templates/cart/index/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/cart/index/content/form.html.twig
@@ -11,7 +11,6 @@
         {{ form_start(form, {'action': path('sylius_shop_cart_checkout'), 'attr': {'novalidate': 'novalidate', 'id': form.vars.id}}) }}
         <input type="hidden" name="_method" value="PATCH"/>
         {{ form_errors(form) }}
-        {{ form_widget(form._token) }}
 
         {% hook 'form' with { form }  %}
 

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form.html.twig
@@ -9,6 +9,5 @@
 
     {% hook 'form' with { form, order: resource, email_exists: emailExists } %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {render_rest: hookable.configuration.render_rest|default(false)}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
@@ -11,7 +11,9 @@
                 <input type="password" class="form-control" placeholder="{{ 'sylius.ui.password'|trans }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'password') }} {{ sylius_test_html_attribute('password-input') }}>
                 <button class="btn btn-primary" type="button" {{ stimulus_action('@sylius/shop-bundle/api-login', 'login') }} {{ sylius_test_html_attribute('login-button') }}>{{ 'sylius.ui.sign_in'|trans }}</button>
             </div>
-            <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
+            {% if sylius_csrf_protection_enabled() %}
+                <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
+            {% endif %}
             <div {{ stimulus_target('@sylius/shop-bundle/api-login', 'error') }} {{ sylius_test_html_attribute('login-validation-error') }}></div>
         {% endif %}
     </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
@@ -12,7 +12,7 @@
                 <button class="btn btn-primary" type="button" {{ stimulus_action('@sylius/shop-bundle/api-login', 'login') }} {{ sylius_test_html_attribute('login-button') }}>{{ 'sylius.ui.sign_in'|trans }}</button>
             </div>
             {% if sylius_csrf_protection_enabled() %}
-                <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
+                <input type="hidden" name="{{ sylius_security_csrf_parameter('shop') }}" value="{{ csrf_token(sylius_security_csrf_token_id('shop')) }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
             {% endif %}
             <div {{ stimulus_target('@sylius/shop-bundle/api-login', 'error') }} {{ sylius_test_html_attribute('login-validation-error') }}></div>
         {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/complete/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/complete/content/form.html.twig
@@ -8,5 +8,4 @@
 
 {% hook 'form' %}
 
-{{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/select_payment/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/select_payment/content/form.html.twig
@@ -10,6 +10,5 @@
 
     {% hook 'form' with { form, order: resource } %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/select_shipping/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/select_shipping/content/form.html.twig
@@ -10,6 +10,5 @@
 
     {% hook 'form' %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/contact/contact_request/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/contact/contact_request/content/form.html.twig
@@ -2,5 +2,4 @@
 
 {{ form_start(form, {'action': path('sylius_shop_contact_request'), 'attr': {'novalidate': 'novalidate'}}) }}
 {% hook 'form' %}
-{{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/ShopBundle/templates/form/theme.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/form/theme.html.twig
@@ -73,3 +73,12 @@
         {% endfor %}
     </div>
 {% endblock %}
+
+{%- block form_end -%}
+    {% for child in form %}
+        {% if 'csrf_token' in child.vars.block_prefixes and child.rendered == false %}
+            {{ form_row(child) }}
+        {% endif %}
+    {% endfor %}
+    </form>
+{%- endblock form_end -%}

--- a/src/Sylius/Bundle/ShopBundle/templates/order/show/content/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/order/show/content/form.html.twig
@@ -12,7 +12,6 @@
 
     {% hook 'form' %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 {% else %}
     {{ messages.info('sylius.ui.you_can_no_longer_change_payment_method_of_this_order') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart.html.twig
@@ -15,7 +15,6 @@
 
             {% hook 'add_to_cart' with { product, form } %}
 
-            {{ form_row(form._token) }}
             {{ form_end(form, {'render_rest': false}) }}
         </div>
     {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product_review/create/content/main/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product_review/create/content/main/form.html.twig
@@ -11,6 +11,5 @@
 
     {{ form_errors(form) }}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/buttons.html.twig
@@ -57,6 +57,8 @@
         <button class="btn btn-sm btn-icon btn-outline-danger w-full" type="submit" data-requires-confirmation {{ sylius_test_html_attribute('button', 'delete') }}>
             {{ ux_icon('tabler:trash', {'class': 'icon icon-xs'})}} {{ ((message is empty and labeled) ? 'sylius.ui.delete' : message)|trans }}
         </button>
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(resourceId) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(resourceId) }}" />
+        {% endif %}
     </form>
 {% endmacro %}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/buttons.html.twig
@@ -58,7 +58,7 @@
             {{ ux_icon('tabler:trash', {'class': 'icon icon-xs'})}} {{ ((message is empty and labeled) ? 'sylius.ui.delete' : message)|trans }}
         </button>
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(resourceId) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(resourceId) }}" />
         {% endif %}
     </form>
 {% endmacro %}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
@@ -13,7 +13,9 @@
 {% block footer %}
     <form action="{{ path }}" method="post" {{ form_attr }}>
         <input type="hidden" name="_method" value="DELETE">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+        {% if sylius_csrf_protection_enabled() %}
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+        {% endif %}
 
         <button type="button" class="btn btn-sm" data-bs-dismiss="modal">
             {{ 'sylius.ui.cancel'|trans }}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
@@ -14,7 +14,7 @@
     <form action="{{ path }}" method="post" {{ form_attr }}>
         <input type="hidden" name="_method" value="DELETE">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(id) }}" />
         {% endif %}
 
         <button type="button" class="btn btn-sm" data-bs-dismiss="modal">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/pull/19008, https://github.com/Sylius/Sylius/pull/19001, https://github.com/Sylius/SyliusResourceBundle/pull/1163
| License         | MIT

## Summary
Replaces hardcoded _csrf_token field name across resource action templates
and admin actions with a configurable parameter, allowing projects to customize
the CSRF field name via configuration.

## Motivation
The CSRF field name for resource actions (delete, cancel, refund, resend email,
avatar removal, etc.) was hardcoded to _csrf_token in 18 templates and
3 PHP actions. Projects requiring custom CSRF field names (for security
conventions or framework compliance) had no way to override it.