### PR TITLE
[DX] Catalog price display

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -56,6 +56,36 @@
 
 2. The `knplabs/gaufrette` and `knplabs/knp-gaufrette-bundle` packages have been removed.
 
+## Deprecations
+
+1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.
+   Implement `Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface` instead, which extends `ProductVariantPricesCalculatorInterface` with no additional methods.
+   It will be required in Sylius 3.0.
+
+   Affected classes:
+   - `Sylius\Bundle\CoreBundle\Twig\PriceExtension`
+   - `Sylius\Bundle\ApiBundle\Serializer\Normalizer\ProductVariantNormalizer`
+   - `Sylius\Bundle\ShopBundle\Twig\Component\Product\PriceComponent`
+   - `Sylius\Bundle\ShopBundle\Twig\Component\Product\CardComponent`
+   - `Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantPriceMapProvider`
+   - `Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantOriginalPriceMapProvider`
+   - `Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantLowestPriceMapProvider`
+
+   If you have a custom calculator used for catalog display, make it implement `CatalogPricesCalculatorInterface`:
+
+   ```php
+   use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
+
+   final class MyCustomCatalogPriceCalculator implements CatalogPricesCalculatorInterface
+   {
+       // ...
+   }
+   ```
+
+   This allows you to decorate catalog display pricing independently from cart/order pricing
+   (`sylius.order_processing.order_prices_recalculator`, `sylius.filter.promotion.price_range`),
+   which remain on `ProductVariantPricesCalculatorInterface`.
+
    The Gaufrette integration has been unusable as a filesystem adapter.
    Since Sylius 2.0 the default filesystem adapter uses Flysystem instead. 
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -55,6 +55,11 @@
    The `StringInflector::nameToSlug()` method has been **deprecated** and will be removed in Sylius 3.0.
 
 2. The `knplabs/gaufrette` and `knplabs/knp-gaufrette-bundle` packages have been removed.
+   
+   The Gaufrette integration has been unusable as a filesystem adapter.
+   Since Sylius 2.0 the default filesystem adapter uses Flysystem instead. 
+
+   If your application depends on the Gaufrette packages directly, require them explicitly in your `composer.json`.
 
 ## Deprecations
 
@@ -85,8 +90,3 @@
    This allows you to decorate catalog display pricing independently from cart/order pricing
    (`sylius.order_processing.order_prices_recalculator`, `sylius.filter.promotion.price_range`),
    which remain on `ProductVariantPricesCalculatorInterface`.
-
-   The Gaufrette integration has been unusable as a filesystem adapter.
-   Since Sylius 2.0 the default filesystem adapter uses Flysystem instead. 
-
-   If your application depends on the Gaufrette packages directly, require them explicitly in your `composer.json`.

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.php
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.php
@@ -127,7 +127,7 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius_api.normalizer.product_variant', ProductVariantNormalizer::class)
         ->args([
-            service('sylius.calculator.product_variant_price'),
+            service('sylius.calculator.product_variant_catalog_price'),
             service('sylius.checker.inventory.availability'),
             service('sylius.section_resolver.uri_based'),
             service('api_platform.symfony.iri_converter'),

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductVariantNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductVariantNormalizer.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
 use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
 use Sylius\Bundle\ApiBundle\Serializer\SerializationGroupsSupportTrait;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
@@ -38,12 +39,21 @@ final class ProductVariantNormalizer implements NormalizerInterface, NormalizerA
     private const ALREADY_CALLED = 'sylius_product_variant_normalizer_already_called';
 
     public function __construct(
-        private readonly ProductVariantPricesCalculatorInterface $priceCalculator,
+        private readonly ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $priceCalculator,
         private readonly AvailabilityCheckerInterface $availabilityChecker,
         private readonly SectionProviderInterface $uriBasedSectionContext,
         private readonly IriConverterInterface $iriConverter,
         private readonly array $serializationGroups,
     ) {
+        if (!$this->priceCalculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $priceCalculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/ProductVariantNormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/ProductVariantNormalizerTest.php
@@ -23,7 +23,7 @@ use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
 use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
 use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ProductVariantNormalizer;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
-use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class ProductVariantNormalizerTest extends TestCase
 {
-    private MockObject&ProductVariantPricesCalculatorInterface $pricesCalculator;
+    private MockObject&CatalogPricesCalculatorInterface $pricesCalculator;
 
     private AvailabilityCheckerInterface&MockObject $availabilityChecker;
 
@@ -57,7 +57,7 @@ final class ProductVariantNormalizerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->pricesCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->pricesCalculator = $this->createMock(CatalogPricesCalculatorInterface::class);
         $this->availabilityChecker = $this->createMock(AvailabilityCheckerInterface::class);
         $this->sectionProvider = $this->createMock(SectionProviderInterface::class);
         $this->iriConverter = $this->createMock(IriConverterInterface::class);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.php
@@ -38,6 +38,7 @@ use Sylius\Bundle\CoreBundle\Security\UserPasswordResetter;
 use Sylius\Bundle\CoreBundle\ShippingMethod\Updater\ShippingMethodUpdater;
 use Sylius\Bundle\CoreBundle\Twig\CheckoutStepsExtension;
 use Sylius\Bundle\CoreBundle\Twig\ProductVariantsMapExtension;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPriceCalculator;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Cart\Modifier\LimitingOrderItemQuantityModifier;
@@ -307,6 +308,12 @@ return static function (ContainerConfigurator $container) {
         ->args([service('sylius.checker.product_variant_lowest_price_display')])
     ;
     $services->alias(ProductVariantPricesCalculatorInterface::class, 'sylius.calculator.product_variant_price');
+
+    $services
+        ->set('sylius.calculator.product_variant_catalog_price', ProductVariantPriceCalculator::class)
+        ->args([service('sylius.checker.product_variant_lowest_price_display')])
+    ;
+    $services->alias(CatalogPricesCalculatorInterface::class, 'sylius.calculator.product_variant_catalog_price');
 
     $services
         ->set('sylius.section_resolver.uri_based', UriBasedSectionProvider::class)

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/product_variant_map.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/product_variant_map.php
@@ -37,13 +37,13 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.provider.product_variant_map.price', ProductVariantPriceMapProvider::class)
-        ->args([service('sylius.calculator.product_variant_price')])
+        ->args([service('sylius.calculator.product_variant_catalog_price')])
         ->tag('sylius.product_variant_data_map_provider')
     ;
 
     $services
         ->set('sylius.provider.product_variant_map.original_price', ProductVariantOriginalPriceMapProvider::class)
-        ->args([service('sylius.calculator.product_variant_price')])
+        ->args([service('sylius.calculator.product_variant_catalog_price')])
         ->tag('sylius.product_variant_data_map_provider')
     ;
 
@@ -54,7 +54,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.provider.product_variant_map.lowest_price', ProductVariantLowestPriceMapProvider::class)
-        ->args([service('sylius.calculator.product_variant_price')])
+        ->args([service('sylius.calculator.product_variant_catalog_price')])
         ->tag('sylius.product_variant_data_map_provider')
     ;
 };

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.php
@@ -31,7 +31,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.twig.extension.price', PriceExtension::class)
-        ->args([service('sylius.calculator.product_variant_price')])
+        ->args([service('sylius.calculator.product_variant_catalog_price')])
         ->private()
         ->tag('twig.extension')
     ;

--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Twig;
 
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Twig\Extension\AbstractExtension;
@@ -21,8 +22,18 @@ use Webmozart\Assert\Assert;
 
 final class PriceExtension extends AbstractExtension
 {
-    public function __construct(private readonly ProductVariantPricesCalculatorInterface $productVariantPricesCalculator)
-    {
+    public function __construct(
+        private readonly ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $productVariantPricesCalculator,
+    ) {
+        if (!$this->productVariantPricesCalculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $productVariantPricesCalculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     public function getFilters(): array

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/product.php
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/product.php
@@ -60,7 +60,7 @@ return static function (ContainerConfigurator $container) {
             service('sylius.resolver.product_variant'),
             service('sylius.context.channel'),
             service('sylius.context.locale'),
-            service('sylius.calculator.product_variant_price'),
+            service('sylius.calculator.product_variant_catalog_price'),
         ])
         ->tag('sylius.twig_component', ['key' => 'sylius_shop:product:card'])
     ;
@@ -78,7 +78,7 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius_shop.twig.component.product.price', PriceComponent::class)
         ->args([
-            service('sylius.calculator.product_variant_price'),
+            service('sylius.calculator.product_variant_catalog_price'),
             service('sylius.formatter.money'),
             service('sylius.context.channel'),
             service('sylius.context.locale'),

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/CardComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/CardComponent.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ShopBundle\Twig\Component\Product;
 
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
@@ -48,8 +49,17 @@ class CardComponent
         protected readonly ProductVariantResolverInterface $productVariantResolver,
         protected readonly ChannelContextInterface $channelContext,
         protected readonly LocaleContextInterface $localeContext,
-        protected readonly ProductVariantPricesCalculatorInterface $productVariantPricesCalculator,
+        protected readonly ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $productVariantPricesCalculator,
     ) {
+        if (!$this->productVariantPricesCalculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $productVariantPricesCalculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     #[PostMount]

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/PriceComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/PriceComponent.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ShopBundle\Twig\Component\Product;
 
 use Sylius\Bundle\MoneyBundle\Formatter\MoneyFormatterInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -43,13 +44,22 @@ class PriceComponent
     public bool $hasDiscount = false;
 
     public function __construct(
-        protected readonly ProductVariantPricesCalculatorInterface $productVariantPricesCalculator,
+        protected readonly ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $productVariantPricesCalculator,
         protected readonly MoneyFormatterInterface $moneyFormatter,
         protected readonly ChannelContextInterface $channelContext,
         protected readonly LocaleContextInterface $localeContext,
         protected readonly CurrencyContextInterface $currencyContext,
         protected readonly CurrencyConverterInterface $currencyConverter,
     ) {
+        if (!$this->productVariantPricesCalculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $productVariantPricesCalculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     #[PostMount]

--- a/src/Sylius/Component/Core/Calculator/CatalogPricesCalculatorInterface.php
+++ b/src/Sylius/Component/Core/Calculator/CatalogPricesCalculatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Calculator;
+
+/**
+ * Calculates prices for catalog display purposes (product listings, detail pages, API responses).
+ *
+ * This is intentionally distinct from ProductVariantPricesCalculatorInterface used in cart/order
+ * processing, allowing independent customization of display pricing (e.g., B2B list prices,
+ * EU Omnibus Directive compliance, geo-pricing, OSS VAT destination-based rules).
+ *
+ * Decorate this interface to customize catalog display pricing without any risk of side effects
+ * on cart totals, order processing, or promotion engines.
+ */
+interface CatalogPricesCalculatorInterface extends ProductVariantPricesCalculatorInterface
+{
+}

--- a/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
+++ b/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
@@ -20,7 +20,7 @@ use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Webmozart\Assert\Assert;
 
-final class ProductVariantPriceCalculator implements ProductVariantPricesCalculatorInterface
+final class ProductVariantPriceCalculator implements CatalogPricesCalculatorInterface
 {
     public function __construct(
         private ProductVariantLowestPriceDisplayCheckerInterface $productVariantLowestPriceDisplayChecker,

--- a/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantLowestPriceMapProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantLowestPriceMapProvider.php
@@ -13,14 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Provider\ProductVariantMap;
 
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
 final readonly class ProductVariantLowestPriceMapProvider implements ProductVariantMapProviderInterface
 {
-    public function __construct(private ProductVariantPricesCalculatorInterface $calculator)
-    {
+    public function __construct(
+        private ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $calculator,
+    ) {
+        if (!$this->calculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $calculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     public function provide(ProductVariantInterface $variant, array $context): array

--- a/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantOriginalPriceMapProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantOriginalPriceMapProvider.php
@@ -13,14 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Provider\ProductVariantMap;
 
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
 final class ProductVariantOriginalPriceMapProvider implements ProductVariantMapProviderInterface
 {
-    public function __construct(private ProductVariantPricesCalculatorInterface $calculator)
-    {
+    public function __construct(
+        private ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $calculator,
+    ) {
+        if (!$this->calculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $calculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     public function provide(ProductVariantInterface $variant, array $context): array

--- a/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantPriceMapProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantPriceMapProvider.php
@@ -13,14 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Provider\ProductVariantMap;
 
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
 final class ProductVariantPriceMapProvider implements ProductVariantMapProviderInterface
 {
-    public function __construct(private ProductVariantPricesCalculatorInterface $calculator)
-    {
+    public function __construct(
+        private ProductVariantPricesCalculatorInterface|CatalogPricesCalculatorInterface $calculator,
+    ) {
+        if (!$this->calculator instanceof CatalogPricesCalculatorInterface) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.3',
+                'Passing an instance of "%s" as $calculator is deprecated. It will require "%s" since Sylius 3.0.',
+                ProductVariantPricesCalculatorInterface::class,
+                CatalogPricesCalculatorInterface::class,
+            );
+        }
     }
 
     public function provide(ProductVariantInterface $variant, array $context): array

--- a/src/Sylius/Component/Core/tests/Provider/ProductVariantMap/ProductVariantLowestPriceMapProviderTest.php
+++ b/src/Sylius/Component/Core/tests/Provider/ProductVariantMap/ProductVariantLowestPriceMapProviderTest.php
@@ -15,7 +15,7 @@ namespace Tests\Sylius\Component\Core\Provider\ProductVariantMap;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -30,13 +30,13 @@ final class ProductVariantLowestPriceMapProviderTest extends TestCase
 
     private ChannelPricingInterface&MockObject $channelPricing;
 
-    private MockObject&ProductVariantPricesCalculatorInterface $calculator;
+    private MockObject&CatalogPricesCalculatorInterface $calculator;
 
     private ProductVariantLowestPriceMapProvider $provider;
 
     protected function setUp(): void
     {
-        $this->calculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->calculator = $this->createMock(CatalogPricesCalculatorInterface::class);
         $this->variant = $this->createMock(ProductVariantInterface::class);
         $this->channel = $this->createMock(ChannelInterface::class);
         $this->channelPricing = $this->createMock(ChannelPricingInterface::class);

--- a/src/Sylius/Component/Core/tests/Provider/ProductVariantMap/ProductVariantOriginalPriceMapProviderTest.php
+++ b/src/Sylius/Component/Core/tests/Provider/ProductVariantMap/ProductVariantOriginalPriceMapProviderTest.php
@@ -15,7 +15,7 @@ namespace Tests\Sylius\Component\Core\Provider\ProductVariantMap;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -30,13 +30,13 @@ final class ProductVariantOriginalPriceMapProviderTest extends TestCase
 
     private ChannelPricingInterface&MockObject $channelPricing;
 
-    private MockObject&ProductVariantPricesCalculatorInterface $calculator;
+    private MockObject&CatalogPricesCalculatorInterface $calculator;
 
     private ProductVariantOriginalPriceMapProvider $provider;
 
     protected function setUp(): void
     {
-        $this->calculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->calculator = $this->createMock(CatalogPricesCalculatorInterface::class);
         $this->variant = $this->createMock(ProductVariantInterface::class);
         $this->channel = $this->createMock(ChannelInterface::class);
         $this->channelPricing = $this->createMock(ChannelPricingInterface::class);

--- a/src/Sylius/Component/Core/tests/Provider/ProductVariantMap/ProductVariantPriceMapProviderTest.php
+++ b/src/Sylius/Component/Core/tests/Provider/ProductVariantMap/ProductVariantPriceMapProviderTest.php
@@ -15,7 +15,7 @@ namespace Tests\Sylius\Component\Core\Provider\ProductVariantMap;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -30,13 +30,13 @@ final class ProductVariantPriceMapProviderTest extends TestCase
 
     private ChannelPricingInterface&MockObject $channelPricing;
 
-    private MockObject&ProductVariantPricesCalculatorInterface $calculator;
+    private MockObject&CatalogPricesCalculatorInterface $calculator;
 
     private ProductVariantPriceMapProvider $provider;
 
     protected function setUp(): void
     {
-        $this->calculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->calculator = $this->createMock(CatalogPricesCalculatorInterface::class);
         $this->variant = $this->createMock(ProductVariantInterface::class);
         $this->channel = $this->createMock(ChannelInterface::class);
         $this->channelPricing = $this->createMock(ChannelPricingInterface::class);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | mentioned in #18142
| License         | MIT

## Summary

This PR implements **Alternative A** proposed in #18142 — a dedicated `CatalogPricesCalculatorInterface` to semantically separate catalog display pricing from cart/order pricing.

The original PR introduced a plain service alias without any PHP-level distinction. After review feedback from @diimpp, the approach was refined: instead of an invisible alias, we introduce a **real PHP contract** that communicates intent and enables clean decoration via Symfony's DI.

## Problem

Sylius currently uses a single `sylius.calculator.product_variant_price` for both catalog display and cart/order processing. Decorating it to customize catalog display (e.g. B2B list prices, EU OSS VAT, Omnibus compliance) inevitably affects cart totals, order recalculation, and the promotion engine — a tight coupling that every other major PHP e-commerce framework (Magento, Shopware, PrestaShop, WooCommerce) has already solved.

## Solution

### New interface

```php
namespace Sylius\Component\Core\Calculator;

/**
 * Calculates prices for catalog display purposes (product listings, detail pages, API responses).
 *
 * This is intentionally distinct from ProductVariantPricesCalculatorInterface used in cart/order
 * processing, allowing independent customization of display pricing (e.g., B2B list prices,
 * EU Omnibus Directive compliance, geo-pricing, OSS VAT destination-based rules).
 *
 * Decorate this interface to customize catalog display pricing without any risk of side effects
 * on cart totals, order processing, or promotion engines.
 */
interface CatalogPricesCalculatorInterface extends ProductVariantPricesCalculatorInterface
{
}
```

`ProductVariantPriceCalculator` implements both interfaces — **zero functional change** for existing installations.

### Catalog-facing consumers updated

| Service / Class | Context |
|---|---|
| `sylius.twig.extension.price` / `PriceExtension` | Twig price filters |
| `sylius_api.normalizer.product_variant` / `ProductVariantNormalizer` | API serialization |
| `sylius_shop.twig.component.product.price` / `PriceComponent` | Shop price component |
| `sylius_shop.twig.component.product.card` / `CardComponent` | Shop product card |
| `sylius.provider.product_variant_map.price` / `ProductVariantPriceMapProvider` | JS variant switching |
| `sylius.provider.product_variant_map.original_price` / `ProductVariantOriginalPriceMapProvider` | JS variant switching |
| `sylius.provider.product_variant_map.lowest_price` / `ProductVariantLowestPriceMapProvider` | JS variant switching |

### Cart/order consumers intentionally unchanged

| Service | Context |
|---|---|
| `sylius.order_processing.order_prices_recalculator` | Cart/order processing |
| `sylius.filter.promotion.price_range` | Promotion engine |

## Result

Developers can now decorate **only catalog display pricing** without touching cart totals:

```php
$services
    ->decorator(CatalogPricesCalculatorInterface::class)
    ->class(MyB2BCatalogPriceCalculator::class)
;
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Passing the legacy product-variant pricing calculator into catalog-facing classes now emits deprecation warnings; implementors should migrate to the new catalog-focused calculator interface (required in Sylius 3.0).

* **Refactor**
  * Introduced a catalog-focused price calculator interface and adapted core components to accept it.

* **Chores**
  * Core service wiring updated to use the new catalog calculator for catalog/listing/price components.

* **Documentation**
  * Added upgrade guide section with migration instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->