### PR TITLE
Fix German Swiss translation for no_label' 

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_CH.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_CH.yml
@@ -591,7 +591,7 @@ sylius:
         no_default_billing_address: 'Keine Standard-Rechnungsadresse'
         no_default_shipping_address: 'Keine Standard-Versandadresse'
         no_description: 'Keine Beschreibung'
-        no_label: 'Kein Label'
+        no_label: 'Nein'
         no_new_notifications: 'Keine neuen Benachrichtigungen'
         no_payment_methods_available: 'Derzeit keine Zahlungsmethoden für Ihre Bestellung verfügbar'
         no_payments: "Bestellung ohne Zahlungen"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | _none_
| License         | MIT

fix wrong translation

in this context "Kein Label" make no sense ;-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the German (Swiss) UI translation for “sylius.ui.no_label” to improve clarity in the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->