### PR TITLE
[Bugfix] Recover order payment_state to "awaiting_payment" after authorized payment is cancelled

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -22,6 +22,44 @@
    or `sylius.live_component.*` tag did not receive the `twig.component` tag.
    The priority has been lowered to `50` to ensure Symfony's autoconfiguration runs first.
 
+## Order payment state recovery after authorized payment cancellation
+
+When an authorized `Payment` transitions to `cancelled` (e.g. the merchant voids the authorization
+via the payment gateway), the `Order.paymentState` now automatically recovers from `authorized` to
+`awaiting_payment`, allowing the customer to retry payment.
+
+Previously the order was left in an inconsistent state — `payment_state = authorized` even though
+the authorization no longer existed — and the customer could not retry.
+
+### Impact on custom code
+
+**Symfony Workflow** — the `sylius_order_payment` workflow gains two new source states for the
+`request_payment` transition:
+
+```yaml
+# Before
+request_payment:
+    from: [cart]
+    to: awaiting_payment
+
+# After
+request_payment:
+    from: [cart, authorized, partially_authorized]
+    to: awaiting_payment
+```
+
+If you override this transition in your application config, add `authorized` and
+`partially_authorized` to the `from` list.
+
+**winzou_state_machine** — the same change applies to
+`config/app/winzou_state_machine/sylius_order_payment.yml`.
+
+**Custom `OrderPaymentStateResolver`** — if you have overridden `getTargetTransition()`, add
+handling for the recovery case: when only `cart` or `new` payments exist on the order (all previous
+payments are cancelled/failed), return `OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT`.
+
+---
+
 # UPGRADE FROM `2.1` TO `2.2`
 
 ## Telemetry

--- a/features/admin/order/managing_orders/handling_order_payment/recovering_order_after_cancelled_authorized_payment.feature
+++ b/features/admin/order/managing_orders/handling_order_payment/recovering_order_after_cancelled_authorized_payment.feature
@@ -10,10 +10,10 @@ Feature: Recovering order payment state after an authorized payment is cancelled
         And the store has a product "PHP T-Shirt"
         And the store allows paying with "Cash on Delivery"
         And the payment method "Cash on Delivery" requires authorization before capturing
-        And there is an "authorized" "#00000001" order with "PHP T-Shirt" product
+        And there is a "authorized" "#00000001" order with "PHP T-Shirt" product
         And I am logged in as an administrator
 
-    @api @ui
+    @api
     Scenario: Order payment state recovers to awaiting payment after the authorized payment is cancelled by the gateway
         When the payment of order "#00000001" is cancelled by the gateway
         Then this order should have order payment state "Awaiting payment"

--- a/features/admin/order/managing_orders/handling_order_payment/recovering_order_after_cancelled_authorized_payment.feature
+++ b/features/admin/order/managing_orders/handling_order_payment/recovering_order_after_cancelled_authorized_payment.feature
@@ -1,0 +1,20 @@
+@managing_orders
+Feature: Recovering order payment state after an authorized payment is cancelled
+    In order to allow the customer to retry payment after an authorization is voided by the gateway
+    As an Administrator
+    I want the order payment state to return to "Awaiting payment" when an authorized payment is cancelled
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store ships everywhere for Free
+        And the store has a product "PHP T-Shirt"
+        And the store allows paying with "Cash on Delivery"
+        And the payment method "Cash on Delivery" requires authorization before capturing
+        And there is an "authorized" "#00000001" order with "PHP T-Shirt" product
+        And I am logged in as an administrator
+
+    @api @ui
+    Scenario: Order payment state recovers to awaiting payment after the authorized payment is cancelled by the gateway
+        When the payment of order "#00000001" is cancelled by the gateway
+        Then this order should have order payment state "Awaiting payment"
+        And there should be only 2 payments

--- a/features/admin/order/managing_orders/handling_order_payment/recovering_order_after_cancelled_authorized_payment.feature
+++ b/features/admin/order/managing_orders/handling_order_payment/recovering_order_after_cancelled_authorized_payment.feature
@@ -13,8 +13,10 @@ Feature: Recovering order payment state after an authorized payment is cancelled
         And there is a "authorized" "#00000001" order with "PHP T-Shirt" product
         And I am logged in as an administrator
 
-    @api
+    @api @ui
     Scenario: Order payment state recovers to awaiting payment after the authorized payment is cancelled by the gateway
         When the payment of order "#00000001" is cancelled by the gateway
+        And I browse orders
         Then this order should have order payment state "Awaiting payment"
-        And there should be only 2 payments
+        When I view the summary of the order "#00000001"
+        Then there should be only 2 payments

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
+use Behat\Step\When;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -696,6 +697,14 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
+    #[When('the payment of order :order is cancelled by the gateway')]
+    public function thePaymentOfOrderIsCancelledByTheGateway(OrderInterface $order): void
+    {
+        $this->applyPaymentTransitionOnOrder($order, PaymentTransitions::TRANSITION_CANCEL);
+
+        $this->objectManager->flush();
+    }
+
     /**
      * @Given /^(this order) has been refunded$/
      * @Given the customer has refunded the order with number :order
@@ -1124,6 +1133,7 @@ final readonly class OrderContext implements Context
         $transitions = [
             'new' => [],
             'processing' => [PaymentTransitions::TRANSITION_PROCESS],
+            'authorized' => [PaymentTransitions::TRANSITION_AUTHORIZE],
             'completed' => [PaymentTransitions::TRANSITION_COMPLETE],
             'cancelled' => [PaymentTransitions::TRANSITION_CANCEL],
             'failed' => [PaymentTransitions::TRANSITION_FAIL],

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_order_payment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_order_payment.yml
@@ -16,7 +16,7 @@ winzou_state_machine:
             refunded: ~
         transitions:
             request_payment:
-                from: [cart]
+                from: [cart, authorized, partially_authorized]
                 to: awaiting_payment
             partially_authorize:
                 from: [awaiting_payment, partially_authorized]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_payment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_payment.yml
@@ -51,4 +51,4 @@ winzou_state_machine:
                     on: ["cancel", "fail"]
                     do: ["@sylius.state_resolver.order_payment", "resolve"]
                     args: ["object.getOrder()"]
-                    priority: -200
+                    priority: -100

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_payment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/winzou_state_machine/sylius_payment.yml
@@ -47,3 +47,8 @@ winzou_state_machine:
                     do: ["@sylius.state_resolver.order_payment", "resolve"]
                     args: ["object.getOrder()"]
                     priority: -100
+                sylius_resolve_state_after_cancel_or_fail:
+                    on: ["cancel", "fail"]
+                    do: ["@sylius.state_resolver.order_payment", "resolve"]
+                    args: ["object.getOrder()"]
+                    priority: -200

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/workflow/sylius_order_payment.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/workflow/sylius_order_payment.yaml
@@ -20,7 +20,10 @@ framework:
                 - !php/const Sylius\Component\Core\OrderPaymentStates::STATE_REFUNDED
             transitions:
                 !php/const Sylius\Component\Core\OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT:
-                    from: !php/const Sylius\Component\Core\OrderPaymentStates::STATE_CART
+                    from:
+                        - !php/const Sylius\Component\Core\OrderPaymentStates::STATE_CART
+                        - !php/const Sylius\Component\Core\OrderPaymentStates::STATE_AUTHORIZED
+                        - !php/const Sylius\Component\Core\OrderPaymentStates::STATE_PARTIALLY_AUTHORIZED
                     to: !php/const Sylius\Component\Core\OrderPaymentStates::STATE_AWAITING_PAYMENT
                 !php/const Sylius\Component\Core\OrderPaymentTransitions::TRANSITION_PARTIALLY_AUTHORIZE:
                     from: 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners/workflow/payment.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners/workflow/payment.xml
@@ -29,6 +29,8 @@
             <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.process" priority="100" />
             <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.refund" priority="100" />
             <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.authorize" priority="100" />
+            <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.cancel" priority="50" />
+            <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.fail" priority="50" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/OrderPaymentWorkflowTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/OrderPaymentWorkflowTest.php
@@ -137,6 +137,7 @@ final class OrderPaymentWorkflowTest extends KernelTestCase
     {
         yield ['cancel', 'cancelled'];
         yield ['pay', 'paid'];
+        yield ['request_payment', 'awaiting_payment'];
     }
 
     public static function availableTransitionsForPartiallyPaidState(): iterable

--- a/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/PaymentWorkflowTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/PaymentWorkflowTest.php
@@ -17,12 +17,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\CoreBundle\EventListener\Workflow\Payment\ProcessOrderListener;
+use Sylius\Bundle\CoreBundle\EventListener\Workflow\Payment\ResolveOrderPaymentStateListener;
 use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Payment\PaymentTransitions;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class PaymentWorkflowTest extends KernelTestCase
 {
@@ -72,6 +75,48 @@ final class PaymentWorkflowTest extends KernelTestCase
         yield [PaymentInterface::STATE_PROCESSING, PaymentTransitions::TRANSITION_CANCEL, PaymentInterface::STATE_CANCELLED];
         yield [PaymentInterface::STATE_AUTHORIZED, PaymentTransitions::TRANSITION_CANCEL, PaymentInterface::STATE_CANCELLED];
         yield [PaymentInterface::STATE_COMPLETED, PaymentTransitions::TRANSITION_REFUND, PaymentInterface::STATE_REFUNDED];
+    }
+
+    #[Test]
+    public function it_fires_resolve_order_payment_state_listener_after_process_order_listener_on_cancel(): void
+    {
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = self::getContainer()->get('event_dispatcher');
+
+        $cancelListeners = $dispatcher->getListeners('workflow.sylius_payment.completed.cancel');
+
+        $listenerClasses = array_map(
+            static fn (mixed $listener): string => is_array($listener) ? get_class($listener[0]) : get_class($listener),
+            $cancelListeners,
+        );
+
+        $processOrderIndex = array_search(ProcessOrderListener::class, $listenerClasses, true);
+        $resolveStateIndex = array_search(ResolveOrderPaymentStateListener::class, $listenerClasses, true);
+
+        $this->assertNotFalse($processOrderIndex, 'ProcessOrderListener must be subscribed to completed.cancel');
+        $this->assertNotFalse($resolveStateIndex, 'ResolveOrderPaymentStateListener must be subscribed to completed.cancel');
+        $this->assertLessThan($processOrderIndex, $resolveStateIndex, 'ResolveOrderPaymentStateListener must run after ProcessOrderListener (higher index = lower priority)');
+    }
+
+    #[Test]
+    public function it_fires_resolve_order_payment_state_listener_after_process_order_listener_on_fail(): void
+    {
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = self::getContainer()->get('event_dispatcher');
+
+        $failListeners = $dispatcher->getListeners('workflow.sylius_payment.completed.fail');
+
+        $listenerClasses = array_map(
+            static fn (mixed $listener): string => is_array($listener) ? get_class($listener[0]) : get_class($listener),
+            $failListeners,
+        );
+
+        $processOrderIndex = array_search(ProcessOrderListener::class, $listenerClasses, true);
+        $resolveStateIndex = array_search(ResolveOrderPaymentStateListener::class, $listenerClasses, true);
+
+        $this->assertNotFalse($processOrderIndex, 'ProcessOrderListener must be subscribed to completed.fail');
+        $this->assertNotFalse($resolveStateIndex, 'ResolveOrderPaymentStateListener must be subscribed to completed.fail');
+        $this->assertLessThan($processOrderIndex, $resolveStateIndex, 'ResolveOrderPaymentStateListener must run after ProcessOrderListener (higher index = lower priority)');
     }
 
     private function getStateMachine(): StateMachineInterface

--- a/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/PaymentWorkflowTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Functional/StateMachine/PaymentWorkflowTest.php
@@ -95,7 +95,7 @@ final class PaymentWorkflowTest extends KernelTestCase
 
         $this->assertNotFalse($processOrderIndex, 'ProcessOrderListener must be subscribed to completed.cancel');
         $this->assertNotFalse($resolveStateIndex, 'ResolveOrderPaymentStateListener must be subscribed to completed.cancel');
-        $this->assertLessThan($processOrderIndex, $resolveStateIndex, 'ResolveOrderPaymentStateListener must run after ProcessOrderListener (higher index = lower priority)');
+        $this->assertGreaterThan($processOrderIndex, $resolveStateIndex, 'ResolveOrderPaymentStateListener must run after ProcessOrderListener (higher index = lower priority)');
     }
 
     #[Test]
@@ -116,7 +116,7 @@ final class PaymentWorkflowTest extends KernelTestCase
 
         $this->assertNotFalse($processOrderIndex, 'ProcessOrderListener must be subscribed to completed.fail');
         $this->assertNotFalse($resolveStateIndex, 'ResolveOrderPaymentStateListener must be subscribed to completed.fail');
-        $this->assertLessThan($processOrderIndex, $resolveStateIndex, 'ResolveOrderPaymentStateListener must run after ProcessOrderListener (higher index = lower priority)');
+        $this->assertGreaterThan($processOrderIndex, $resolveStateIndex, 'ResolveOrderPaymentStateListener must run after ProcessOrderListener (higher index = lower priority)');
     }
 
     private function getStateMachine(): StateMachineInterface

--- a/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
@@ -105,6 +105,14 @@ final class OrderPaymentStateResolver implements StateResolverInterface
             return OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT;
         }
 
+        $hasReplayablePayment =
+            !$this->getPaymentsWithState($order, PaymentInterface::STATE_CART)->isEmpty()
+            || !$this->getPaymentsWithState($order, PaymentInterface::STATE_NEW)->isEmpty();
+
+        if ($hasReplayablePayment) {
+            return OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT;
+        }
+
         return null;
     }
 

--- a/src/Sylius/Component/Core/tests/StateResolver/OrderPaymentStateResolverTest.php
+++ b/src/Sylius/Component/Core/tests/StateResolver/OrderPaymentStateResolverTest.php
@@ -299,4 +299,48 @@ final class OrderPaymentStateResolverTest extends TestCase
 
         $this->stateResolver->resolve($this->order);
     }
+
+    public function testShouldMarkOrderAsAwaitingPaymentWhenCancelledPaymentExistsAlongsideNewCartPayment(): void
+    {
+        $this->firstPayment->expects($this->exactly(5))->method('getState')->willReturn(PaymentInterface::STATE_CANCELLED);
+        $this->secondPayment->expects($this->exactly(5))->method('getState')->willReturn(PaymentInterface::STATE_CART);
+        $this->order
+            ->expects($this->exactly(6))
+            ->method('getPayments')
+            ->willReturn(new ArrayCollection([$this->firstPayment, $this->secondPayment]));
+        $this->order->expects($this->exactly(3))->method('getTotal')->willReturn(10000);
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($this->order, OrderPaymentTransitions::GRAPH, OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT)
+            ->willReturn(true);
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->order, OrderPaymentTransitions::GRAPH, OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT);
+
+        $this->stateResolver->resolve($this->order);
+    }
+
+    public function testShouldMarkOrderAsAwaitingPaymentWhenFailedPaymentExistsAlongsideNewCartPayment(): void
+    {
+        $this->firstPayment->expects($this->exactly(5))->method('getState')->willReturn(PaymentInterface::STATE_FAILED);
+        $this->secondPayment->expects($this->exactly(5))->method('getState')->willReturn(PaymentInterface::STATE_CART);
+        $this->order
+            ->expects($this->exactly(6))
+            ->method('getPayments')
+            ->willReturn(new ArrayCollection([$this->firstPayment, $this->secondPayment]));
+        $this->order->expects($this->exactly(3))->method('getTotal')->willReturn(10000);
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($this->order, OrderPaymentTransitions::GRAPH, OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT)
+            ->willReturn(true);
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->order, OrderPaymentTransitions::GRAPH, OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT);
+
+        $this->stateResolver->resolve($this->order);
+    }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

## Problem

  When a payment gateway voids/cancels an authorized payment, the order payment state remained stuck in authorized — making it impossible for the customer to retry payment without manual admin
  intervention.

## The expected behavior:
  1. Gateway cancels an authorized payment
  2. System creates a new payment (existing OrderPaymentProcessor behavior)
  3. Order payment state returns to awaiting_payment so the customer can pay again
  
## Root Cause

  The OrderPaymentStateResolver had no logic to handle the presence of a new cart/new state payment created after cancellation. It would fall through to return null, leaving the order payment state
  unchanged.

  Additionally, for the Symfony Workflow adapter the resolver was never invoked on cancel/fail transitions, and for the winzou adapter the request_payment transition didn't allow transitioning from
  authorized or partially_authorized states.

## Changes

  OrderPaymentStateResolver
  - Added hasReplayablePayment check: if a cart or new state payment exists, return TRANSITION_REQUEST_PAYMENT to move the order back to awaiting_payment

  Symfony Workflow — sylius_order_payment.yaml
  - Extended request_payment transition from states to include authorized and partially_authorized (previously only cart)
  
  Symfony Workflow — payment.xml listeners
  - Registered ResolveOrderPaymentStateListener for cancel and fail events (priority 50, after ProcessOrderListener at priority 100) so the resolver runs once the new payment is created
  
  Winzou — sylius_order_payment.yml
  - Extended request_payment transition from states to include authorized and partially_authorized

  Winzou — sylius_payment.yml
  - Added sylius_resolve_state_after_cancel_or_fail callback (priority -100) on cancel/fail transitions
  - Priority is identical to sylius_process_order so YAML definition order guarantees the processor runs first (creating the new payment before the resolver inspects it)