### PR TITLE
Prevent a coupon from invalidating its own promotion eligibility

### DIFF
--- a/features/shop/promotion/applying_promotion_coupon/applying_coupon_on_already_discounted_cart.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_coupon_on_already_discounted_cart.feature
@@ -1,0 +1,32 @@
+@applying_promotion_coupon
+Feature: Applying a coupon on an already discounted cart
+    In order to have predictable discounts when several promotions apply
+    As a Customer
+    I want a coupon's items total rule to be evaluated against the price already reduced by other promotions
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$50.00"
+        And there is a promotion "Automatic sale"
+        And this promotion gives "$15.00" discount to every order
+        And the store has promotion "Coupon sale" with coupon "STACK10"
+        And this promotion gives "$10.00" discount to every order with items total at least "$40.00"
+        And the store ships everywhere for Free
+        And the store allows paying "Cash on Delivery"
+        And I am a logged in customer
+
+    @api @ui
+    Scenario: Not applying the coupon when another promotion reduced the cart below the threshold
+        Given I added product "PHP T-Shirt" to the cart
+        And I applied the coupon with code "STACK10"
+        When I check the details of my cart
+        Then my cart total should be "$35.00"
+        And my discount should be "-$15.00"
+
+    @api @ui
+    Scenario: Applying the coupon when the cart stays above the threshold after the other promotion
+        Given I added 2 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "STACK10"
+        When I check the details of my cart
+        Then my cart total should be "$75.00"
+        And my discount should be "-$25.00"

--- a/features/shop/promotion/applying_promotion_coupon/applying_coupon_with_total_of_items_from_taxon_rule.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_coupon_with_total_of_items_from_taxon_rule.feature
@@ -1,0 +1,61 @@
+@applying_promotion_coupon
+Feature: Applying a coupon with a total of items from taxon rule
+    In order to get predictable discounts on a coupon scoped to a taxon
+    As a Customer
+    I want the taxon total rule to count other promotions but not its own, and only items from the configured taxon
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store classifies its products as "T-Shirts" and "Mugs"
+        And the store has a product "PHP T-Shirt" priced at "$50.00"
+        And it belongs to "T-Shirts"
+        And the store has a product "PHP Mug" priced at "$30.00"
+        And it belongs to "Mugs"
+        And the store ships everywhere for Free
+        And the store allows paying "Cash on Delivery"
+        And I am a logged in customer
+
+    @api @ui
+    Scenario: Not applying the taxon coupon when another promotion reduced the taxon items below the threshold
+        Given there is a promotion "Automatic sale"
+        And this promotion gives "$15.00" discount to every order
+        And the store has promotion "T-Shirts coupon" with coupon "STACK10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$40.00"
+        And I added product "PHP T-Shirt" to the cart
+        And I applied the coupon with code "STACK10"
+        When I check the details of my cart
+        Then my cart total should be "$35.00"
+        And my discount should be "-$15.00"
+
+    @api @ui
+    Scenario: Applying the taxon coupon when the taxon items stay above the threshold after the other promotion
+        Given there is a promotion "Automatic sale"
+        And this promotion gives "$15.00" discount to every order
+        And the store has promotion "T-Shirts coupon" with coupon "STACK10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "STACK10"
+        When I check the details of my cart
+        Then my cart total should be "$75.00"
+        And my discount should be "-$25.00"
+
+    @api @ui
+    Scenario: Not counting items from other taxons towards the taxon rule threshold
+        Given the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$60.00"
+        And I added product "PHP T-Shirt" to the cart
+        And I added 2 products "PHP Mug" to the cart
+        And I applied the coupon with code "TSHIRTS10"
+        When I check the details of my cart
+        Then my cart total should be "$110.00"
+        And there should be no discount applied
+
+    @api @no-ui
+    Scenario: Being notified that the taxon coupon is invalid when the taxon items do not meet the minimum
+        Given the store has promotion "T-Shirts coupon" with coupon "TSHIRTS10"
+        And this promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$60.00"
+        And I added product "PHP T-Shirt" to the cart
+        When I use coupon with code "TSHIRTS10"
+        Then I should be notified that the coupon is invalid
+        And my cart total should be "$50.00"
+        And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_coupon/e2e/not_invalidating_own_coupon_with_items_total_rule.feature
+++ b/features/shop/promotion/applying_promotion_coupon/e2e/not_invalidating_own_coupon_with_items_total_rule.feature
@@ -1,0 +1,21 @@
+@applying_promotion_coupon
+Feature: Not invalidating own coupon with items total rule
+    In order to keep my legitimately applied discount while editing my cart
+    As a Customer
+    I want the items total rule to not count its own promotion's discount when revalidating the coupon
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$22.00"
+        And the store has promotion "Black Friday" with coupon "BUGME10"
+        And this promotion gives "$30.00" discount to every order with items total at least "$40.00"
+        And I am a logged in customer
+
+    @api @ui @mink:chromedriver
+    Scenario: Keeping the discount after increasing quantity while the coupon stays eligible
+        Given I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        And I use coupon with code "BUGME10"
+        And I change product "PHP T-Shirt" quantity to 3 in my cart
+        Then my cart total should be "$36.00"
+        And my discount should be "-$30.00"

--- a/features/shop/promotion/applying_promotion_coupon/not_invalidating_own_coupon_with_items_total_rule.feature
+++ b/features/shop/promotion/applying_promotion_coupon/not_invalidating_own_coupon_with_items_total_rule.feature
@@ -1,0 +1,62 @@
+@applying_promotion_coupon
+Feature: Not invalidating own coupon with items total rule
+    In order to keep my legitimately applied discount on my cart
+    As a Customer
+    I want the items total rule to not count its own promotion's discount when revalidating the coupon
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$22.00"
+        And the store has promotion "Black Friday" with coupon "BUGME10"
+        And the store ships everywhere for Free
+        And the store allows paying "Cash on Delivery"
+        And I am a logged in customer
+
+    @api @no-ui
+    Scenario: Keeping the order fixed discount when the coupon is re-sent on an already discounted cart
+        Given this promotion gives "$10.00" discount to every order with items total at least "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I use coupon with code "BUGME10"
+        And I use coupon with code "BUGME10"
+        Then I should not be notified that the coupon is invalid
+        And my cart total should be "$34.00"
+        And my discount should be "-$10.00"
+
+    @api @no-ui
+    Scenario: Keeping the order percentage discount when the coupon is re-sent on an already discounted cart
+        Given this promotion gives "25%" discount to every order with items total at least "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I use coupon with code "BUGME10"
+        And I use coupon with code "BUGME10"
+        Then I should not be notified that the coupon is invalid
+        And my cart total should be "$33.00"
+        And my discount should be "-$11.00"
+
+    @api @no-ui
+    Scenario: Keeping the unit percentage discount when the coupon is re-sent on an already discounted cart
+        Given this promotion gives "25%" off on every product when the item total is at least "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I use coupon with code "BUGME10"
+        And I use coupon with code "BUGME10"
+        Then I should not be notified that the coupon is invalid
+        And my cart total should be "$33.00"
+        And my discount should be "-$11.00"
+
+    @api @ui
+    Scenario: Receiving the discount on the first application within the bug window
+        Given this promotion gives "$10.00" discount to every order with items total at least "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "BUGME10"
+        When I check the details of my cart
+        Then my cart total should be "$34.00"
+        And my discount should be "-$10.00"
+
+    @api @no-ui
+    Scenario: Dropping the discount when the cart genuinely falls below the threshold
+        Given this promotion gives "$10.00" discount to every order with items total at least "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "BUGME10"
+        And I changed product "PHP T-Shirt" quantity to 1 in my cart
+        When I check the details of my cart
+        Then my cart total should be "$22.00"
+        And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_coupon/not_invalidating_own_coupon_with_total_of_items_from_taxon_rule.feature
+++ b/features/shop/promotion/applying_promotion_coupon/not_invalidating_own_coupon_with_total_of_items_from_taxon_rule.feature
@@ -1,0 +1,44 @@
+@applying_promotion_coupon
+Feature: Not invalidating own coupon with total of items from taxon rule
+    In order to keep my legitimately applied discount on my cart
+    As a Customer
+    I want the total of items from taxon rule to not count its own promotion's discount when revalidating the coupon
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store classifies its products as "T-Shirts"
+        And the store has a product "PHP T-Shirt" priced at "$22.00"
+        And it belongs to "T-Shirts"
+        And the store has promotion "Black Friday" with coupon "BUGME10"
+        And the store ships everywhere for Free
+        And the store allows paying "Cash on Delivery"
+        And I am a logged in customer
+
+    @api @no-ui
+    Scenario: Keeping the discount when the coupon is re-sent on an already discounted cart
+        Given the promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I use coupon with code "BUGME10"
+        And I use coupon with code "BUGME10"
+        Then I should not be notified that the coupon is invalid
+        And my cart total should be "$34.00"
+        And my discount should be "-$10.00"
+
+    @api @ui
+    Scenario: Receiving the discount on the first application within the bug window
+        Given the promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "BUGME10"
+        When I check the details of my cart
+        Then my cart total should be "$34.00"
+        And my discount should be "-$10.00"
+
+    @api @no-ui
+    Scenario: Dropping the discount when the cart genuinely falls below the threshold
+        Given the promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$40.00"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I applied the coupon with code "BUGME10"
+        And I changed product "PHP T-Shirt" quantity to 1 in my cart
+        When I check the details of my cart
+        Then my cart total should be "$22.00"
+        And there should be no discount applied

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
 use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -46,6 +47,14 @@ final class PromotionContext implements Context
 
         Assert::same($response->getStatusCode(), 422);
         Assert::same($this->responseChecker->getError($response), 'couponCode: Coupon code is invalid.');
+    }
+
+    #[Then('I should not be notified that the coupon is invalid')]
+    public function iShouldNotBeNotifiedThatCouponIsInvalid(): void
+    {
+        $response = $this->client->getLastResponse();
+
+        Assert::notSame($response->getStatusCode(), 422, 'The coupon was unexpectedly rejected as invalid.');
     }
 
     private function getCartTokenValue(): ?string

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -63,7 +63,7 @@
         <service id="Sylius\Bundle\ApiBundle\Mapper\AddressMapperInterface" alias="sylius_api.mapper.address" />
 
         <service id="sylius_api.checker.applied_coupon_eligibility" class="Sylius\Bundle\ApiBundle\Checker\AppliedCouponEligibilityChecker">
-            <argument type="service" id="sylius.checker.promotion_eligibility" />
+            <argument type="service" id="sylius.checker.promotion_eligibility.without_own_adjustments" />
             <argument type="service" id="sylius.checker.promotion_coupon_eligibility" />
         </service>
         <service id="Sylius\Bundle\ApiBundle\Checker\AppliedCouponEligibilityCheckerInterface" alias="sylius_api.checker.applied_coupon_eligibility" />

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/eligibility_checkers.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/eligibility_checkers.xml
@@ -69,6 +69,12 @@
         <service id="sylius.checker.promotion_eligibility.composite" alias="sylius.checker.promotion_eligibility" />
         <service id="Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface" alias="sylius.checker.promotion_eligibility" />
 
+        <service id="sylius.checker.promotion_eligibility.without_own_adjustments"
+                 class="Sylius\Component\Promotion\Checker\Eligibility\WithoutOwnAdjustmentsPromotionEligibilityChecker">
+            <argument type="service" id="sylius.checker.promotion_eligibility" />
+            <argument type="service" id="sylius.action.applicator.promotion" />
+        </service>
+
         <service id="sylius.checker.promotion.archival_eligibility"
                  class="Sylius\Component\Promotion\Checker\Eligibility\PromotionArchivalEligibilityChecker"
                  public="false">

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
@@ -18,7 +18,7 @@
 >
     <services>
         <service id="sylius.validator.promotion_subject_coupon" class="Sylius\Bundle\PromotionBundle\Validator\PromotionSubjectCouponValidator">
-            <argument type="service" id="sylius.checker.promotion_eligibility" />
+            <argument type="service" id="sylius.checker.promotion_eligibility.without_own_adjustments" />
             <tag name="validator.constraint_validator" alias="sylius_promotion_subject_validator" />
         </service>
 

--- a/src/Sylius/Bundle/PromotionBundle/tests/Validator/PromotionSubjectCouponValidatorTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/tests/Validator/PromotionSubjectCouponValidatorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\PromotionBundle\Validator;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\PromotionBundle\Validator\Constraints\PromotionSubjectCoupon;
+use Sylius\Bundle\PromotionBundle\Validator\PromotionSubjectCouponValidator;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
+use Sylius\Component\Promotion\Model\PromotionCouponAwarePromotionSubjectInterface;
+use Sylius\Component\Promotion\Model\PromotionCouponInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+final class PromotionSubjectCouponValidatorTest extends TestCase
+{
+    private ExecutionContextInterface&MockObject $context;
+
+    private MockObject&PromotionEligibilityCheckerInterface $promotionEligibilityChecker;
+
+    private PromotionSubjectCouponValidator $validator;
+
+    private MockObject&PromotionCouponAwarePromotionSubjectInterface $subject;
+
+    private MockObject&PromotionCouponInterface $coupon;
+
+    private MockObject&PromotionInterface $promotion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->context = $this->createMock(ExecutionContextInterface::class);
+        $this->promotionEligibilityChecker = $this->createMock(PromotionEligibilityCheckerInterface::class);
+        $this->validator = new PromotionSubjectCouponValidator($this->promotionEligibilityChecker);
+        $this->validator->initialize($this->context);
+        $this->subject = $this->createMock(PromotionCouponAwarePromotionSubjectInterface::class);
+        $this->coupon = $this->createMock(PromotionCouponInterface::class);
+        $this->promotion = $this->createMock(PromotionInterface::class);
+    }
+
+    public function testDoesNothingWhenValueIsNotACouponAwareSubject(): void
+    {
+        $this->promotionEligibilityChecker->expects(self::never())->method('isEligible');
+        $this->context->expects(self::never())->method('buildViolation');
+
+        $this->validator->validate(new \stdClass(), new PromotionSubjectCoupon());
+    }
+
+    public function testDoesNothingWhenSubjectHasNoCoupon(): void
+    {
+        $this->subject->expects(self::once())->method('getPromotionCoupon')->willReturn(null);
+
+        $this->promotionEligibilityChecker->expects(self::never())->method('isEligible');
+        $this->context->expects(self::never())->method('buildViolation');
+
+        $this->validator->validate($this->subject, new PromotionSubjectCoupon());
+    }
+
+    public function testDoesNotAddViolationWhenThePromotionIsEligible(): void
+    {
+        $this->subject->method('getPromotionCoupon')->willReturn($this->coupon);
+        $this->coupon->method('getPromotion')->willReturn($this->promotion);
+
+        $this->promotionEligibilityChecker->expects(self::once())
+            ->method('isEligible')
+            ->with($this->subject, $this->promotion)
+            ->willReturn(true);
+
+        $this->context->expects(self::never())->method('buildViolation');
+
+        $this->validator->validate($this->subject, new PromotionSubjectCoupon());
+    }
+
+    public function testAddsViolationWhenThePromotionIsNotEligible(): void
+    {
+        $this->subject->method('getPromotionCoupon')->willReturn($this->coupon);
+        $this->coupon->method('getPromotion')->willReturn($this->promotion);
+
+        $this->promotionEligibilityChecker->expects(self::once())
+            ->method('isEligible')
+            ->with($this->subject, $this->promotion)
+            ->willReturn(false);
+
+        $constraint = new PromotionSubjectCoupon();
+
+        /** @var ConstraintViolationBuilderInterface&MockObject $violationBuilder */
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+
+        $this->context->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+
+        $violationBuilder->expects(self::once())
+            ->method('atPath')
+            ->with('promotionCoupon')
+            ->willReturn($violationBuilder);
+
+        $violationBuilder->expects(self::once())->method('addViolation');
+
+        $this->validator->validate($this->subject, $constraint);
+    }
+}

--- a/src/Sylius/Component/Promotion/Checker/Eligibility/WithoutOwnAdjustmentsPromotionEligibilityChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/Eligibility/WithoutOwnAdjustmentsPromotionEligibilityChecker.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Promotion\Checker\Eligibility;
+
+use Sylius\Component\Promotion\Action\PromotionApplicatorInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+
+/**
+ * Checks the promotion eligibility as if the promotion was not applied to the subject yet.
+ *
+ * A promotion's own adjustments must not count towards its own eligibility, otherwise a promotion
+ * lowering the subject total below its rule threshold would invalidate its own coupon. Adjustments
+ * coming from other promotions are intentionally taken into account.
+ *
+ * The check itself stays side effect free: an already applied promotion is temporarily reverted
+ * only to run the eligibility check and is restored afterwards, regardless of the outcome and even
+ * if the inner check throws. Removing a no longer eligible promotion is the promotion processor's
+ * responsibility, not this checker's.
+ */
+final readonly class WithoutOwnAdjustmentsPromotionEligibilityChecker implements PromotionEligibilityCheckerInterface
+{
+    public function __construct(
+        private PromotionEligibilityCheckerInterface $promotionEligibilityChecker,
+        private PromotionApplicatorInterface $promotionApplicator,
+    ) {
+    }
+
+    public function isEligible(PromotionSubjectInterface $promotionSubject, PromotionInterface $promotion): bool
+    {
+        if (!$promotionSubject->hasPromotion($promotion)) {
+            return $this->promotionEligibilityChecker->isEligible($promotionSubject, $promotion);
+        }
+
+        $this->promotionApplicator->revert($promotionSubject, $promotion);
+
+        try {
+            return $this->promotionEligibilityChecker->isEligible($promotionSubject, $promotion);
+        } finally {
+            $this->promotionApplicator->apply($promotionSubject, $promotion);
+        }
+    }
+}

--- a/src/Sylius/Component/Promotion/tests/Checker/Eligibility/WithoutOwnAdjustmentsPromotionEligibilityCheckerTest.php
+++ b/src/Sylius/Component/Promotion/tests/Checker/Eligibility/WithoutOwnAdjustmentsPromotionEligibilityCheckerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Promotion\Checker\Eligibility;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Promotion\Action\PromotionApplicatorInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\WithoutOwnAdjustmentsPromotionEligibilityChecker;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+
+final class WithoutOwnAdjustmentsPromotionEligibilityCheckerTest extends TestCase
+{
+    private MockObject&PromotionEligibilityCheckerInterface $promotionEligibilityChecker;
+
+    private MockObject&PromotionApplicatorInterface $promotionApplicator;
+
+    private WithoutOwnAdjustmentsPromotionEligibilityChecker $checker;
+
+    private MockObject&PromotionSubjectInterface $subject;
+
+    private MockObject&PromotionInterface $promotion;
+
+    protected function setUp(): void
+    {
+        $this->promotionEligibilityChecker = $this->createMock(PromotionEligibilityCheckerInterface::class);
+        $this->promotionApplicator = $this->createMock(PromotionApplicatorInterface::class);
+        $this->checker = new WithoutOwnAdjustmentsPromotionEligibilityChecker(
+            $this->promotionEligibilityChecker,
+            $this->promotionApplicator,
+        );
+        $this->subject = $this->createMock(PromotionSubjectInterface::class);
+        $this->promotion = $this->createMock(PromotionInterface::class);
+    }
+
+    public function testImplementsPromotionEligibilityCheckerInterface(): void
+    {
+        self::assertInstanceOf(PromotionEligibilityCheckerInterface::class, $this->checker);
+    }
+
+    public function testChecksEligibilityWithoutTouchingTheSubjectWhenPromotionIsNotApplied(): void
+    {
+        $this->subject->method('hasPromotion')->with($this->promotion)->willReturn(false);
+
+        $this->promotionApplicator->expects(self::never())->method('revert');
+        $this->promotionApplicator->expects(self::never())->method('apply');
+
+        $this->promotionEligibilityChecker->expects(self::once())
+            ->method('isEligible')
+            ->with($this->subject, $this->promotion)
+            ->willReturn(true);
+
+        self::assertTrue($this->checker->isEligible($this->subject, $this->promotion));
+    }
+
+    public function testRevertsItsOwnAppliedPromotionBeforeCheckingAndReappliesItWhenStillEligible(): void
+    {
+        $this->subject->method('hasPromotion')->with($this->promotion)->willReturn(true);
+
+        $this->promotionApplicator->expects(self::once())->method('revert')->with($this->subject, $this->promotion);
+
+        $this->promotionEligibilityChecker->expects(self::once())
+            ->method('isEligible')
+            ->with($this->subject, $this->promotion)
+            ->willReturn(true);
+
+        $this->promotionApplicator->expects(self::once())->method('apply')->with($this->subject, $this->promotion);
+
+        self::assertTrue($this->checker->isEligible($this->subject, $this->promotion));
+    }
+
+    public function testRestoresItsOwnAppliedPromotionAfterCheckingEvenWhenNoLongerEligible(): void
+    {
+        $this->subject->method('hasPromotion')->with($this->promotion)->willReturn(true);
+
+        $this->promotionApplicator->expects(self::once())->method('revert')->with($this->subject, $this->promotion);
+
+        $this->promotionEligibilityChecker->expects(self::once())
+            ->method('isEligible')
+            ->with($this->subject, $this->promotion)
+            ->willReturn(false);
+
+        $this->promotionApplicator->expects(self::once())->method('apply')->with($this->subject, $this->promotion);
+
+        self::assertFalse($this->checker->isEligible($this->subject, $this->promotion));
+    }
+
+    public function testRestoresItsOwnAppliedPromotionWhenTheInnerCheckThrows(): void
+    {
+        $this->subject->method('hasPromotion')->with($this->promotion)->willReturn(true);
+
+        $this->promotionApplicator->expects(self::once())->method('revert')->with($this->subject, $this->promotion);
+
+        $exception = new \RuntimeException('Eligibility check failed.');
+        $this->promotionEligibilityChecker->expects(self::once())
+            ->method('isEligible')
+            ->with($this->subject, $this->promotion)
+            ->willThrowException($exception);
+
+        $this->promotionApplicator->expects(self::once())->method('apply')->with($this->subject, $this->promotion);
+
+        $this->expectExceptionObject($exception);
+
+        $this->checker->isEligible($this->subject, $this->promotion);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #16303
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
A coupon could invalidate its own promotion. The two rule checkers that look at a
monetary total, `ItemTotalRuleChecker` and `TotalOfItemsFromTaxonRuleChecker`, read the order total *after* discounts are applied. So once a coupon's promotion lowers the cart below its own rule threshold, re-validating that same coupon sees the reduced total, decides the rule is no longer met, and drops the discount. On the shop this shows up as a cart that keeps bouncing the coupon ("Coupon code is invalid") and on the API as a 422 when the coupon is sent again on an already-discounted cart.

Instead of patching the rule checkers, the eligibility is checked as if the promotion beingvalidated was not applied yet. A small decorator (`WithoutOwnAdjustmentsPromotionEligibilityChecker`) reverts *only that promotion's own* adjustments, runs the normal eligibility check, and re-applies them if it still qualifies. Adjustments coming from other promotions are kept on purpose, so the result stays consistent with how `PromotionProcessor` already evaluates promotions sequentially by priority.

The decorator is wired into the only two places that validate a coupon against an
already-processed cart:

- shop: `PromotionSubjectCouponValidator`
- API: `AppliedCouponEligibilityChecker`

`PromotionProcessor` keeps using the plain eligibility checker, so the promotion-application path is unchanged. This only affects coupon validation.

Because the fix lives at the eligibility level it covers both total-based rules at once, not
just the taxon one. This is why it supersedes #18977 (which patched only `TotalOfItemsFromTaxonRuleChecker` and computed from the base unit price, changing the rule's meaning for everyone and ignoring other promotions) and the earlier #16648.