### PR TITLE
[Fix] Product Summary using wrong variant resolver

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/product.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/product.xml
@@ -102,7 +102,7 @@
             id="sylius_shop.twig.component.product.summary"
             class="Sylius\Bundle\ShopBundle\Twig\Component\Product\SummaryComponent"
         >
-            <argument type="service" id="sylius.resolver.product_variant.default" />
+            <argument type="service" id="sylius.resolver.product_variant" />
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="sylius.repository.product_variant" />
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I encountered an issue where I'm using my own specific `sylius.resolver.product_variant`, I discovered that the component Product Summary was using the default resolver instead of the composite one.

The PR is aiming to fix this.
