### PR TITLE
Add post-event dispatches for cart operations

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -620,6 +620,38 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    Existing subclasses overriding this method with the `RedirectResponse` return type remain valid thanks to
    return type covariance and require no changes.
 
+## New Features
+
+1. New post-flush cart events have been added to `Sylius\Component\Order\SyliusCartEvents`.
+
+   The following events are now dispatched **after** `$manager->flush()`, allowing listeners to react once the cart has been safely persisted to the database:
+
+   | New constant | Event name |
+         |---|---|
+   | `SyliusCartEvents::CART_ITEM_POST_ADD` | `sylius.cart_item_post_add` |
+   | `SyliusCartEvents::CART_ITEM_POST_REMOVE` | `sylius.cart_item_post_remove` |
+   | `SyliusCartEvents::CART_POST_CHANGE` | `sylius.cart_post_change` |
+   | `SyliusCartEvents::CART_POST_CLEAR` | `sylius.cart_post_clear` |
+
+   Example usage — sending a cart to an external service only after it is stored:
+
+   ```php
+   use Sylius\Component\Order\SyliusCartEvents;
+   use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+   use Symfony\Component\EventDispatcher\GenericEvent;
+
+   #[AsEventListener(event: SyliusCartEvents::CART_ITEM_POST_ADD)]
+   final class SendCartToMarketingAutomationListener
+   {
+       public function __invoke(GenericEvent $event): void
+       {
+           // Cart is already persisted — safe to send to external service.
+       }
+   }
+   ```
+
+   The existing pre-flush events (`CART_ITEM_ADD`, `CART_ITEM_REMOVE`, `CART_CHANGE`, `CART_CLEAR`) remain unchanged.
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -633,6 +633,14 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    | `SyliusCartEvents::CART_POST_CHANGE` | `sylius.cart_post_change` |
    | `SyliusCartEvents::CART_POST_CLEAR` | `sylius.cart_post_clear` |
 
+   > **Note:** because these events are dispatched after the flush, their subjects no longer carry the full picture,
+   > so the missing data is passed as event arguments:
+   >
+   > | Event | Why | Argument |
+   > |---|---|---|
+   > | `CART_ITEM_POST_REMOVE` | `CART_ITEM_REMOVE` triggers `OrderModifier::removeFromOrder()`, which calls `$orderItem->setOrder(null)`, so `$orderItem->getOrder()` returns `null` | `$event->getArgument('cart')` |
+   > | `CART_POST_CLEAR` | Doctrine resets the identifier of a removed entity on flush, so `$cart->getId()` returns `null` | `$event->getArgument('cartId')` |
+
    Example usage — sending a cart to an external service only after it is stored:
 
    ```php

--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
@@ -90,6 +90,7 @@ class OrderController extends ResourceController
 
             $this->getEventDispatcher()->dispatch(new GenericEvent($resource), SyliusCartEvents::CART_CHANGE);
             $this->manager->flush();
+            $this->getEventDispatcher()->dispatch(new GenericEvent($resource), SyliusCartEvents::CART_POST_CHANGE);
 
             if (!$configuration->isHtmlRequest()) {
                 return $this->createRestView($configuration, null, Response::HTTP_NO_CONTENT);

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/FormComponent.php
@@ -107,7 +107,10 @@ class FormComponent
         $this->manager->persist($this->resource);
         $this->manager->flush();
         $this->manager->refresh($this->resource);
-        $this->eventDispatcher->dispatch(new GenericEvent($orderItem), SyliusCartEvents::CART_ITEM_POST_REMOVE);
+        $this->eventDispatcher->dispatch(
+            new GenericEvent($orderItem, ['cart' => $this->resource]),
+            SyliusCartEvents::CART_ITEM_POST_REMOVE,
+        );
 
         $this->shouldSaveCart = false;
         $this->submitForm();
@@ -124,9 +127,13 @@ class FormComponent
         $this->formValues['items'] = [];
         $this->eventDispatcher->dispatch(new GenericEvent($this->resource), SyliusCartEvents::CART_CLEAR);
         $clearedCart = $this->resource;
+        $clearedCartId = $clearedCart->getId();
         $this->manager->remove($this->resource);
         $this->manager->flush();
-        $this->eventDispatcher->dispatch(new GenericEvent($clearedCart), SyliusCartEvents::CART_POST_CLEAR);
+        $this->eventDispatcher->dispatch(
+            new GenericEvent($clearedCart, ['cartId' => $clearedCartId]),
+            SyliusCartEvents::CART_POST_CLEAR,
+        );
 
         $this->resource = $this->createResource();
         $this->resetForm();

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/FormComponent.php
@@ -84,6 +84,7 @@ class FormComponent
             if ($form->isValid()) {
                 $this->eventDispatcher->dispatch(new GenericEvent($form->getData()), SyliusCartEvents::CART_CHANGE);
                 $this->manager->flush();
+                $this->eventDispatcher->dispatch(new GenericEvent($form->getData()), SyliusCartEvents::CART_POST_CHANGE);
                 $this->emit(self::SYLIUS_SHOP_CART_CHANGED, ['cartId' => $this->resource->getId()]);
             }
         }
@@ -106,6 +107,7 @@ class FormComponent
         $this->manager->persist($this->resource);
         $this->manager->flush();
         $this->manager->refresh($this->resource);
+        $this->eventDispatcher->dispatch(new GenericEvent($orderItem), SyliusCartEvents::CART_ITEM_POST_REMOVE);
 
         $this->shouldSaveCart = false;
         $this->submitForm();
@@ -121,8 +123,10 @@ class FormComponent
 
         $this->formValues['items'] = [];
         $this->eventDispatcher->dispatch(new GenericEvent($this->resource), SyliusCartEvents::CART_CLEAR);
+        $clearedCart = $this->resource;
         $this->manager->remove($this->resource);
         $this->manager->flush();
+        $this->eventDispatcher->dispatch(new GenericEvent($clearedCart), SyliusCartEvents::CART_POST_CLEAR);
 
         $this->resource = $this->createResource();
         $this->resetForm();

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
@@ -126,6 +126,7 @@ class AddToCartFormComponent
         $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
         $this->manager->persist($addToCartCommand->getCart());
         $this->manager->flush();
+        $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_POST_ADD);
 
         if ($addFlashMessage) {
             FlashBagProvider::getFlashBag($this->requestStack)->add('success', 'sylius.cart.add_item');

--- a/src/Sylius/Component/Order/SyliusCartEvents.php
+++ b/src/Sylius/Component/Order/SyliusCartEvents.php
@@ -17,11 +17,19 @@ interface SyliusCartEvents
 {
     public const CART_CHANGE = 'sylius.cart_change';
 
+    public const CART_POST_CHANGE = 'sylius.cart_post_change';
+
     public const CART_CLEAR = 'sylius.cart_clear';
+
+    public const CART_POST_CLEAR = 'sylius.cart_post_clear';
 
     public const CART_ITEM_ADD = 'sylius.cart_item_add';
 
+    public const CART_ITEM_POST_ADD = 'sylius.cart_item_post_add';
+
     public const CART_ITEM_REMOVE = 'sylius.cart_item_remove';
+
+    public const CART_ITEM_POST_REMOVE = 'sylius.cart_item_post_remove';
 
     public const CART_SUMMARY = 'sylius.cart_summary';
 }

--- a/tests/Functional/CartPostFlushEventsTest.php
+++ b/tests/Functional/CartPostFlushEventsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Fidry\AliceDataFixtures\LoaderInterface;
+use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Bundle\ShopBundle\Twig\Component\Cart\FormComponent;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItem;
+use Sylius\Component\Core\Model\OrderItemUnit;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Order\SyliusCartEvents;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+final class CartPostFlushEventsTest extends KernelTestCase
+{
+    #[Test]
+    public function it_passes_the_cart_as_an_argument_of_the_cart_item_post_remove_event(): void
+    {
+        $cart = $this->createCartWithItem();
+        $component = $this->createComponentForCart($cart);
+
+        $capturedSubjectOrder = false;
+        $capturedCart = null;
+
+        $this->listenTo(SyliusCartEvents::CART_ITEM_POST_REMOVE, function (GenericEvent $event) use (&$capturedSubjectOrder, &$capturedCart): void {
+            $capturedSubjectOrder = $event->getSubject()->getOrder();
+            $capturedCart = $event->hasArgument('cart') ? $event->getArgument('cart') : null;
+        });
+
+        $component->removeItem(0);
+
+        // the item is detached from its cart by CartItemRemoveListener, so the subject alone is not enough
+        $this->assertNull($capturedSubjectOrder);
+        $this->assertSame($cart, $capturedCart);
+    }
+
+    #[Test]
+    public function it_passes_the_cleared_cart_id_as_an_argument_of_the_cart_post_clear_event(): void
+    {
+        $cart = $this->createCartWithItem();
+        $cartId = $cart->getId();
+        $component = $this->createComponentForCart($cart);
+
+        $capturedSubjectId = false;
+        $capturedCartId = null;
+
+        $this->listenTo(SyliusCartEvents::CART_POST_CLEAR, function (GenericEvent $event) use (&$capturedSubjectId, &$capturedCartId): void {
+            $capturedSubjectId = $event->getSubject()->getId();
+            $capturedCartId = $event->hasArgument('cartId') ? $event->getArgument('cartId') : null;
+        });
+
+        $component->clearCart();
+
+        // Doctrine resets the identifier of a removed entity on flush, so the subject alone is not enough
+        $this->assertNull($capturedSubjectId);
+        $this->assertSame($cartId, $capturedCartId);
+    }
+
+    private function createCartWithItem(): OrderInterface
+    {
+        $fixtures = $this->loadFixtures([__DIR__ . '/../DataFixtures/ORM/resources/cart.yml']);
+
+        /** @var OrderInterface $cart */
+        $cart = $fixtures['order_001'];
+        /** @var ProductVariantInterface $variant */
+        $variant = $fixtures['mug_sw'];
+
+        $orderItem = new OrderItem();
+        $orderItem->setVariant($variant);
+        $orderItem->setUnitPrice(2000);
+        new OrderItemUnit($orderItem);
+
+        $cart->addItem($orderItem);
+
+        $manager = $this->getManager();
+        $manager->persist($cart);
+        $manager->flush();
+
+        return $cart;
+    }
+
+    private function createComponentForCart(OrderInterface $cart): FormComponent
+    {
+        // the cart form is CSRF-protected, so building its view requires a request with a session
+        $request = new Request();
+        $request->setSession(self::getContainer()->get('session.factory')->createSession());
+        self::getContainer()->get('request_stack')->push($request);
+
+        /** @var FormComponent $component */
+        $component = self::getContainer()->get('sylius_shop.twig.component.cart.form');
+        $component->resource = $cart;
+        $component->initializeForm([]);
+
+        return $component;
+    }
+
+    private function listenTo(string $eventName, callable $listener): void
+    {
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = self::getContainer()->get('event_dispatcher');
+        $dispatcher->addListener($eventName, $listener);
+    }
+
+    private function getManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function loadFixtures(array $fixtureFiles): array
+    {
+        /** @var LoaderInterface $fixtureLoader */
+        $fixtureLoader = self::getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+
+        return $fixtureLoader->load($fixtureFiles, [], [], PurgeMode::createDeleteMode());
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | #19016
| License         | MIT

## Description:                                                                                                                                                                                         
                                                                                                                                                                                                       
  Previously, all events from `SyliusCartEvents` (`sylius.cart_item_add`, `sylius.cart_item_remove`, `sylius.cart_change`, `sylius.cart_clear`) were dispatched exclusively before $manager->flush(). This made  
  it impossible for plugins and custom listeners to react after the cart was actually persisted to the database — for example, sending a cart to a marketing automation service only once it was safely
  stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new post-operation cart lifecycle events that fire after cart changes are saved, after item additions/removals, and after the cart is cleared—providing additional integration points for custom cart-related behavior.
* **Documentation**
  * Updated upgrade notes to list the new event names and include an example listener, clarifying that existing pre-operation events remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->