### PR TITLE
[API] Fix missing channel check on shop product GET item endpoint

### DIFF
--- a/src/Sylius/Behat/Client/ResponseCheckerInterface.php
+++ b/src/Sylius/Behat/Client/ResponseCheckerInterface.php
@@ -93,7 +93,7 @@ interface ResponseCheckerInterface
 
     public function hasViolationWithMessage(Response $response, string $message, ?string $property = null): bool;
 
-    public function appendError(Response $response): ResponseCheckerInterface;
+    public function appendError(Response $response): self;
 
     public function cleanErrors(): void;
 

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product;
 
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use Doctrine\ORM\QueryBuilder;
@@ -23,7 +24,7 @@ use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Webmozart\Assert\Assert;
 
-final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionExtensionInterface
+final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
     public function __construct(private SectionProviderInterface $sectionProvider)
     {
@@ -38,6 +39,33 @@ final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionEx
         string $resourceClass,
         ?Operation $operation = null,
         array $context = [],
+    ): void {
+        $this->applyConditions($queryBuilder, $queryNameGenerator, $resourceClass, $context);
+    }
+
+    /**
+     * @param array<array-key, mixed> $identifiers
+     * @param array<array-key, mixed> $context
+     */
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyConditions($queryBuilder, $queryNameGenerator, $resourceClass, $context);
+    }
+
+    /**
+     * @param array<array-key, mixed> $context
+     */
+    private function applyConditions(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $context,
     ): void {
         if (!is_a($resourceClass, ProductInterface::class, true)) {
             return;

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -56,6 +56,7 @@
         >
             <argument type="service" id="sylius.section_resolver.uri_based" />
             <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.item" />
         </service>
 
         <service

--- a/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtensionTest.php
@@ -167,4 +167,130 @@ final class ChannelAndLocaleBasedExtensionTest extends TestCase
             ],
         );
     }
+
+    public function test_it_does_not_apply_conditions_to_item_for_unsupported_resource(): void
+    {
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            \stdClass::class,
+            [],
+        );
+    }
+
+    public function test_it_does_not_apply_conditions_to_item_for_admin_api_section(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new AdminApiSection());
+
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            [],
+        );
+    }
+
+    public function test_it_throws_exception_if_item_context_has_no_channel(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            [],
+            new Get(),
+        );
+    }
+
+    public function test_it_throws_exception_if_item_context_has_no_locale(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            [],
+            new Get(),
+            [ContextKeys::CHANNEL => $channel],
+        );
+    }
+
+    public function test_it_filters_item_by_channel_and_locale(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->queryNameGenerator->expects(self::exactly(2))
+            ->method('generateParameterName')
+            ->with($this->callback(function ($param) {
+                return $param === 'channel' || $param === 'localeCode';
+            }))
+            ->willReturnCallback(function ($param) {
+                return $param;
+            });
+
+        $this->queryBuilder->method('getRootAliases')->willReturn(['o']);
+
+        $this->queryBuilder->expects(self::once())
+            ->method('addSelect')
+            ->with('translation')
+            ->willReturnSelf();
+
+        $this->queryBuilder->expects(self::once())
+            ->method('innerJoin')
+            ->with('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
+            ->willReturnSelf();
+
+        $this->queryBuilder->expects(self::once())
+            ->method('andWhere')
+            ->with(':channel MEMBER OF o.channels')
+            ->willReturnSelf();
+
+        $expectedParams = [
+            ['channel', $channel],
+            ['localeCode', 'en_US'],
+        ];
+        $callIndex = 0;
+        $this->queryBuilder->expects(self::exactly(2))
+            ->method('setParameter')
+            ->with(
+                $this->callback(function ($name) use (&$expectedParams, &$callIndex) {
+                    return $name === $expectedParams[$callIndex][0];
+                }),
+                $this->callback(function ($value) use (&$expectedParams, &$callIndex) {
+                    $result = $value === $expectedParams[$callIndex][1];
+                    ++$callIndex;
+
+                    return $result;
+                }),
+            )
+            ->willReturnSelf();
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            [],
+            new Get(),
+            [
+                ContextKeys::CHANNEL => $channel,
+                ContextKeys::LOCALE_CODE => 'en_US',
+            ],
+        );
+    }
 }

--- a/tests/Api/DataFixtures/ORM/product/product_not_in_channel.yaml
+++ b/tests/Api/DataFixtures/ORM/product/product_not_in_channel.yaml
@@ -1,0 +1,58 @@
+Sylius\Component\Core\Model\Channel:
+    channel_web:
+        code: 'WEB'
+        name: 'Web Channel'
+        hostname: 'localhost'
+        description: 'Lorem ipsum'
+        baseCurrency: '@currency_usd'
+        defaultLocale: '@locale_en'
+        locales: ['@locale_en']
+        color: 'black'
+        enabled: true
+        taxCalculationStrategy: 'order_items_based'
+    channel_mobile:
+        code: 'MOBILE'
+        name: 'Mobile Channel'
+        hostname: 'mobile.localhost'
+        description: 'Lorem ipsum'
+        baseCurrency: '@currency_usd'
+        defaultLocale: '@locale_en'
+        locales: ['@locale_en']
+        color: 'black'
+        enabled: true
+        taxCalculationStrategy: 'order_items_based'
+
+Sylius\Component\Currency\Model\Currency:
+    currency_usd:
+        code: 'USD'
+
+Sylius\Component\Locale\Model\Locale:
+    locale_en:
+        code: 'en_US'
+
+Sylius\Component\Core\Model\Product:
+    product_mug:
+        code: 'MUG'
+        enabled: true
+        channels: ['@channel_mobile']
+        currentLocale: 'en_US'
+
+Sylius\Component\Core\Model\ProductTranslation:
+    product_translation_mug_en_US:
+        locale: 'en_US'
+        translatable: '@product_mug'
+        slug: 'mug'
+        name: 'Mug'
+
+Sylius\Component\Core\Model\ProductVariant:
+    product_variant_mug:
+        code: 'MUG_DEFAULT'
+        product: '@product_mug'
+        currentLocale: 'en_US'
+        channelPricings:
+            MOBILE: '@channel_pricing_mug_mobile'
+
+Sylius\Component\Core\Model\ChannelPricing:
+    channel_pricing_mug_mobile:
+        channelCode: 'MOBILE'
+        price: 2000

--- a/tests/Api/JsonApiTestCase.php
+++ b/tests/Api/JsonApiTestCase.php
@@ -305,6 +305,7 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
         if (preg_match('/@\w+@\./', $value)) {
             return true;
         }
+
         return false;
     }
 

--- a/tests/Api/Shop/ProductsTest.php
+++ b/tests/Api/Shop/ProductsTest.php
@@ -169,6 +169,20 @@ final class ProductsTest extends JsonApiTestCase
     }
 
     #[Test]
+    public function it_returns_not_found_for_product_not_assigned_to_current_channel(): void
+    {
+        $this->loadFixturesFromFile('product/product_not_in_channel.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/products/MUG',
+            server: self::CONTENT_TYPE_HEADER,
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
     public function it_returns_associated_products_collection_by_association_type(): void
     {
         $this->loadFixturesFromFile('product/products_with_associations.yaml');


### PR DESCRIPTION
## Summary

  `GET /api/v2/shop/products/{code}` was returning products regardless of whether they belonged to the current channel, unlike `GET /api/v2/shop/products-by-slug/{slug}` which correctly returned 404.

  The fix extends `ChannelAndLocaleBasedExtension` with `QueryItemExtensionInterface` so the channel filter is applied to item queries as well as collection queries.
