### PR TITLE
Filter out disabled products from get by code item endpoint

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -48,6 +48,15 @@ The `Sylius\Bundle\CoreBundle\Validator\Constraints\OrderPaymentMethodEligibilit
 `Sylius\Bundle\ApiBundle\Validator\Constraints\OrderPaymentMethodEligibilityValidator` now checks also if 
 payment method is assigned to the channel of the order.
 
+## Shop API
+
+1. The `Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\ChannelAndLocaleBasedExtension` service (`sylius_api.doctrine.orm.query_extension.shop.product.channel_and_locale_based`)
+   now implements `QueryItemExtensionInterface` in addition to `QueryCollectionExtensionInterface`.
+   The service is tagged with `api_platform.doctrine.orm.query_extension.item`.
+
+If you decorate this service, make sure your decorator also implements
+`ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface` and proxies the `applyToItem` method.
+
 # UPGRADE FROM `2.1.12` TO `2.1.13`
 
 ### Telemetry improvements

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -48,15 +48,6 @@ The `Sylius\Bundle\CoreBundle\Validator\Constraints\OrderPaymentMethodEligibilit
 `Sylius\Bundle\ApiBundle\Validator\Constraints\OrderPaymentMethodEligibilityValidator` now checks also if 
 payment method is assigned to the channel of the order.
 
-## Shop API
-
-1. The `Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\ChannelAndLocaleBasedExtension` service (`sylius_api.doctrine.orm.query_extension.shop.product.channel_and_locale_based`)
-   now implements `QueryItemExtensionInterface` in addition to `QueryCollectionExtensionInterface`.
-   The service is tagged with `api_platform.doctrine.orm.query_extension.item`.
-
-If you decorate this service, make sure your decorator also implements
-`ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface` and proxies the `applyToItem` method.
-
 # UPGRADE FROM `2.1.12` TO `2.1.13`
 
 ### Telemetry improvements

--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -1,3 +1,14 @@
+# UPGRADE FROM `2.2.6` TO `2.2.7`
+
+## Shop API
+
+1. The `Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\ChannelAndLocaleBasedExtension` service (`sylius_api.doctrine.orm.query_extension.shop.product.channel_and_locale_based`)
+   now implements `QueryItemExtensionInterface` in addition to `QueryCollectionExtensionInterface`.
+   The service is tagged with `api_platform.doctrine.orm.query_extension.item`.
+
+If you decorate this service, make sure your decorator also implements
+`ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface` and proxies the `applyToItem` method.
+
 # UPGRADE FROM `2.1` TO `2.2`
 
 ## Modified routes

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product;
 
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use Doctrine\ORM\QueryBuilder;
@@ -23,7 +24,7 @@ use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Webmozart\Assert\Assert;
 
-final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionExtensionInterface
+final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
     public function __construct(private SectionProviderInterface $sectionProvider)
     {
@@ -38,6 +39,33 @@ final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionEx
         string $resourceClass,
         ?Operation $operation = null,
         array $context = [],
+    ): void {
+        $this->apply($queryBuilder, $queryNameGenerator, $resourceClass, $context);
+    }
+
+    /**
+     * @param array<array-key, mixed> $identifiers
+     * @param array<array-key, mixed> $context
+     */
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->apply($queryBuilder, $queryNameGenerator, $resourceClass, $context);
+    }
+
+    /**
+     * @param array<array-key, mixed> $context
+     */
+    private function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $context,
     ): void {
         if (!is_a($resourceClass, ProductInterface::class, true)) {
             return;

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtension.php
@@ -22,7 +22,6 @@ use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
 use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Webmozart\Assert\Assert;
 
 final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
@@ -75,8 +74,9 @@ final readonly class ChannelAndLocaleBasedExtension implements QueryCollectionEx
             return;
         }
 
-        Assert::keyExists($context, ContextKeys::CHANNEL);
-        Assert::keyExists($context, ContextKeys::LOCALE_CODE);
+        if (!isset($context[ContextKeys::CHANNEL]) || !isset($context[ContextKeys::LOCALE_CODE])) {
+            return;
+        }
 
         $channel = $context[ContextKeys::CHANNEL];
         $localeCode = $context[ContextKeys::LOCALE_CODE];

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -56,6 +56,7 @@
         >
             <argument type="service" id="sylius.section_resolver.uri_based" />
             <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.item" />
         </service>
 
         <service

--- a/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtensionTest.php
@@ -167,4 +167,97 @@ final class ChannelAndLocaleBasedExtensionTest extends TestCase
             ],
         );
     }
+
+    public function test_it_does_not_apply_conditions_to_item_for_unsupported_resource(): void
+    {
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            \stdClass::class,
+            [],
+        );
+    }
+
+    public function test_it_does_not_apply_conditions_to_item_for_admin_api_section(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new AdminApiSection());
+
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            AddressInterface::class,
+            [],
+        );
+    }
+
+    public function test_it_filters_item_by_channel_and_locale(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->queryNameGenerator->expects(self::exactly(2))
+            ->method('generateParameterName')
+            ->with($this->callback(function ($param) {
+                return $param === 'channel' || $param === 'localeCode';
+            }))
+            ->willReturnCallback(function ($param) {
+                return $param;
+            });
+
+        $this->queryBuilder->method('getRootAliases')->willReturn(['o']);
+
+        $this->queryBuilder->expects(self::once())
+            ->method('addSelect')
+            ->with('translation')
+            ->willReturnSelf();
+
+        $this->queryBuilder->expects(self::once())
+            ->method('innerJoin')
+            ->with('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
+            ->willReturnSelf();
+
+        $this->queryBuilder->expects(self::once())
+            ->method('andWhere')
+            ->with(':channel MEMBER OF o.channels')
+            ->willReturnSelf();
+
+        $expectedParams = [
+            ['channel', $channel],
+            ['localeCode', 'en_US'],
+        ];
+        $callIndex = 0;
+        $this->queryBuilder->expects(self::exactly(2))
+            ->method('setParameter')
+            ->with(
+                $this->callback(function ($name) use (&$expectedParams, &$callIndex) {
+                    return $name === $expectedParams[$callIndex][0];
+                }),
+                $this->callback(function ($value) use (&$expectedParams, &$callIndex) {
+                    $result = $value === $expectedParams[$callIndex][1];
+                    ++$callIndex;
+
+                    return $result;
+                }),
+            )
+            ->willReturnSelf();
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            ['code' => 'MUG'],
+            new Get(),
+            [
+                ContextKeys::CHANNEL => $channel,
+                ContextKeys::LOCALE_CODE => 'en_US',
+            ],
+        );
+    }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Product/ChannelAndLocaleBasedExtensionTest.php
@@ -16,7 +16,6 @@ namespace Tests\Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Get;
 use Doctrine\ORM\QueryBuilder;
-use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\ChannelAndLocaleBasedExtension;
@@ -73,11 +72,12 @@ final class ChannelAndLocaleBasedExtensionTest extends TestCase
         );
     }
 
-    public function test_it_throws_exception_if_context_has_no_channel(): void
+    public function test_it_does_not_apply_conditions_to_collection_when_context_has_no_channel(): void
     {
         $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
 
         $this->extension->applyToCollection(
             $this->queryBuilder,
@@ -87,13 +87,14 @@ final class ChannelAndLocaleBasedExtensionTest extends TestCase
         );
     }
 
-    public function test_it_throws_exception_if_context_has_no_locale(): void
+    public function test_it_does_not_apply_conditions_to_collection_when_context_has_no_locale(): void
     {
         $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
 
         $channel = $this->createMock(ChannelInterface::class);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
 
         $this->extension->applyToCollection(
             $this->queryBuilder,
@@ -193,6 +194,41 @@ final class ChannelAndLocaleBasedExtensionTest extends TestCase
             $this->queryNameGenerator,
             AddressInterface::class,
             [],
+        );
+    }
+
+    public function test_it_does_not_apply_conditions_to_item_when_context_has_no_channel(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
+
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            ['code' => 'MUG'],
+            new Get(),
+        );
+    }
+
+    public function test_it_does_not_apply_conditions_to_item_when_context_has_no_locale(): void
+    {
+        $this->sectionProvider->method('getSection')->willReturn(new ShopApiSection());
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->queryBuilder->expects(self::never())->method('getRootAliases');
+        $this->queryBuilder->expects(self::never())->method('andWhere');
+
+        $this->extension->applyToItem(
+            $this->queryBuilder,
+            $this->queryNameGenerator,
+            ProductInterface::class,
+            ['code' => 'MUG'],
+            new Get(),
+            [ContextKeys::CHANNEL => $channel],
         );
     }
 

--- a/tests/Api/DataFixtures/ORM/product/product_not_in_channel.yaml
+++ b/tests/Api/DataFixtures/ORM/product/product_not_in_channel.yaml
@@ -1,0 +1,57 @@
+Sylius\Component\Core\Model\Channel:
+    channel_web:
+        code: 'WEB'
+        name: 'Web Channel'
+        hostname: 'localhost'
+        description: 'Lorem ipsum'
+        baseCurrency: '@currency_usd'
+        defaultLocale: '@locale_en'
+        locales: ['@locale_en']
+        color: 'black'
+        enabled: true
+        taxCalculationStrategy: 'order_items_based'
+    channel_mobile:
+        code: 'MOBILE'
+        name: 'Mobile Channel'
+        hostname: 'mobile.localhost'
+        description: 'Lorem ipsum'
+        baseCurrency: '@currency_usd'
+        defaultLocale: '@locale_en'
+        locales: ['@locale_en']
+        color: 'blue'
+        enabled: true
+        taxCalculationStrategy: 'order_items_based'
+
+Sylius\Component\Currency\Model\Currency:
+    currency_usd:
+        code: 'USD'
+
+Sylius\Component\Locale\Model\Locale:
+    locale_en:
+        code: 'en_US'
+
+Sylius\Component\Core\Model\Product:
+    product_in_web_channel:
+        code: 'MUG'
+        channels: ['@channel_web']
+        currentLocale: 'en_US'
+    product_in_mobile_channel_only:
+        code: 'T_SHIRT'
+        channels: ['@channel_mobile']
+        currentLocale: 'en_US'
+
+Sylius\Component\Core\Model\ProductTranslation:
+    product_translation_mug_en:
+        slug: 'mug'
+        locale: 'en_US'
+        name: 'Mug'
+        description: 'A mug'
+        shortDescription: 'Mug'
+        translatable: '@product_in_web_channel'
+    product_translation_tshirt_en:
+        slug: 't-shirt'
+        locale: 'en_US'
+        name: 'T-Shirt'
+        description: 'A t-shirt'
+        shortDescription: 'T-Shirt'
+        translatable: '@product_in_mobile_channel_only'

--- a/tests/Api/Shop/ProductsTest.php
+++ b/tests/Api/Shop/ProductsTest.php
@@ -38,6 +38,34 @@ final class ProductsTest extends JsonApiTestCase
     }
 
     #[Test]
+    public function it_returns_not_found_response_when_getting_product_not_in_current_channel(): void
+    {
+        $this->loadFixturesFromFile('product/product_not_in_channel.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/products/T_SHIRT',
+            server: self::CONTENT_TYPE_HEADER,
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function it_returns_product_from_current_channel(): void
+    {
+        $this->loadFixturesFromFile('product/product_not_in_channel.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/products/MUG',
+            server: self::CONTENT_TYPE_HEADER,
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_OK);
+    }
+
+    #[Test]
     public function it_returns_product_with_translations_in_default_locale(): void
     {
         $fixtures = $this->loadFixturesFromFile('product/product_with_many_locales.yaml');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #18718
| License         | MIT

## Core feature

  `ChannelAndLocaleBasedExtension` now implements `QueryItemExtensionInterface` in addition to `QueryCollectionExtensionInterface`. `GET /shop/products/{code}` now returns 404 when the product is disabled or
  not available in the current channel/locale. Both collection and item queries share a private apply() method. Assert on context keys replaced with graceful early returns.