### PR TITLE
[2.2] [AttributeBundle] make Add and Delete button translatable in product attribute select type

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Form/Type/AttributeType/Configuration/SelectAttributeConfigurationType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/AttributeType/Configuration/SelectAttributeConfigurationType.php
@@ -33,6 +33,9 @@ class SelectAttributeConfigurationType extends BaseSelectAttributeConfigurationT
             'entry_options' => [
                 'entry_type' => TextType::class,
             ],
+            'button_add_options' => [
+                'label' => 'sylius.form.attribute_type_configuration.select.add_choice',
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/templates/product_attribute/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_attribute/form_theme.html.twig
@@ -8,6 +8,6 @@
 
     <div {{ sylius_test_html_attribute('choice-key', key) }}>
         {{ translations.single_field(form, key, {accordion_id: 'product-attribute-choices-' ~ key}) }}
-        {{ form_row(form.vars.button_delete, sylius_test_form_attribute('choice-removal', key)|sylius_merge_recursive({ label: 'Delete', attr: { class: 'mt-2 mb-4 btn btn-outline-danger' } })) }}
+        {{ form_row(form.vars.button_delete, sylius_test_form_attribute('choice-removal', key)|sylius_merge_recursive({ label: 'sylius.form.attribute_type_configuration.select.delete_choice', attr: { class: 'mt-2 mb-4 btn btn-outline-danger' } })) }}
     </div>
 {% endblock %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de.yml
@@ -36,6 +36,8 @@ sylius:
                 choose: Bitte wählen Sie eine Option
                 min: Mindestanzahl Einträge
                 max: Maximalanzahl Einträge
+                add_choice: Hinzufügen
+                delete_choice: Löschen
             text:
                 min: Mindestlänge
                 max: Maximale Länge

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_AT.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_AT.yml
@@ -36,6 +36,8 @@ sylius:
                 choose: 'Option wählen'
                 min: 'Min Einträge'
                 max: 'Max Einträge'
+                add_choice: 'Hinzufügen'
+                delete_choice: 'Löschen'
             text:
                 min: 'Min Länge'
                 max: 'Max Länge'

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_CH.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_CH.yml
@@ -36,6 +36,8 @@ sylius:
                 choose: 'Option wählen'
                 min: 'Min. Einträge'
                 max: 'Max. Einträge'
+                add_choice: 'Hinzufügen'
+                delete_choice: 'Löschen'
             text:
                 min: 'Min. Länge'
                 max: 'Max. Länge'

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en.yml
@@ -33,6 +33,8 @@ sylius:
                 choose: Choose an option
                 min: Min entries
                 max: Max entries
+                add_choice: Add
+                delete_choice: Delete
             text:
                 min: Min length
                 max: Max length

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en_GB.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en_GB.yml
@@ -33,6 +33,8 @@ sylius:
                 choose: 'Choose an option'
                 min: 'Minimum number of entries'
                 max: 'Maximum number of entries'
+                add_choice: 'Add'
+                delete_choice: 'Delete'
             text:
                 min: 'Minimum length'
                 max: 'Maximum length'


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X
| License         | MIT

**Description**

So far it wasnt possible to translate the "Add" and "Delete" button when creating Product Attributes with the "Select" type.

<img width="1289" height="884" alt="image" src="https://github.com/user-attachments/assets/1e06ff47-4b88-4663-a7c1-61cca8c67464" />


