### PR TITLE
Fix/state provider throw exception on restricted resource

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/SectionResolver/UriBasedSectionProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/SectionResolver/UriBasedSectionProvider.php
@@ -44,6 +44,6 @@ final class UriBasedSectionProvider implements SectionProviderInterface
             }
         }
 
-        return null;
+        throw new SectionCannotBeResolvedException(sprintf('Section cannot be resolved for URI "%s".', $uri));
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/SectionResolver/UriBasedSectionProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/SectionResolver/UriBasedSectionProviderTest.php
@@ -88,4 +88,36 @@ final class UriBasedSectionProviderTest extends TestCase
         $this->requestStack->expects($this->once())->method('getMainRequest')->willReturn(null);
         $this->assertNull($this->uriBasedSectionProvider->getSection());
     }
+
+    public function testThrowsExceptionIfNoResolverCanHandleTheUri(): void
+    {
+        $request = $this->createMock(Request::class);
+
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getMainRequest')
+            ->willReturn($request);
+        $request
+            ->expects($this->once())
+            ->method('getPathInfo')
+            ->willReturn('/unknown-section');
+
+        $this->firstSectionResolver
+            ->expects($this->once())
+            ->method('getSection')
+            ->with('/unknown-section')
+            ->willThrowException(new SectionCannotBeResolvedException())
+        ;
+
+        $this->secondSectionResolver
+            ->expects($this->once())
+            ->method('getSection')
+            ->with('/unknown-section')
+            ->willThrowException(new SectionCannotBeResolvedException())
+        ;
+
+        $this->expectException(SectionCannotBeResolvedException::class);
+
+        $this->uriBasedSectionProvider->getSection();
+    }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

`UriBasedSectionProvider::getSection()` previously returned `null` when the current request URI could not be matched by any registered section resolver. This caused all Doctrine ORM query extensions that rely on the section to silently skip their filters.

A concrete example: extensions such as `Shop\Address\ShopUserBasedExtension`, `Shop\Order\ShopUserBasedExtension` or `Shop\Customer\ShopUserBasedExtension` guard their filter behind an `instanceof ShopApiSection` check. When `getSection()` returned `null`, the check evaluated to `false` and the shop-user scoping was never applied — potentially exposing other users' data.

This scenario can be triggered when a request is forwarded (e.g. via a controller sub-request) to a Shop API endpoint from a URI that does not belong to any known section (admin, shop, API shop, API admin). The main request URI is then unresolvable, `getSection()` returns `null`, and every security filter depending on the resolved section is bypassed.

## Changes

- **`UriBasedSectionProvider::getSection()`** now throws `SectionCannotBeResolvedException` (with the unresolvable URI in the message) when no registered resolver can handle the current request URI, instead of silently returning `null`. Returning `null` is still the correct behaviour when there is no main request at all (e.g. a CLI command context).
- **`UriBasedSectionProviderTest`** — added `testThrowsExceptionIfNoResolverCanHandleTheUri()` to cover the new fail-closed behaviour.

## Impact

**Fail closed by design.** Any request that reaches the API without a resolvable section now produces a hard failure instead of silently bypassing security filters. This makes misconfigured forwarding or unknown URI prefixes immediately visible rather than a hidden data-leak risk.

## Files changed

| File | Change |
|---|---|
| `src/Sylius/Bundle/CoreBundle/SectionResolver/UriBasedSectionProvider.php` | Throw `SectionCannotBeResolvedException` instead of returning `null` when no resolver matches |
| `src/Sylius/Bundle/CoreBundle/tests/SectionResolver/UriBasedSectionProviderTest.php` | Add test for the new exception behaviour |
