### PR TITLE
[2.1][API] Enforce channel eligibility check when changing payment method via account endpoint

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Changer/PaymentMethodChanger.php
+++ b/src/Sylius/Bundle/ApiBundle/Changer/PaymentMethodChanger.php
@@ -27,7 +27,7 @@ final readonly class PaymentMethodChanger implements PaymentMethodChangerInterfa
     public function __construct(
         private PaymentRepositoryInterface $paymentRepository,
         private PaymentMethodRepositoryInterface $paymentMethodRepository,
-        private PaymentMethodsResolverInterface $paymentMethodsResolver,
+        private ?PaymentMethodsResolverInterface $paymentMethodsResolver = null,
     ) {
     }
 
@@ -45,7 +45,10 @@ final readonly class PaymentMethodChanger implements PaymentMethodChangerInterfa
         $payment = $this->paymentRepository->findOneByOrderId($paymentId, $order->getId());
         Assert::notNull($payment, 'Can not find payment with given identifier.');
 
-        if (!in_array($paymentMethod, $this->paymentMethodsResolver->getSupportedMethods($payment), true)) {
+        if (
+            $this->paymentMethodsResolver !== null &&
+            !in_array($paymentMethod, $this->paymentMethodsResolver->getSupportedMethods($payment), true)
+        ) {
             throw new PaymentMethodCannotBeChangedException();
         }
 

--- a/src/Sylius/Bundle/ApiBundle/Changer/PaymentMethodChanger.php
+++ b/src/Sylius/Bundle/ApiBundle/Changer/PaymentMethodChanger.php
@@ -19,6 +19,7 @@ use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Core\Repository\PaymentRepositoryInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
 use Webmozart\Assert\Assert;
 
 final readonly class PaymentMethodChanger implements PaymentMethodChangerInterface
@@ -26,6 +27,7 @@ final readonly class PaymentMethodChanger implements PaymentMethodChangerInterfa
     public function __construct(
         private PaymentRepositoryInterface $paymentRepository,
         private PaymentMethodRepositoryInterface $paymentMethodRepository,
+        private PaymentMethodsResolverInterface $paymentMethodsResolver,
     ) {
     }
 
@@ -42,6 +44,10 @@ final readonly class PaymentMethodChanger implements PaymentMethodChangerInterfa
 
         $payment = $this->paymentRepository->findOneByOrderId($paymentId, $order->getId());
         Assert::notNull($payment, 'Can not find payment with given identifier.');
+
+        if (!in_array($paymentMethod, $this->paymentMethodsResolver->getSupportedMethods($payment), true)) {
+            throw new PaymentMethodCannotBeChangedException();
+        }
 
         if ($order->getState() === OrderInterface::STATE_NEW) {
             Assert::same(

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -32,6 +32,7 @@
         <service id="sylius_api.changer.payment_method" class="Sylius\Bundle\ApiBundle\Changer\PaymentMethodChanger">
             <argument type="service" id="sylius.repository.payment" />
             <argument type="service" id="sylius.repository.payment_method" />
+            <argument type="service" id="sylius.resolver.payment_methods" />
         </service>
         <service id="Sylius\Bundle\ApiBundle\Changer\PaymentMethodChangerInterface" alias="sylius_api.changer.payment_method" />
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/validation/ChangePaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/validation/ChangePaymentMethod.xml
@@ -21,5 +21,10 @@
                 <value>sylius</value>
             </option>
         </constraint>
+        <constraint name="Sylius\Bundle\ApiBundle\Validator\Constraints\ChosenPaymentMethodEligibility">
+            <option name="groups">
+                <value>sylius</value>
+            </option>
+        </constraint>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibilityValidator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod;
 use Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
@@ -38,7 +39,7 @@ final class ChosenPaymentMethodEligibilityValidator extends ConstraintValidator
 
     public function validate(mixed $value, Constraint $constraint): void
     {
-        Assert::isInstanceOf($value, ChoosePaymentMethod::class);
+        Assert::isInstanceOfAny($value, [ChoosePaymentMethod::class, ChangePaymentMethod::class]);
 
         /** @var ChosenPaymentMethodEligibility $constraint */
         Assert::isInstanceOf($constraint, ChosenPaymentMethodEligibility::class);

--- a/src/Sylius/Bundle/ApiBundle/tests/Changer/PaymentMethodChangerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Changer/PaymentMethodChangerTest.php
@@ -22,12 +22,15 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Core\Repository\PaymentRepositoryInterface;
+use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
 
 final class PaymentMethodChangerTest extends TestCase
 {
     private MockObject&PaymentRepositoryInterface $paymentRepository;
 
     private MockObject&PaymentMethodRepositoryInterface $paymentMethodRepository;
+
+    private MockObject&PaymentMethodsResolverInterface $paymentMethodsResolver;
 
     private PaymentMethodChanger $paymentMethodChanger;
 
@@ -42,9 +45,11 @@ final class PaymentMethodChangerTest extends TestCase
         parent::setUp();
         $this->paymentRepository = $this->createMock(PaymentRepositoryInterface::class);
         $this->paymentMethodRepository = $this->createMock(PaymentMethodRepositoryInterface::class);
+        $this->paymentMethodsResolver = $this->createMock(PaymentMethodsResolverInterface::class);
         $this->paymentMethodChanger = new PaymentMethodChanger(
             $this->paymentRepository,
             $this->paymentMethodRepository,
+            $this->paymentMethodsResolver,
         );
         $this->order = $this->createMock(OrderInterface::class);
         $this->paymentMethod = $this->createMock(PaymentMethodInterface::class);
@@ -69,6 +74,12 @@ final class PaymentMethodChangerTest extends TestCase
             ->method('findOneByOrderId')
             ->with('123', '444')
             ->willReturn($this->payment);
+
+        $this->paymentMethodsResolver
+            ->expects(self::once())
+            ->method('getSupportedMethods')
+            ->with($this->payment)
+            ->willReturn([$this->paymentMethod]);
 
         $this->order
             ->expects(self::once())
@@ -146,6 +157,12 @@ final class PaymentMethodChangerTest extends TestCase
             ->method('findOneByOrderId')
             ->with('123', '444')
             ->willReturn($this->payment);
+
+        $this->paymentMethodsResolver
+            ->expects(self::once())
+            ->method('getSupportedMethods')
+            ->with($this->payment)
+            ->willReturn([$this->paymentMethod]);
 
         $this->order->expects(self::once())->method('getState')->willReturn(OrderInterface::STATE_NEW);
 

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentMethodEligibilityValidatorTest.php
@@ -15,6 +15,7 @@ namespace Tests\Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod;
 use Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\ChosenPaymentMethodEligibility;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\ChosenPaymentMethodEligibilityValidator;
@@ -95,6 +96,28 @@ final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
         $firstPaymentMethodMock->expects(self::once())->method('getName')->willReturn('offline');
         $this->paymentRepository->expects(self::once())->method('find')->with('123')->willReturn($paymentMock);
         $this->paymentMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($paymentMock)->willReturn([$secondPaymentMethodMock, $thirdPaymentMethodMock]);
+        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.payment_method.not_available', ['%name%' => 'offline'])
+        ;
+        $this->chosenPaymentMethodEligibilityValidator->validate($command, new ChosenPaymentMethodEligibility());
+    }
+
+    public function testAddsViolationIfChangePaymentMethodDoesNotMatchSupportedMethods(): void
+    {
+        /** @var PaymentMethodInterface|MockObject $outOfChannelPaymentMethodMock */
+        $outOfChannelPaymentMethodMock = $this->createMock(PaymentMethodInterface::class);
+        /** @var PaymentMethodInterface|MockObject $supportedPaymentMethodMock */
+        $supportedPaymentMethodMock = $this->createMock(PaymentMethodInterface::class);
+        /** @var PaymentInterface|MockObject $paymentMock */
+        $paymentMock = $this->createMock(PaymentInterface::class);
+        $command = new ChangePaymentMethod(
+            orderTokenValue: 'ORDER_TOKEN',
+            paymentId: 123,
+            paymentMethodCode: 'PAYMENT_METHOD_CODE',
+        );
+        $this->paymentMethodRepository->expects(self::once())->method('findOneBy')->with(['code' => 'PAYMENT_METHOD_CODE'])->willReturn($outOfChannelPaymentMethodMock);
+        $outOfChannelPaymentMethodMock->expects(self::once())->method('getName')->willReturn('offline');
+        $this->paymentRepository->expects(self::once())->method('find')->with('123')->willReturn($paymentMock);
+        $this->paymentMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($paymentMock)->willReturn([$supportedPaymentMethodMock]);
         $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.payment_method.not_available', ['%name%' => 'offline'])
         ;
         $this->chosenPaymentMethodEligibilityValidator->validate($command, new ChosenPaymentMethodEligibility());

--- a/tests/Api/DataFixtures/ORM/payment_method/out_of_channel_payment_method.yaml
+++ b/tests/Api/DataFixtures/ORM/payment_method/out_of_channel_payment_method.yaml
@@ -1,0 +1,16 @@
+Sylius\Component\Payment\Model\PaymentMethodTranslation:
+    payment_method_not_in_channel_translation:
+        name: 'Out of channel'
+        locale: 'en_US'
+        description: '<paragraph(2)>'
+        translatable: '@payment_method_not_in_channel'
+
+Sylius\Component\Core\Model\PaymentMethod:
+    payment_method_not_in_channel:
+        code: 'PAYMENT_METHOD_NOT_IN_CHANNEL'
+        enabled: true
+        gatewayConfig: '@gateway_offline'
+        currentLocale: 'en_US'
+        translations:
+            - '@payment_method_not_in_channel_translation'
+        channels: ['@channel_mobile']

--- a/tests/Api/Shop/Checkout/PaymentMethodTest.php
+++ b/tests/Api/Shop/Checkout/PaymentMethodTest.php
@@ -292,4 +292,40 @@ final class PaymentMethodTest extends JsonApiTestCase
             ],
         );
     }
+
+    #[Test]
+    public function it_does_not_allow_to_choose_payment_method_that_is_not_assigned_to_channel(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles([
+            'channel/channel.yaml',
+            'cart.yaml',
+            'country.yaml',
+            'shipping_method.yaml',
+            'payment_method.yaml',
+            'payment_method/out_of_channel_payment_method.yaml',
+        ]);
+
+        /** @var PaymentMethodInterface $outOfChannelPaymentMethod */
+        $outOfChannelPaymentMethod = $fixtures['payment_method_not_in_channel'];
+
+        $tokenValue = $this->pickUpCart();
+        $this->addItemToCart('MUG_BLUE', 3, $tokenValue);
+        $cart = $this->updateCartWithAddress($tokenValue);
+        $cart = $this->dispatchShippingMethodChooseCommand($tokenValue, 'DHL', $cart->getShipments()->first()->getId());
+
+        $this->client->request(
+            method: 'PATCH',
+            uri: sprintf('/api/v2/shop/orders/%s/payments/%s', $tokenValue, $cart->getLastPayment()->getId()),
+            server: $this->headerBuilder()->withMergePatchJsonContentType()->withJsonLdAccept()->build(),
+            content: json_encode([
+                'paymentMethod' => $outOfChannelPaymentMethod->getCode(),
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponseViolations(
+            [
+                ['propertyPath' => '', 'message' => 'The payment method Out of channel is not available for this order. Please choose another one.'],
+            ],
+        );
+    }
 }

--- a/tests/Api/Shop/OrdersTest.php
+++ b/tests/Api/Shop/OrdersTest.php
@@ -468,6 +468,40 @@ final class OrdersTest extends JsonApiTestCase
     }
 
     #[Test]
+    public function it_does_not_allow_to_change_payment_method_to_one_not_assigned_to_channel(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles([
+            'authentication/shop_user.yaml',
+            'channel/channel.yaml',
+            'cart.yaml',
+            'country.yaml',
+            'customer.yaml',
+            'shipping_method.yaml',
+            'payment_method.yaml',
+            'payment_method/out_of_channel_payment_method.yaml',
+        ]);
+
+        /** @var PaymentMethodInterface $outOfChannelPaymentMethod */
+        $outOfChannelPaymentMethod = $fixtures['payment_method_not_in_channel'];
+        $order = $this->placeOrder('token', 'oliver@doe.com');
+
+        $this->client->request(
+            method: 'PATCH',
+            uri: sprintf('/api/v2/shop/account/orders/token/payments/%s', $order->getPayments()->first()->getId()),
+            server: $this->headerBuilder()->withMergePatchJsonContentType()->withJsonLdAccept()->withShopUserAuthorization('oliver@doe.com')->build(),
+            content: json_encode([
+                'paymentMethod' => $outOfChannelPaymentMethod->getCode(),
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponseViolations(
+            [
+                ['propertyPath' => '', 'message' => 'The payment method Out of channel is not available for this order. Please choose another one.'],
+            ],
+        );
+    }
+
+    #[Test]
     public function it_gets_payment_configuration_of_order_created_by_a_user_authenticated_as_a_user(): void
     {
         $this->setCompositePaymentConfigurationProvider();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
