### PR TITLE
Add appendError method to ResponseCheckerInterface

### DIFF
--- a/src/Sylius/Behat/Client/ResponseCheckerInterface.php
+++ b/src/Sylius/Behat/Client/ResponseCheckerInterface.php
@@ -93,6 +93,8 @@ interface ResponseCheckerInterface
 
     public function hasViolationWithMessage(Response $response, string $message, ?string $property = null): bool;
 
+    public function appendError(Response $response): ResponseCheckerInterface;
+
     public function cleanErrors(): void;
 
     /** @return array{


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

A missing interface method signature `appendError` is missing in the `ResponseCheckerInterface`, I don't know why PHPStan did not spot this but this method  is used here : https://github.com/Sylius/Sylius/blob/2.2/src/Sylius/Behat/Client/ApiPlatformClient.php#L357 therefore the interface method must exists.