### PR TITLE
[2.3][Feature] Add independent promotion rules and actions per channel

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -61,6 +61,34 @@
 
    If your application depends on the Gaufrette packages directly, require them explicitly in your `composer.json`.
 
+## Promotion
+
+1. Promotion rules and actions can now be configured **independently per channel**. The feature is additive — existing
+   promotions keep working unchanged — but two core services had their **class swapped** by `OverridePromotionServicesPass`.
+   The service ids, the implemented interfaces and the constructor arguments are **unchanged**:
+
+   | Service id | Old class | New class |
+   |------------|-----------|-----------|
+   | `sylius.checker.promotion.rules_eligibility` | `Sylius\Component\Promotion\Checker\Eligibility\PromotionRulesEligibilityChecker` | `Sylius\Component\Core\Promotion\Checker\Eligibility\ChannelAwarePromotionRulesEligibilityChecker` |
+   | `sylius.action.applicator.promotion` | `Sylius\Component\Promotion\Action\PromotionApplicator` | `Sylius\Component\Core\Promotion\Action\ChannelAwarePromotionApplicator` |
+
+   If you **decorate** these services, no change is required. If you **replaced** their definition or relied on the
+   concrete class (e.g. `instanceof PromotionApplicator`), update your code to the new classes or to the
+   `Sylius\Component\Promotion\Action\PromotionApplicatorInterface` /
+   `Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface` abstractions.
+
+2. A reserved configuration key `_excludedChannels`
+   (`Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY`) may now be
+   present in a promotion rule's or action's `configuration` array. It holds the channel codes for which the rule/action
+   is skipped and is stripped before the configuration reaches the rule checker / action command.
+
+   If you read a promotion rule/action `configuration` directly (custom rule checkers, action commands, serializers,
+   exports), ignore this key — it is not part of a rule/action's own configuration.
+
+3. New `*_per_channel` promotion rule and action types were added (e.g. `cart_quantity_per_channel`,
+   `customer_group_per_channel`, `order_percentage_discount_per_channel`). Their configuration is keyed by channel code,
+   so each channel can have its own values. These are additional types and do not replace the existing ones.
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/features/admin/promotion/managing_promotions/adding_promotion_with_independent_rules_per_channel.feature
+++ b/features/admin/promotion/managing_promotions/adding_promotion_with_independent_rules_per_channel.feature
@@ -1,0 +1,34 @@
+@managing_promotions
+Feature: Adding a new promotion with independent rules configured per channel
+    In order to have complex promotion rules that differ by channel
+    As an Administrator
+    I want to add promotions with independent rules per channel to the registry
+
+    Background:
+        Given the store operates on a channel named "Web-US" in "USD" currency
+        And the store operates on a channel named "Web-GB" in "GBP" currency
+        And I am logged in as an administrator
+
+    @api @ui @mink:chromedriver
+    Scenario: Adding a new promotion with independent item total rules per channel
+        When I want to create a new promotion
+        And I specify its code as "INDEPENDENT_RULES_PROMO"
+        And I name it "Independent Rules Promotion"
+        And I add the "Item total" rule configured with "€100.00" amount for "Web-US" channel
+        And I add the "Item total" rule configured with "£50.00" amount for "Web-GB" channel
+        And I add the "Order fixed discount" action configured with amount of "$10.00" for "Web-US" channel
+        And it is also configured with amount of "£5.00" for "Web-GB" channel
+        And I add it
+        Then the "Independent Rules Promotion" promotion should be successfully created
+
+    @api @ui @mink:chromedriver
+    Scenario: Adding a new promotion with different rule types per channel
+        When I want to create a new promotion
+        And I specify its code as "DIFFERENT_RULE_TYPES"
+        And I name it "Different Rule Types Per Channel"
+        And I add the "Item total" rule configured with "€100.00" amount for "Web-US" channel
+        And I add the "Cart quantity" rule with minimum 2 items for "Web-GB" channel
+        And I add the "Item fixed discount" action configured with amount of "$10.00" for "Web-US" channel
+        And it is also configured with amount of "£5.00" for "Web-GB" channel
+        And I add it
+        Then the "Different Rule Types Per Channel" promotion should be successfully created

--- a/features/shop/promotion/receiving_discount/receiving_discount_with_independent_promotion_rules_per_channel.feature
+++ b/features/shop/promotion/receiving_discount/receiving_discount_with_independent_promotion_rules_per_channel.feature
@@ -1,0 +1,99 @@
+@receiving_discount
+Feature: Receiving discount with independent promotion rules configured per channel
+    In order to pay proper amount while buying promoted goods with different rules per channel
+    As a Customer
+    I want to have promotions with independent rules applied correctly in different channels
+
+    Background:
+        Given the store operates on a channel named "Web-US" in "USD" currency and with hostname "united.states"
+        And the store operates on another channel named "Web-GB" in "GBP" currency and with hostname "great.britain"
+        And the store has a product "PHP T-Shirt" priced at "$100.00" in "Web-US" channel
+        And this product is also priced at "£80.00" in "Web-GB" channel
+        And the store has a product "Symfony T-Shirt" priced at "$60.00" in "Web-US" channel
+        And this product is also priced at "£40.00" in "Web-GB" channel
+        And the store has a product "Golang T-Shirt" priced at "$50.00" in "Web-US" channel
+        And this product is also priced at "£35.00" in "Web-GB" channel
+        And there is a promotion "Holiday promotion"
+        And I am a logged in customer
+
+    @api @ui
+    Scenario: Receiving discount with different total rules per channel
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£5.00" discount to every order in the "Web-GB" channel
+        And this promotion only applies to orders with a total of at least "$100.00" for "Web-US" channel and "$50.00" for "Web-GB" channel
+        When I changed my current channel to "Web-US"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$90.00"
+        And my discount should be "-$10.00"
+
+    @api @ui
+    Scenario: Receiving discount skips rules not configured for current channel
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£5.00" discount to every order in the "Web-GB" channel
+        And this promotion only applies to orders with a total of at least "$100.00" for "Web-US" channel
+        When I changed my current channel to "Web-GB"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£75.00"
+        And my discount should be "-£5.00"
+
+    @api @ui
+    Scenario: Not receiving discount when rule with independent channel configuration is not met
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£5.00" discount to every order in the "Web-GB" channel
+        And this promotion only applies to orders with a total of at least "$100.00" for "Web-US" channel and "$150.00" for "Web-GB" channel
+        When I changed my current channel to "Web-GB"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£80.00"
+        And there should be no discount applied
+
+    @api @ui
+    Scenario: Promotion with different rule types per channel - item total for US, cart quantity for GB
+        Given the promotion has an item total rule for at least "$100.00" in "Web-US" channel
+        And the promotion has a cart quantity rule for at least 2 items in "Web-GB" channel
+        And the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£3.00" discount to every order in the "Web-GB" channel
+        When I changed my current channel to "Web-US"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$90.00"
+        And my discount should be "-$10.00"
+
+    @api @ui
+    Scenario: Promotion with different rule types per channel - Web-GB ignores item total, requires quantity
+        Given the promotion has an item total rule for at least "$100.00" in "Web-US" channel
+        And the promotion has a cart quantity rule for at least 2 items in "Web-GB" channel
+        And the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£3.00" discount to every order in the "Web-GB" channel
+        When I changed my current channel to "Web-GB"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£80.00"
+        And there should be no discount applied
+
+    @api @ui
+    Scenario: Promotion with different rule types per channel - Web-GB accepts with required quantity
+        Given the promotion has an item total rule for at least "$100.00" in "Web-US" channel
+        And the promotion has a cart quantity rule for at least 2 items in "Web-GB" channel
+        And the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£3.00" discount to every order in the "Web-GB" channel
+        When I changed my current channel to "Web-GB"
+        And I added product "Golang T-Shirt" to the cart
+        And I added product "Golang T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£67.00"
+        And my discount should be "-£3.00"
+
+    @api @ui
+    Scenario: Not receiving discount when action is excluded from customer's channel
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel only
+        When I changed my current channel to "Web-GB"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£80.00"
+        And there should be no discount applied
+
+    @api @ui
+    Scenario: Receiving discount when customer's channel matches action configuration
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel only
+        When I changed my current channel to "Web-US"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$90.00"
+        And my discount should be "-$10.00"

--- a/features/shop/promotion/receiving_discount/receiving_discount_with_independent_promotion_rules_per_channel.feature
+++ b/features/shop/promotion/receiving_discount/receiving_discount_with_independent_promotion_rules_per_channel.feature
@@ -81,6 +81,37 @@ Feature: Receiving discount with independent promotion rules configured per chan
         And my discount should be "-£3.00"
 
     @api @ui
+    Scenario: Single per-channel cart quantity rule accepts the order when the channel threshold is met
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£3.00" discount to every order in the "Web-GB" channel
+        And the promotion has a per channel cart quantity rule requiring at least 1 items in "Web-US" channel and 2 items in "Web-GB" channel
+        When I changed my current channel to "Web-US"
+        And I added product "Golang T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$40.00"
+        And my discount should be "-$10.00"
+
+    @api @ui
+    Scenario: Single per-channel cart quantity rule rejects the order when the channel threshold is not met
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£3.00" discount to every order in the "Web-GB" channel
+        And the promotion has a per channel cart quantity rule requiring at least 1 items in "Web-US" channel and 2 items in "Web-GB" channel
+        When I changed my current channel to "Web-GB"
+        And I added product "Golang T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£35.00"
+        And there should be no discount applied
+
+    @api @ui
+    Scenario: Single per-channel cart quantity rule accepts the second channel once its higher threshold is met
+        Given the promotion gives "$10.00" discount to every order in the "Web-US" channel and "£3.00" discount to every order in the "Web-GB" channel
+        And the promotion has a per channel cart quantity rule requiring at least 1 items in "Web-US" channel and 2 items in "Web-GB" channel
+        When I changed my current channel to "Web-GB"
+        And I added product "Golang T-Shirt" to the cart
+        And I added product "Golang T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "£67.00"
+        And my discount should be "-£3.00"
+
+    @api @ui
     Scenario: Not receiving discount when action is excluded from customer's channel
         Given the promotion gives "$10.00" discount to every order in the "Web-US" channel only
         When I changed my current channel to "Web-GB"

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
@@ -834,7 +834,7 @@ final readonly class ManagingPromotionsContext implements Context
     /** @return list<string> */
     private function getExcludedChannelCodes(string $onlyChannelCode): array
     {
-        $all = array_column($this->channelRepository->findAllWithBasicData(), 'code');
+        $all = array_column([...$this->channelRepository->findAllWithBasicData()], 'code');
 
         return array_values(array_filter($all, fn (string $code) => $code !== $onlyChannelCode));
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
@@ -21,6 +21,7 @@ use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Context\Api\Resources;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
@@ -30,6 +31,8 @@ use Sylius\Component\Core\Promotion\Action\PercentageDiscountPromotionActionComm
 use Sylius\Component\Core\Promotion\Action\ShippingPercentageDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Action\UnitFixedDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Action\UnitPercentageDiscountPromotionActionCommand;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Core\Promotion\Checker\Rule\CartQuantityRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\ContainsProductRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\CustomerGroupRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\HasTaxonRuleChecker;
@@ -47,6 +50,7 @@ final readonly class ManagingPromotionsContext implements Context
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
+        private ChannelRepositoryInterface $channelRepository,
     ) {
     }
 
@@ -334,6 +338,36 @@ final readonly class ManagingPromotionsContext implements Context
                 $secondChannel->getCode() => [
                     'amount' => $secondAmount,
                 ],
+            ],
+        );
+    }
+
+    #[When('/^I add the "Item total" rule configured with "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/')]
+    public function iAddTheItemTotalRuleConfiguredWithAmountForChannel(
+        int $amount,
+        ChannelInterface $channel,
+    ): void {
+        $this->appendRuleToRequest(
+            ItemTotalRuleChecker::TYPE,
+            [
+                $channel->getCode() => [
+                    'amount' => $amount,
+                ],
+                ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => $this->getExcludedChannelCodes($channel->getCode()),
+            ],
+        );
+    }
+
+    #[When('/^I add the "Cart quantity" rule with minimum (\d+) items for ("[^"]+" channel)$/')]
+    public function iAddTheCartQuantityRuleWithMinimumItemsForChannel(
+        int $quantity,
+        ChannelInterface $channel,
+    ): void {
+        $this->appendRuleToRequest(
+            CartQuantityRuleChecker::TYPE,
+            [
+                'count' => $quantity,
+                ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => $this->getExcludedChannelCodes($channel->getCode()),
             ],
         );
     }
@@ -784,5 +818,24 @@ final readonly class ManagingPromotionsContext implements Context
         ];
 
         $this->client->updateRequestData($data);
+    }
+
+    private function appendRuleToRequest(string $type, array $configuration): void
+    {
+        $rules = $this->client->getContent()['rules'] ?? [];
+        $rules[] = [
+            'type' => $type,
+            'configuration' => $configuration,
+        ];
+
+        $this->client->addRequestData('rules', $rules);
+    }
+
+    /** @return list<string> */
+    private function getExcludedChannelCodes(string $onlyChannelCode): array
+    {
+        $all = array_column($this->channelRepository->findAllWithBasicData(), 'code');
+
+        return array_values(array_filter($all, fn (string $code) => $code !== $onlyChannelCode));
     }
 }

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -1154,7 +1154,7 @@ final readonly class PromotionContext implements Context
     /** @return list<string> */
     private function getExcludedChannelCodes(string $onlyChannelCode): array
     {
-        $all = array_column($this->channelRepository->findAllWithBasicData(), 'code');
+        $all = array_column([...$this->channelRepository->findAllWithBasicData()], 'code');
 
         return array_values(array_filter($all, fn (string $code) => $code !== $onlyChannelCode));
     }

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -1112,6 +1112,28 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
+    #[Given('/^(the promotion) has a per channel cart quantity rule requiring at least (\d+) items in ("[^"]+" channel) and (\d+) items in ("[^"]+" channel)$/')]
+    public function thePromotionHasAPerChannelCartQuantityRuleRequiringItemsInChannelAndItemsInChannel(
+        PromotionInterface $promotion,
+        int $firstCount,
+        ChannelInterface $firstChannel,
+        int $secondCount,
+        ChannelInterface $secondChannel,
+    ): void {
+        $rule = $this->ruleFactory->createNew();
+        $rule->setType('cart_quantity_per_channel');
+        $rule->setConfiguration([
+            $firstChannel->getCode() => ['count' => $firstCount],
+            $secondChannel->getCode() => ['count' => $secondCount],
+        ]);
+
+        $promotion->addRule($rule);
+        $promotion->addChannel($firstChannel);
+        $promotion->addChannel($secondChannel);
+
+        $this->objectManager->flush();
+    }
+
     #[Given('/^(this promotion) only applies to orders with a total of at least ("[^"]+") for ("[^"]+" channel)$/')]
     public function thisPromotionOnlyAppliesToOrdersWithTotalOfAtLeast(
         PromotionInterface $promotion,

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -19,6 +19,7 @@ use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Factory\PromotionActionFactoryInterface;
 use Sylius\Component\Core\Factory\PromotionRuleFactoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -27,6 +28,7 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\PromotionCouponInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
 use Sylius\Component\Core\Promotion\Checker\Rule\ContainsProductRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\CustomerGroupRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\HasTaxonRuleChecker;
@@ -58,6 +60,7 @@ final readonly class PromotionContext implements Context
         private ObjectManager $objectManager,
         private ExampleFactoryInterface $promotionExampleFactory,
         private MessageBusInterface $commandBus,
+        private ChannelRepositoryInterface $channelRepository,
     ) {
     }
 
@@ -399,6 +402,25 @@ final readonly class PromotionContext implements Context
 
         $promotion->addChannel($firstChannel);
         $promotion->addChannel($secondChannel);
+        $promotion->addAction($action);
+
+        $this->objectManager->flush();
+    }
+
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order in the ("[^"]+" channel) only$/')]
+    public function thisPromotionGivesDiscountToEveryOrderInChannelOnly(
+        PromotionInterface $promotion,
+        int $amount,
+        ChannelInterface $channel,
+    ): void {
+        $action = $this->actionFactory->createFixedDiscount($amount, $channel->getCode());
+        $configuration = $action->getConfiguration();
+        $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $this->getExcludedChannelCodes($channel->getCode());
+        $action->setConfiguration($configuration);
+
+        foreach ($this->channelRepository->findAll() as $ch) {
+            $promotion->addChannel($ch);
+        }
         $promotion->addAction($action);
 
         $this->objectManager->flush();
@@ -872,8 +894,12 @@ final readonly class PromotionContext implements Context
         int $secondAmount,
         ChannelInterface $secondChannel,
     ): void {
-        $promotion->addRule($this->ruleFactory->createItemTotal($firstChannel->getCode(), $firstAmount));
-        $promotion->addRule($this->ruleFactory->createItemTotal($secondChannel->getCode(), $secondAmount));
+        $rule = $this->ruleFactory->createItemTotal($firstChannel->getCode(), $firstAmount);
+        $rule->setConfiguration(array_merge(
+            $rule->getConfiguration(),
+            [$secondChannel->getCode() => ['amount' => $secondAmount]],
+        ));
+        $promotion->addRule($rule);
 
         $this->objectManager->flush();
     }
@@ -1048,5 +1074,66 @@ final readonly class PromotionContext implements Context
     private function getChannelCode(): string
     {
         return $this->sharedStorage->get('channel')->getCode();
+    }
+
+    #[Given('/^(the promotion) has an item total rule for at least ("[^"]+") in ("[^"]+" channel)$/')]
+    public function thePromotionHasAnItemTotalRuleForChannelOnly(
+        PromotionInterface $promotion,
+        int $amount,
+        ChannelInterface $channel,
+    ): void {
+        $rule = $this->ruleFactory->createItemTotal($channel->getCode(), $amount);
+
+        $configuration = $rule->getConfiguration();
+        $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $this->getExcludedChannelCodes($channel->getCode());
+        $rule->setConfiguration($configuration);
+
+        $promotion->addRule($rule);
+        $promotion->addChannel($channel);
+
+        $this->objectManager->flush();
+    }
+
+    #[Given('/^(the promotion) has a cart quantity rule for at least (\d+) items in ("[^"]+" channel)$/')]
+    public function thePromotionHasACartQuantityRuleForChannelOnly(
+        PromotionInterface $promotion,
+        int $count,
+        ChannelInterface $channel,
+    ): void {
+        $rule = $this->ruleFactory->createCartQuantity($count);
+
+        $configuration = $rule->getConfiguration();
+        $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $this->getExcludedChannelCodes($channel->getCode());
+        $rule->setConfiguration($configuration);
+
+        $promotion->addRule($rule);
+        $promotion->addChannel($channel);
+
+        $this->objectManager->flush();
+    }
+
+    #[Given('/^(this promotion) only applies to orders with a total of at least ("[^"]+") for ("[^"]+" channel)$/')]
+    public function thisPromotionOnlyAppliesToOrdersWithTotalOfAtLeast(
+        PromotionInterface $promotion,
+        int $amount,
+        ChannelInterface $channel,
+    ): void {
+        $rule = $this->ruleFactory->createItemTotal($channel->getCode(), $amount);
+        $rule->setConfiguration(array_merge(
+            $rule->getConfiguration(),
+            [ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => $this->getExcludedChannelCodes($channel->getCode())],
+        ));
+        $promotion->addRule($rule);
+        $promotion->addChannel($channel);
+
+        $this->objectManager->flush();
+    }
+
+    /** @return list<string> */
+    private function getExcludedChannelCodes(string $onlyChannelCode): array
+    {
+        $all = array_column($this->channelRepository->findAllWithBasicData(), 'code');
+
+        return array_values(array_filter($all, fn (string $code) => $code !== $onlyChannelCode));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -778,4 +778,22 @@ final class ManagingPromotionsContext implements Context
     {
         return $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
     }
+
+    #[When('/^I add the "Cart quantity" rule with minimum (\d+) items for ("[^"]+" channel)$/')]
+    public function iAddTheCartQuantityRuleWithMinimumItemsForChannel(int $quantity, ChannelInterface $channel): void
+    {
+        $this->formElement->addRule(CartQuantityRuleChecker::TYPE);
+        $this->formElement->fillRuleOption('Count', (string) $quantity);
+        $this->formElement->excludeRuleChannelsExcept($channel->getCode());
+    }
+
+    #[When('/^I add the "Item total" rule configured with "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/')]
+    public function iAddTheItemTotalRuleConfiguredWithAmountForChannel(
+        $amount,
+        ChannelInterface $channel,
+    ): void {
+        $this->formElement->addRule(ItemTotalRuleChecker::TYPE);
+        $this->formElement->fillRuleOptionForChannel($channel->getCode(), 'Amount', $amount);
+        $this->formElement->excludeRuleChannelsExcept($channel->getCode());
+    }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -789,7 +789,7 @@ final class ManagingPromotionsContext implements Context
 
     #[When('/^I add the "Item total" rule configured with "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/')]
     public function iAddTheItemTotalRuleConfiguredWithAmountForChannel(
-        $amount,
+        string $amount,
         ChannelInterface $channel,
     ): void {
         $this->formElement->addRule(ItemTotalRuleChecker::TYPE);

--- a/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
@@ -147,6 +147,25 @@ class FormElement extends BaseFormElement implements FormElementInterface
         $lastRule->fillField($option, $value);
     }
 
+    public function excludeRuleChannelsExcept(string $channelCode): void
+    {
+        while (true) {
+            $lastRule = $this->getLastRule();
+            $toUncheck = null;
+            foreach ($lastRule->findAll('css', 'input[type="checkbox"][id*="__excludedChannels_"]') as $checkbox) {
+                if ($checkbox->getAttribute('value') !== $channelCode && $checkbox->isChecked()) {
+                    $toUncheck = $checkbox;
+                    break;
+                }
+            }
+            if ($toUncheck === null) {
+                break;
+            }
+            $toUncheck->uncheck();
+            $this->waitForFormUpdate();
+        }
+    }
+
     public function selectAutocompleteRuleOptions(array $values, ?string $channelCode = null): void
     {
         $count = count($this->getElement('rules')->findAll('css', '[data-test-entry-row]'));

--- a/src/Sylius/Behat/Element/Admin/Promotion/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Promotion/FormElementInterface.php
@@ -59,6 +59,8 @@ interface FormElementInterface extends BaseFormElementInterface
 
     public function fillRuleOptionForChannel(string $channelCode, string $option, string $value): void;
 
+    public function excludeRuleChannelsExcept(string $channelCode): void;
+
     public function selectAutocompleteRuleOptions(array $values, ?string $channelCode = null): void;
 
     public function selectAutocompleteActionFilterOptions(array $values, string $channelCode, string $filterType): void;

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/admin.php
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/admin.php
@@ -388,6 +388,7 @@ return static function (ContainerConfigurator $container) {
             service('sylius.behat.api_platform_client.admin'),
             service(ResponseCheckerInterface::class),
             service('api_platform.iri_converter'),
+            service('sylius.repository.channel'),
         ])
     ;
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.php
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.php
@@ -362,6 +362,7 @@ return static function (ContainerConfigurator $container) {
             service('doctrine.orm.entity_manager'),
             service('sylius.fixture.example_factory.promotion'),
             service('sylius.command_bus'),
+            service('sylius.repository.channel'),
         ])
     ;
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Builder/ChannelExclusionFormBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Builder/ChannelExclusionFormBuilder.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Builder;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Model\ConfigurablePromotionElementInterface;
+use Sylius\Component\Promotion\Model\PromotionActionInterface;
+use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+final readonly class ChannelExclusionFormBuilder
+{
+    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    {
+    }
+
+    /**
+     * @param class-string<ConfigurablePromotionElementInterface> $subjectClass
+     */
+    public function build(FormBuilderInterface $builder, string $label, string $subjectClass): void
+    {
+        $builder->add('type', HiddenType::class);
+
+        $choices = [];
+        foreach ($this->channelRepository->findAll() as $channel) {
+            $choices[$channel->getName()] = $channel->getCode();
+        }
+        $availableCodes = array_values($choices);
+
+        $builder->add(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
+            'label' => $label,
+            'choices' => $choices,
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false,
+            'choice_translation_domain' => false,
+            'mapped' => false,
+        ]);
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes, $subjectClass): void {
+            $data = $event->getData();
+            if (!$data instanceof $subjectClass) {
+                $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
+                    ->setData($availableCodes);
+
+                return;
+            }
+            $excludedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
+            $checkedCodes = $excludedCodes === [] ? $availableCodes : array_values(array_diff($availableCodes, $excludedCodes));
+            $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
+                ->setData($checkedCodes);
+        });
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($availableCodes, $subjectClass): void {
+            $data = $event->getData();
+            $entityData = $event->getForm()->getData();
+            if (is_array($data) &&
+                !array_key_exists(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, $data) &&
+                !$entityData instanceof $subjectClass) {
+                $data[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $availableCodes;
+                $event->setData($data);
+            }
+        });
+
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes, $subjectClass): void {
+            $data = $event->getData();
+            if (!$data instanceof $subjectClass) {
+                return;
+            }
+
+            \assert($data instanceof PromotionActionInterface || $data instanceof PromotionRuleInterface);
+
+            $configuration = $data->getConfiguration();
+            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] =
+                array_values(array_diff($availableCodes, $selectedChannels));
+            $data->setConfiguration($configuration);
+        });
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
@@ -13,79 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
 
+use Sylius\Bundle\AdminBundle\Form\Builder\ChannelExclusionFormBuilder;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionActionType;
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
 use Sylius\Component\Promotion\Model\PromotionActionInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 
 final class PromotionActionTypeExtension extends AbstractTypeExtension
 {
-    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    public function __construct(private ?ChannelExclusionFormBuilder $channelExclusionFormBuilder = null)
     {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('type', HiddenType::class);
-
-        $choices = [];
-        foreach ($this->channelRepository->findAll() as $channel) {
-            $choices[$channel->getName()] = $channel->getCode();
-        }
-        $availableCodes = array_values($choices);
-
-        $builder->add(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
-            'label' => 'sylius.form.promotion_action.channels',
-            'choices' => $choices,
-            'multiple' => true,
-            'expanded' => true,
-            'required' => false,
-            'choice_translation_domain' => false,
-            'mapped' => false,
-        ]);
-
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes): void {
-            $data = $event->getData();
-            if (!$data instanceof PromotionActionInterface) {
-                $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
-                    ->setData($availableCodes);
-
-                return;
-            }
-            $excludedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
-            $checkedCodes = $excludedCodes === [] ? $availableCodes : array_values(array_diff($availableCodes, $excludedCodes));
-            $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
-                ->setData($checkedCodes);
-        });
-
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($availableCodes): void {
-            $data = $event->getData();
-            $entityData = $event->getForm()->getData();
-            if (is_array($data)
-                && !array_key_exists(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, $data)
-                && !$entityData instanceof PromotionActionInterface) {
-                $data[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $availableCodes;
-                $event->setData($data);
-            }
-        });
-
-        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes): void {
-            $data = $event->getData();
-            if (!$data instanceof PromotionActionInterface) {
-                return;
-            }
-            $configuration = $data->getConfiguration();
-            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
-            $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] =
-                array_values(array_diff($availableCodes, $selectedChannels));
-            $data->setConfiguration($configuration);
-        });
+        $this->channelExclusionFormBuilder?->build(
+            $builder,
+            'sylius.form.promotion_action.channels',
+            PromotionActionInterface::class,
+        );
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
@@ -56,18 +56,26 @@ final class PromotionActionTypeExtension extends AbstractTypeExtension
                 return;
             }
             $storedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
+            if ($storedCodes === []) {
+                $storedCodes = $availableCodes;
+            }
             $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)
                 ->setData(array_values(array_intersect($storedCodes, $availableCodes)));
         });
 
-        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes): void {
             $data = $event->getData();
             if (!$data instanceof PromotionActionInterface) {
                 return;
             }
             $configuration = $data->getConfiguration();
+            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $sortedSelected = $selectedChannels;
+            $sortedAvailable = $availableCodes;
+            sort($sortedSelected);
+            sort($sortedAvailable);
             $configuration[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] =
-                $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+                ($sortedSelected === $sortedAvailable) ? [] : $selectedChannels;
             $data->setConfiguration($configuration);
         });
     }

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
@@ -14,15 +14,62 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
 
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionActionType;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Model\PromotionActionInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 final class PromotionActionTypeExtension extends AbstractTypeExtension
 {
+    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('type', HiddenType::class);
+
+        $choices = [];
+        foreach ($this->channelRepository->findAll() as $channel) {
+            $choices[$channel->getName()] = $channel->getCode();
+        }
+        $availableCodes = array_values($choices);
+
+        $builder->add(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
+            'label' => 'sylius.form.promotion_action.channels',
+            'choices' => $choices,
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false,
+            'choice_translation_domain' => false,
+            'mapped' => false,
+        ]);
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes): void {
+            $data = $event->getData();
+            if (!$data instanceof PromotionActionInterface) {
+                return;
+            }
+            $storedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
+            $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)
+                ->setData(array_values(array_intersect($storedCodes, $availableCodes)));
+        });
+
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            if (!$data instanceof PromotionActionInterface) {
+                return;
+            }
+            $configuration = $data->getConfiguration();
+            $configuration[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] =
+                $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $data->setConfiguration($configuration);
+        });
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionActionTypeExtension.php
@@ -40,7 +40,7 @@ final class PromotionActionTypeExtension extends AbstractTypeExtension
         }
         $availableCodes = array_values($choices);
 
-        $builder->add(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
+        $builder->add(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
             'label' => 'sylius.form.promotion_action.channels',
             'choices' => $choices,
             'multiple' => true,
@@ -53,14 +53,26 @@ final class PromotionActionTypeExtension extends AbstractTypeExtension
         $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes): void {
             $data = $event->getData();
             if (!$data instanceof PromotionActionInterface) {
+                $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
+                    ->setData($availableCodes);
+
                 return;
             }
-            $storedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
-            if ($storedCodes === []) {
-                $storedCodes = $availableCodes;
+            $excludedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
+            $checkedCodes = $excludedCodes === [] ? $availableCodes : array_values(array_diff($availableCodes, $excludedCodes));
+            $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
+                ->setData($checkedCodes);
+        });
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($availableCodes): void {
+            $data = $event->getData();
+            $entityData = $event->getForm()->getData();
+            if (is_array($data)
+                && !array_key_exists(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, $data)
+                && !$entityData instanceof PromotionActionInterface) {
+                $data[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $availableCodes;
+                $event->setData($data);
             }
-            $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)
-                ->setData(array_values(array_intersect($storedCodes, $availableCodes)));
         });
 
         $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes): void {
@@ -69,13 +81,9 @@ final class PromotionActionTypeExtension extends AbstractTypeExtension
                 return;
             }
             $configuration = $data->getConfiguration();
-            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
-            $sortedSelected = $selectedChannels;
-            $sortedAvailable = $availableCodes;
-            sort($sortedSelected);
-            sort($sortedAvailable);
-            $configuration[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] =
-                ($sortedSelected === $sortedAvailable) ? [] : $selectedChannels;
+            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] =
+                array_values(array_diff($availableCodes, $selectedChannels));
             $data->setConfiguration($configuration);
         });
     }

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
@@ -13,79 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
 
+use Sylius\Bundle\AdminBundle\Form\Builder\ChannelExclusionFormBuilder;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionRuleType;
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
 use Sylius\Component\Promotion\Model\PromotionRuleInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 
 final class PromotionRuleTypeExtension extends AbstractTypeExtension
 {
-    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    public function __construct(private ?ChannelExclusionFormBuilder $channelExclusionFormBuilder = null)
     {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('type', HiddenType::class);
-
-        $choices = [];
-        foreach ($this->channelRepository->findAll() as $channel) {
-            $choices[$channel->getName()] = $channel->getCode();
-        }
-        $availableCodes = array_values($choices);
-
-        $builder->add(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
-            'label' => 'sylius.form.promotion_rule.channels',
-            'choices' => $choices,
-            'multiple' => true,
-            'expanded' => true,
-            'required' => false,
-            'choice_translation_domain' => false,
-            'mapped' => false,
-        ]);
-
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes): void {
-            $data = $event->getData();
-            if (!$data instanceof PromotionRuleInterface) {
-                $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
-                    ->setData($availableCodes);
-
-                return;
-            }
-            $excludedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
-            $checkedCodes = $excludedCodes === [] ? $availableCodes : array_values(array_diff($availableCodes, $excludedCodes));
-            $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
-                ->setData($checkedCodes);
-        });
-
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($availableCodes): void {
-            $data = $event->getData();
-            $entityData = $event->getForm()->getData();
-            if (is_array($data)
-                && !array_key_exists(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, $data)
-                && !$entityData instanceof PromotionRuleInterface) {
-                $data[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $availableCodes;
-                $event->setData($data);
-            }
-        });
-
-        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes): void {
-            $data = $event->getData();
-            if (!$data instanceof PromotionRuleInterface) {
-                return;
-            }
-            $configuration = $data->getConfiguration();
-            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
-            $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] =
-                array_values(array_diff($availableCodes, $selectedChannels));
-            $data->setConfiguration($configuration);
-        });
+        $this->channelExclusionFormBuilder?->build(
+            $builder,
+            'sylius.form.promotion_rule.channels',
+            PromotionRuleInterface::class,
+        );
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
@@ -40,7 +40,7 @@ final class PromotionRuleTypeExtension extends AbstractTypeExtension
         }
         $availableCodes = array_values($choices);
 
-        $builder->add(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
+        $builder->add(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
             'label' => 'sylius.form.promotion_rule.channels',
             'choices' => $choices,
             'multiple' => true,
@@ -53,14 +53,26 @@ final class PromotionRuleTypeExtension extends AbstractTypeExtension
         $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes): void {
             $data = $event->getData();
             if (!$data instanceof PromotionRuleInterface) {
+                $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
+                    ->setData($availableCodes);
+
                 return;
             }
-            $storedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
-            if ($storedCodes === []) {
-                $storedCodes = $availableCodes;
+            $excludedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
+            $checkedCodes = $excludedCodes === [] ? $availableCodes : array_values(array_diff($availableCodes, $excludedCodes));
+            $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)
+                ->setData($checkedCodes);
+        });
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($availableCodes): void {
+            $data = $event->getData();
+            $entityData = $event->getForm()->getData();
+            if (is_array($data)
+                && !array_key_exists(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY, $data)
+                && !$entityData instanceof PromotionRuleInterface) {
+                $data[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] = $availableCodes;
+                $event->setData($data);
             }
-            $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)
-                ->setData(array_values(array_intersect($storedCodes, $availableCodes)));
         });
 
         $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes): void {
@@ -69,13 +81,9 @@ final class PromotionRuleTypeExtension extends AbstractTypeExtension
                 return;
             }
             $configuration = $data->getConfiguration();
-            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
-            $sortedSelected = $selectedChannels;
-            $sortedAvailable = $availableCodes;
-            sort($sortedSelected);
-            sort($sortedAvailable);
-            $configuration[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] =
-                ($sortedSelected === $sortedAvailable) ? [] : $selectedChannels;
+            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $configuration[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] =
+                array_values(array_diff($availableCodes, $selectedChannels));
             $data->setConfiguration($configuration);
         });
     }

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
@@ -14,15 +14,62 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
 
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionRuleType;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Model\PromotionRuleInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 final class PromotionRuleTypeExtension extends AbstractTypeExtension
 {
+    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('type', HiddenType::class);
+
+        $choices = [];
+        foreach ($this->channelRepository->findAll() as $channel) {
+            $choices[$channel->getName()] = $channel->getCode();
+        }
+        $availableCodes = array_values($choices);
+
+        $builder->add(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY, ChoiceType::class, [
+            'label' => 'sylius.form.promotion_rule.channels',
+            'choices' => $choices,
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false,
+            'choice_translation_domain' => false,
+            'mapped' => false,
+        ]);
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($availableCodes): void {
+            $data = $event->getData();
+            if (!$data instanceof PromotionRuleInterface) {
+                return;
+            }
+            $storedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
+            $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)
+                ->setData(array_values(array_intersect($storedCodes, $availableCodes)));
+        });
+
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            if (!$data instanceof PromotionRuleInterface) {
+                return;
+            }
+            $configuration = $data->getConfiguration();
+            $configuration[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] =
+                $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $data->setConfiguration($configuration);
+        });
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/Promotion/PromotionRuleTypeExtension.php
@@ -56,18 +56,26 @@ final class PromotionRuleTypeExtension extends AbstractTypeExtension
                 return;
             }
             $storedCodes = $data->getConfiguration()[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
+            if ($storedCodes === []) {
+                $storedCodes = $availableCodes;
+            }
             $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)
                 ->setData(array_values(array_intersect($storedCodes, $availableCodes)));
         });
 
-        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($availableCodes): void {
             $data = $event->getData();
             if (!$data instanceof PromotionRuleInterface) {
                 return;
             }
             $configuration = $data->getConfiguration();
+            $selectedChannels = $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+            $sortedSelected = $selectedChannels;
+            $sortedAvailable = $availableCodes;
+            sort($sortedSelected);
+            sort($sortedAvailable);
             $configuration[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] =
-                $event->getForm()->get(ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY)->getData() ?? [];
+                ($sortedSelected === $sortedAvailable) ? [] : $selectedChannels;
             $data->setConfiguration($configuration);
         });
     }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Sylius\Bundle\AdminBundle\Form\Builder\ChannelExclusionFormBuilder;
 use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\Action\ProductFilterConfigurationTypeExtension;
 use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\Action\TaxonFilterConfigurationTypeExtension;
 use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\PromotionActionTypeExtension;
@@ -112,8 +113,13 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
-        ->set('sylius_admin.form.extension.type.promotion.promotion_action', PromotionActionTypeExtension::class)
+        ->set('sylius_admin.form.builder.channel_exclusion', ChannelExclusionFormBuilder::class)
         ->args([service('sylius.repository.channel')])
+    ;
+
+    $services
+        ->set('sylius_admin.form.extension.type.promotion.promotion_action', PromotionActionTypeExtension::class)
+        ->args([service('sylius_admin.form.builder.channel_exclusion')])
         ->tag('form.type_extension')
     ;
 
@@ -131,7 +137,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius_admin.form.extension.type.promotion.promotion_rule', PromotionRuleTypeExtension::class)
-        ->args([service('sylius.repository.channel')])
+        ->args([service('sylius_admin.form.builder.channel_exclusion')])
         ->tag('form.type_extension')
     ;
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.php
@@ -113,6 +113,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius_admin.form.extension.type.promotion.promotion_action', PromotionActionTypeExtension::class)
+        ->args([service('sylius.repository.channel')])
         ->tag('form.type_extension')
     ;
 
@@ -130,6 +131,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius_admin.form.extension.type.promotion.promotion_rule', PromotionRuleTypeExtension::class)
+        ->args([service('sylius.repository.channel')])
         ->tag('form.type_extension')
     ;
 

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/form_theme.html.twig
@@ -19,7 +19,7 @@
             </div>
             <div class="flex-grow-1">
                 {{- form_row(form.configuration, {'label': false}) -}}
-                {{- form_row(form._channels) -}}
+                {{- form_row(form._excludedChannels) -}}
             </div>
         </div>
     </div>
@@ -36,7 +36,7 @@
             </div>
             <div class="flex-grow-1">
                 {{- form_row(form.configuration, {'label': false}) -}}
-                {{- form_row(form._channels) -}}
+                {{- form_row(form._excludedChannels) -}}
             </div>
         </div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/form_theme.html.twig
@@ -19,6 +19,7 @@
             </div>
             <div class="flex-grow-1">
                 {{- form_row(form.configuration, {'label': false}) -}}
+                {{- form_row(form._channels) -}}
             </div>
         </div>
     </div>
@@ -35,6 +36,7 @@
             </div>
             <div class="flex-grow-1">
                 {{- form_row(form.configuration, {'label': false}) -}}
+                {{- form_row(form._channels) -}}
             </div>
         </div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/tests/Form/Builder/ChannelExclusionFormBuilderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Form/Builder/ChannelExclusionFormBuilderTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\AdminBundle\Form\Builder;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Form\Builder\ChannelExclusionFormBuilder;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+
+#[CoversClass(ChannelExclusionFormBuilder::class)]
+final class ChannelExclusionFormBuilderTest extends TestCase
+{
+    private const KEY = ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY;
+
+    private const LABEL = 'sylius.form.promotion_rule.channels';
+
+    private ChannelRepositoryInterface&MockObject $channelRepository;
+
+    /** @var array<string, callable> */
+    private array $listeners = [];
+
+    protected function setUp(): void
+    {
+        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+
+        $webChannel = $this->createMock(ChannelInterface::class);
+        $webChannel->method('getName')->willReturn('Web');
+        $webChannel->method('getCode')->willReturn('WEB');
+
+        $mobileChannel = $this->createMock(ChannelInterface::class);
+        $mobileChannel->method('getName')->willReturn('Mobile');
+        $mobileChannel->method('getCode')->willReturn('MOBILE');
+
+        $this->channelRepository->method('findAll')->willReturn([$webChannel, $mobileChannel]);
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->method('add')->willReturnSelf();
+        $builder->method('addEventListener')->willReturnCallback(
+            function (string $event, callable $listener): FormBuilderInterface {
+                $this->listeners[$event] = $listener;
+
+                return $this->createMock(FormBuilderInterface::class);
+            },
+        );
+
+        (new ChannelExclusionFormBuilder($this->channelRepository))
+            ->build($builder, self::LABEL, PromotionRuleInterface::class);
+    }
+
+    public function testPreSubmitInjectsDefaultChannelsForNewItem(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'item_total']);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->once())->method('setData')->with([
+            'type' => 'item_total',
+            self::KEY => ['WEB', 'MOBILE'],
+        ]);
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNotInjectForExistingItemWithNoKeyPresent(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn($rule);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'item_total']);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNotInjectWhenKeyAlreadyPresent(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'item_total', self::KEY => ['WEB']]);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNothingForNonArrayData(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPostSetDataSetsAllChannelsCheckedForNewItem(): void
+    {
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testPostSetDataSetsAllChannelsCheckedWhenNoExclusions(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([self::KEY => []]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testPostSetDataSetsOnlyNonExcludedChannelsChecked(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([self::KEY => ['MOBILE']]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testSubmitComputesExcludedChannelsFromSelectedChannels(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([]);
+        $rule->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => ['MOBILE'],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn(['WEB']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitStoresEmptyExclusionsWhenAllChannelsSelected(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([]);
+        $rule->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => [],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitStoresAllChannelsExcludedWhenNoneSelected(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([]);
+        $rule->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => ['WEB', 'MOBILE'],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn([]);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitDoesNothingForNonSubjectData(): void
+    {
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->expects($this->never())->method('getForm');
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionActionTypeExtensionTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionActionTypeExtensionTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\PromotionActionTypeExtension;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Model\PromotionActionInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+
+#[CoversClass(PromotionActionTypeExtension::class)]
+final class PromotionActionTypeExtensionTest extends TestCase
+{
+    private const KEY = ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY;
+
+    private ChannelRepositoryInterface&MockObject $channelRepository;
+
+    private PromotionActionTypeExtension $extension;
+
+    /** @var array<string, callable> */
+    private array $listeners = [];
+
+    protected function setUp(): void
+    {
+        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+
+        $webChannel = $this->createMock(ChannelInterface::class);
+        $webChannel->method('getName')->willReturn('Web');
+        $webChannel->method('getCode')->willReturn('WEB');
+
+        $mobileChannel = $this->createMock(ChannelInterface::class);
+        $mobileChannel->method('getName')->willReturn('Mobile');
+        $mobileChannel->method('getCode')->willReturn('MOBILE');
+
+        $this->channelRepository->method('findAll')->willReturn([$webChannel, $mobileChannel]);
+
+        $this->extension = new PromotionActionTypeExtension($this->channelRepository);
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->method('add')->willReturnSelf();
+        $builder->method('addEventListener')->willReturnCallback(
+            function (string $event, callable $listener): FormBuilderInterface {
+                $this->listeners[$event] = $listener;
+
+                return $this->createMock(FormBuilderInterface::class);
+            },
+        );
+
+        $this->extension->buildForm($builder, []);
+    }
+
+    public function testPreSubmitInjectsDefaultChannelsForNewAction(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'order_percentage_discount']);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->once())->method('setData')->with([
+            'type' => 'order_percentage_discount',
+            self::KEY => ['WEB', 'MOBILE'],
+        ]);
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNotInjectForExistingActionWithNoKeyPresent(): void
+    {
+        $action = $this->createMock(PromotionActionInterface::class);
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn($action);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'order_percentage_discount']);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNotInjectWhenKeyAlreadyPresent(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'order_percentage_discount', self::KEY => ['WEB']]);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPostSetDataSetsAllChannelsCheckedForNewAction(): void
+    {
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testPostSetDataSetsAllChannelsCheckedWhenNoExclusions(): void
+    {
+        $action = $this->createMock(PromotionActionInterface::class);
+        $action->method('getConfiguration')->willReturn([self::KEY => []]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($action);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testPostSetDataSetsOnlyNonExcludedChannelsChecked(): void
+    {
+        $action = $this->createMock(PromotionActionInterface::class);
+        $action->method('getConfiguration')->willReturn([self::KEY => ['MOBILE']]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($action);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testSubmitComputesExcludedChannelsFromSelectedChannels(): void
+    {
+        $action = $this->createMock(PromotionActionInterface::class);
+        $action->method('getConfiguration')->willReturn([]);
+        $action->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => ['MOBILE'],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn(['WEB']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($action);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitStoresEmptyExclusionsWhenAllChannelsSelected(): void
+    {
+        $action = $this->createMock(PromotionActionInterface::class);
+        $action->method('getConfiguration')->willReturn([]);
+        $action->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => [],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($action);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitStoresAllChannelsExcludedWhenNoneSelected(): void
+    {
+        $action = $this->createMock(PromotionActionInterface::class);
+        $action->method('getConfiguration')->willReturn([]);
+        $action->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => ['WEB', 'MOBILE'],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn([]);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($action);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitDoesNothingForNonActionData(): void
+    {
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->expects($this->never())->method('getForm');
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionActionTypeExtensionTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionActionTypeExtensionTest.php
@@ -14,222 +14,40 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Form\Builder\ChannelExclusionFormBuilder;
 use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\PromotionActionTypeExtension;
-use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionActionType;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
-use Sylius\Component\Promotion\Model\PromotionActionInterface;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormInterface;
 
 #[CoversClass(PromotionActionTypeExtension::class)]
 final class PromotionActionTypeExtensionTest extends TestCase
 {
-    private const KEY = ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY;
-
-    private ChannelRepositoryInterface&MockObject $channelRepository;
-
-    private PromotionActionTypeExtension $extension;
-
-    /** @var array<string, callable> */
-    private array $listeners = [];
-
-    protected function setUp(): void
+    public function testItExtendsPromotionActionType(): void
     {
-        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+        $this->assertSame([PromotionActionType::class], iterator_to_array(PromotionActionTypeExtension::getExtendedTypes()));
+    }
 
-        $webChannel = $this->createMock(ChannelInterface::class);
-        $webChannel->method('getName')->willReturn('Web');
-        $webChannel->method('getCode')->willReturn('WEB');
-
-        $mobileChannel = $this->createMock(ChannelInterface::class);
-        $mobileChannel->method('getName')->willReturn('Mobile');
-        $mobileChannel->method('getCode')->willReturn('MOBILE');
-
-        $this->channelRepository->method('findAll')->willReturn([$webChannel, $mobileChannel]);
-
-        $this->extension = new PromotionActionTypeExtension($this->channelRepository);
+    public function testItDelegatesFormBuildingToChannelExclusionFormBuilder(): void
+    {
+        $channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+        $channelRepository->method('findAll')->willReturn([]);
 
         $builder = $this->createMock(FormBuilderInterface::class);
         $builder->method('add')->willReturnSelf();
-        $builder->method('addEventListener')->willReturnCallback(
-            function (string $event, callable $listener): FormBuilderInterface {
-                $this->listeners[$event] = $listener;
+        $builder->expects($this->atLeastOnce())->method('addEventListener')->willReturnSelf();
 
-                return $this->createMock(FormBuilderInterface::class);
-            },
-        );
-
-        $this->extension->buildForm($builder, []);
+        (new PromotionActionTypeExtension(new ChannelExclusionFormBuilder($channelRepository)))
+            ->buildForm($builder, []);
     }
 
-    public function testPreSubmitInjectsDefaultChannelsForNewAction(): void
+    public function testItDoesNothingWhenNoChannelExclusionFormBuilderIsInjected(): void
     {
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn(null);
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->expects($this->never())->method('add');
+        $builder->expects($this->never())->method('addEventListener');
 
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(['type' => 'order_percentage_discount']);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->once())->method('setData')->with([
-            'type' => 'order_percentage_discount',
-            self::KEY => ['WEB', 'MOBILE'],
-        ]);
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPreSubmitDoesNotInjectForExistingActionWithNoKeyPresent(): void
-    {
-        $action = $this->createMock(PromotionActionInterface::class);
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn($action);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(['type' => 'order_percentage_discount']);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->never())->method('setData');
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPreSubmitDoesNotInjectWhenKeyAlreadyPresent(): void
-    {
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn(null);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(['type' => 'order_percentage_discount', self::KEY => ['WEB']]);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->never())->method('setData');
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPostSetDataSetsAllChannelsCheckedForNewAction(): void
-    {
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(null);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::POST_SET_DATA])($event);
-    }
-
-    public function testPostSetDataSetsAllChannelsCheckedWhenNoExclusions(): void
-    {
-        $action = $this->createMock(PromotionActionInterface::class);
-        $action->method('getConfiguration')->willReturn([self::KEY => []]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($action);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::POST_SET_DATA])($event);
-    }
-
-    public function testPostSetDataSetsOnlyNonExcludedChannelsChecked(): void
-    {
-        $action = $this->createMock(PromotionActionInterface::class);
-        $action->method('getConfiguration')->willReturn([self::KEY => ['MOBILE']]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->expects($this->once())->method('setData')->with(['WEB']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($action);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::POST_SET_DATA])($event);
-    }
-
-    public function testSubmitComputesExcludedChannelsFromSelectedChannels(): void
-    {
-        $action = $this->createMock(PromotionActionInterface::class);
-        $action->method('getConfiguration')->willReturn([]);
-        $action->expects($this->once())->method('setConfiguration')->with([
-            self::KEY => ['MOBILE'],
-        ]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->method('getData')->willReturn(['WEB']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($action);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
-    }
-
-    public function testSubmitStoresEmptyExclusionsWhenAllChannelsSelected(): void
-    {
-        $action = $this->createMock(PromotionActionInterface::class);
-        $action->method('getConfiguration')->willReturn([]);
-        $action->expects($this->once())->method('setConfiguration')->with([
-            self::KEY => [],
-        ]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->method('getData')->willReturn(['WEB', 'MOBILE']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($action);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
-    }
-
-    public function testSubmitStoresAllChannelsExcludedWhenNoneSelected(): void
-    {
-        $action = $this->createMock(PromotionActionInterface::class);
-        $action->method('getConfiguration')->willReturn([]);
-        $action->expects($this->once())->method('setConfiguration')->with([
-            self::KEY => ['WEB', 'MOBILE'],
-        ]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->method('getData')->willReturn([]);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($action);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
-    }
-
-    public function testSubmitDoesNothingForNonActionData(): void
-    {
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(null);
-        $event->expects($this->never())->method('getForm');
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
+        (new PromotionActionTypeExtension())->buildForm($builder, []);
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionRuleTypeExtensionTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionRuleTypeExtensionTest.php
@@ -14,235 +14,40 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Form\Builder\ChannelExclusionFormBuilder;
 use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\PromotionRuleTypeExtension;
-use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionRuleType;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
-use Sylius\Component\Promotion\Model\PromotionRuleInterface;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormInterface;
 
 #[CoversClass(PromotionRuleTypeExtension::class)]
 final class PromotionRuleTypeExtensionTest extends TestCase
 {
-    private const KEY = ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY;
-
-    private ChannelRepositoryInterface&MockObject $channelRepository;
-
-    private PromotionRuleTypeExtension $extension;
-
-    /** @var array<string, callable> */
-    private array $listeners = [];
-
-    protected function setUp(): void
+    public function testItExtendsPromotionRuleType(): void
     {
-        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+        $this->assertSame([PromotionRuleType::class], iterator_to_array(PromotionRuleTypeExtension::getExtendedTypes()));
+    }
 
-        $webChannel = $this->createMock(ChannelInterface::class);
-        $webChannel->method('getName')->willReturn('Web');
-        $webChannel->method('getCode')->willReturn('WEB');
-
-        $mobileChannel = $this->createMock(ChannelInterface::class);
-        $mobileChannel->method('getName')->willReturn('Mobile');
-        $mobileChannel->method('getCode')->willReturn('MOBILE');
-
-        $this->channelRepository->method('findAll')->willReturn([$webChannel, $mobileChannel]);
-
-        $this->extension = new PromotionRuleTypeExtension($this->channelRepository);
+    public function testItDelegatesFormBuildingToChannelExclusionFormBuilder(): void
+    {
+        $channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+        $channelRepository->method('findAll')->willReturn([]);
 
         $builder = $this->createMock(FormBuilderInterface::class);
         $builder->method('add')->willReturnSelf();
-        $builder->method('addEventListener')->willReturnCallback(
-            function (string $event, callable $listener): FormBuilderInterface {
-                $this->listeners[$event] = $listener;
+        $builder->expects($this->atLeastOnce())->method('addEventListener')->willReturnSelf();
 
-                return $this->createMock(FormBuilderInterface::class);
-            },
-        );
-
-        $this->extension->buildForm($builder, []);
+        (new PromotionRuleTypeExtension(new ChannelExclusionFormBuilder($channelRepository)))
+            ->buildForm($builder, []);
     }
 
-    public function testPreSubmitInjectsDefaultChannelsForNewItem(): void
+    public function testItDoesNothingWhenNoChannelExclusionFormBuilderIsInjected(): void
     {
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn(null);
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->expects($this->never())->method('add');
+        $builder->expects($this->never())->method('addEventListener');
 
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(['type' => 'item_total']);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->once())->method('setData')->with([
-            'type' => 'item_total',
-            self::KEY => ['WEB', 'MOBILE'],
-        ]);
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPreSubmitDoesNotInjectForExistingRuleWithNoKeyPresent(): void
-    {
-        $rule = $this->createMock(PromotionRuleInterface::class);
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn($rule);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(['type' => 'item_total']);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->never())->method('setData');
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPreSubmitDoesNotInjectWhenKeyAlreadyPresent(): void
-    {
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn(null);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(['type' => 'item_total', self::KEY => ['WEB']]);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->never())->method('setData');
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPreSubmitDoesNothingForNonArrayData(): void
-    {
-        $innerForm = $this->createMock(FormInterface::class);
-        $innerForm->method('getData')->willReturn(null);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(null);
-        $event->method('getForm')->willReturn($innerForm);
-        $event->expects($this->never())->method('setData');
-
-        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
-    }
-
-    public function testPostSetDataSetsAllChannelsCheckedForNewRule(): void
-    {
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(null);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::POST_SET_DATA])($event);
-    }
-
-    public function testPostSetDataSetsAllChannelsCheckedWhenNoExclusions(): void
-    {
-        $rule = $this->createMock(PromotionRuleInterface::class);
-        $rule->method('getConfiguration')->willReturn([self::KEY => []]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($rule);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::POST_SET_DATA])($event);
-    }
-
-    public function testPostSetDataSetsOnlyNonExcludedChannelsChecked(): void
-    {
-        $rule = $this->createMock(PromotionRuleInterface::class);
-        $rule->method('getConfiguration')->willReturn([self::KEY => ['MOBILE']]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->expects($this->once())->method('setData')->with(['WEB']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($rule);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::POST_SET_DATA])($event);
-    }
-
-    public function testSubmitComputesExcludedChannelsFromSelectedChannels(): void
-    {
-        $rule = $this->createMock(PromotionRuleInterface::class);
-        $rule->method('getConfiguration')->willReturn([]);
-        $rule->expects($this->once())->method('setConfiguration')->with([
-            self::KEY => ['MOBILE'],
-        ]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->method('getData')->willReturn(['WEB']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($rule);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
-    }
-
-    public function testSubmitStoresEmptyExclusionsWhenAllChannelsSelected(): void
-    {
-        $rule = $this->createMock(PromotionRuleInterface::class);
-        $rule->method('getConfiguration')->willReturn([]);
-        $rule->expects($this->once())->method('setConfiguration')->with([
-            self::KEY => [],
-        ]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->method('getData')->willReturn(['WEB', 'MOBILE']);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($rule);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
-    }
-
-    public function testSubmitStoresAllChannelsExcludedWhenNoneSelected(): void
-    {
-        $rule = $this->createMock(PromotionRuleInterface::class);
-        $rule->method('getConfiguration')->willReturn([]);
-        $rule->expects($this->once())->method('setConfiguration')->with([
-            self::KEY => ['WEB', 'MOBILE'],
-        ]);
-
-        $channelField = $this->createMock(FormInterface::class);
-        $channelField->method('getData')->willReturn([]);
-
-        $form = $this->createMock(FormInterface::class);
-        $form->method('get')->with(self::KEY)->willReturn($channelField);
-
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn($rule);
-        $event->method('getForm')->willReturn($form);
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
-    }
-
-    public function testSubmitDoesNothingForNonRuleData(): void
-    {
-        $event = $this->createMock(FormEvent::class);
-        $event->method('getData')->willReturn(null);
-        $event->expects($this->never())->method('getForm');
-
-        ($this->listeners[FormEvents::SUBMIT])($event);
+        (new PromotionRuleTypeExtension())->buildForm($builder, []);
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionRuleTypeExtensionTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Form/Extension/Promotion/PromotionRuleTypeExtensionTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\AdminBundle\Form\Extension\Promotion;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Form\Extension\Promotion\PromotionRuleTypeExtension;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+
+#[CoversClass(PromotionRuleTypeExtension::class)]
+final class PromotionRuleTypeExtensionTest extends TestCase
+{
+    private const KEY = ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY;
+
+    private ChannelRepositoryInterface&MockObject $channelRepository;
+
+    private PromotionRuleTypeExtension $extension;
+
+    /** @var array<string, callable> */
+    private array $listeners = [];
+
+    protected function setUp(): void
+    {
+        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+
+        $webChannel = $this->createMock(ChannelInterface::class);
+        $webChannel->method('getName')->willReturn('Web');
+        $webChannel->method('getCode')->willReturn('WEB');
+
+        $mobileChannel = $this->createMock(ChannelInterface::class);
+        $mobileChannel->method('getName')->willReturn('Mobile');
+        $mobileChannel->method('getCode')->willReturn('MOBILE');
+
+        $this->channelRepository->method('findAll')->willReturn([$webChannel, $mobileChannel]);
+
+        $this->extension = new PromotionRuleTypeExtension($this->channelRepository);
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->method('add')->willReturnSelf();
+        $builder->method('addEventListener')->willReturnCallback(
+            function (string $event, callable $listener): FormBuilderInterface {
+                $this->listeners[$event] = $listener;
+
+                return $this->createMock(FormBuilderInterface::class);
+            },
+        );
+
+        $this->extension->buildForm($builder, []);
+    }
+
+    public function testPreSubmitInjectsDefaultChannelsForNewItem(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'item_total']);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->once())->method('setData')->with([
+            'type' => 'item_total',
+            self::KEY => ['WEB', 'MOBILE'],
+        ]);
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNotInjectForExistingRuleWithNoKeyPresent(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn($rule);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'item_total']);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNotInjectWhenKeyAlreadyPresent(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(['type' => 'item_total', self::KEY => ['WEB']]);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPreSubmitDoesNothingForNonArrayData(): void
+    {
+        $innerForm = $this->createMock(FormInterface::class);
+        $innerForm->method('getData')->willReturn(null);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->method('getForm')->willReturn($innerForm);
+        $event->expects($this->never())->method('setData');
+
+        ($this->listeners[FormEvents::PRE_SUBMIT])($event);
+    }
+
+    public function testPostSetDataSetsAllChannelsCheckedForNewRule(): void
+    {
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testPostSetDataSetsAllChannelsCheckedWhenNoExclusions(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([self::KEY => []]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testPostSetDataSetsOnlyNonExcludedChannelsChecked(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([self::KEY => ['MOBILE']]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->expects($this->once())->method('setData')->with(['WEB']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::POST_SET_DATA])($event);
+    }
+
+    public function testSubmitComputesExcludedChannelsFromSelectedChannels(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([]);
+        $rule->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => ['MOBILE'],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn(['WEB']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitStoresEmptyExclusionsWhenAllChannelsSelected(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([]);
+        $rule->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => [],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn(['WEB', 'MOBILE']);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitStoresAllChannelsExcludedWhenNoneSelected(): void
+    {
+        $rule = $this->createMock(PromotionRuleInterface::class);
+        $rule->method('getConfiguration')->willReturn([]);
+        $rule->expects($this->once())->method('setConfiguration')->with([
+            self::KEY => ['WEB', 'MOBILE'],
+        ]);
+
+        $channelField = $this->createMock(FormInterface::class);
+        $channelField->method('getData')->willReturn([]);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('get')->with(self::KEY)->willReturn($channelField);
+
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn($rule);
+        $event->method('getForm')->willReturn($form);
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+
+    public function testSubmitDoesNothingForNonRuleData(): void
+    {
+        $event = $this->createMock(FormEvent::class);
+        $event->method('getData')->willReturn(null);
+        $event->expects($this->never())->method('getForm');
+
+        ($this->listeners[FormEvents::SUBMIT])($event);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/OverridePromotionServicesPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/OverridePromotionServicesPass.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Sylius\Component\Core\Promotion\Action\ChannelAwarePromotionApplicator;
+use Sylius\Component\Core\Promotion\Checker\Eligibility\ChannelAwarePromotionRulesEligibilityChecker;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class OverridePromotionServicesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('sylius.checker.promotion.rules_eligibility')) {
+            $container->getDefinition('sylius.checker.promotion.rules_eligibility')
+                ->setClass(ChannelAwarePromotionRulesEligibilityChecker::class);
+        }
+
+        if ($container->hasDefinition('sylius.action.applicator.promotion')) {
+            $container->getDefinition('sylius.action.applicator.promotion')
+                ->setClass(ChannelAwarePromotionApplicator::class);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedPercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedPercentageDiscountConfigurationType.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Action;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Bundle\PromotionBundle\Form\Type\Action\PercentageDiscountConfigurationType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedPercentageDiscountConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => PercentageDiscountConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedCartQuantityConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedCartQuantityConfigurationType.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Bundle\PromotionBundle\Form\Type\Rule\CartQuantityConfigurationType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedCartQuantityConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => CartQuantityConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedContainsProductConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedContainsProductConfigurationType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedContainsProductConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => ContainsProductConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedCustomerGroupConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedCustomerGroupConfigurationType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedCustomerGroupConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => CustomerGroupConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedHasTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedHasTaxonConfigurationType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedHasTaxonConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => HasTaxonConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedNthOrderConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedNthOrderConfigurationType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedNthOrderConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => NthOrderConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedShippingCountryConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedShippingCountryConfigurationType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
+
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ChannelBasedShippingCountryConfigurationType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'entry_type' => ShippingCountryConfigurationType::class,
+            'entry_options' => fn (ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChannelCollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius/sylius_promotion.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius/sylius_promotion.yml
@@ -44,9 +44,15 @@ sylius_promotion:
             order_percentage_discount:
                 - 'sylius'
                 - 'sylius_promotion_action_order_percentage_discount'
+            order_percentage_discount_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_action_order_percentage_discount_per_channel'
             shipping_percentage_discount:
                 - 'sylius'
                 - 'sylius_promotion_action_shipping_percentage_discount'
+            shipping_percentage_discount_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_action_shipping_percentage_discount_per_channel'
             order_fixed_discount:
                 - 'sylius'
                 - 'sylius_promotion_action_order_fixed_discount'
@@ -62,18 +68,36 @@ sylius_promotion:
             customer_group:
                 - 'sylius'
                 - 'sylius_promotion_rule_customer_group'
+            customer_group_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_rule_customer_group_per_channel'
             nth_order:
                 - 'sylius'
                 - 'sylius_promotion_rule_nth_order'
+            nth_order_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_rule_nth_order_per_channel'
             shipping_country:
                 - 'sylius'
                 - 'sylius_promotion_rule_shipping_country'
+            shipping_country_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_rule_shipping_country_per_channel'
             has_taxon:
                 - 'sylius'
                 - 'sylius_promotion_rule_has_taxon'
+            has_taxon_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_rule_has_taxon_per_channel'
             total_of_items_from_taxon:
                 - 'sylius'
                 - 'sylius_promotion_rule_total_of_items_from_taxon'
             contains_product:
                 - 'sylius'
                 - 'sylius_promotion_rule_contains_product'
+            contains_product_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_rule_contains_product_per_channel'
+            cart_quantity_per_channel:
+                - 'sylius'
+                - 'sylius_promotion_rule_cart_quantity_per_channel'

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.php
@@ -95,9 +95,21 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius.checker.promotion_rule.customer_group_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.customer_group')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'customer_group_per_channel', 'label' => 'sylius.form.promotion_rule.customer_group_per_channel', 'form_type' => ChannelBasedCustomerGroupConfigurationType::class])
+    ;
+
+    $services
         ->set('sylius.checker.promotion_rule.nth_order', NthOrderRuleChecker::class)
         ->args([service('sylius.repository.order')])
         ->tag('sylius.promotion_rule_checker', ['type' => 'nth_order', 'label' => 'sylius.form.promotion_rule.nth_order', 'form_type' => NthOrderConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.nth_order_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.nth_order')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'nth_order_per_channel', 'label' => 'sylius.form.promotion_rule.nth_order_per_channel', 'form_type' => ChannelBasedNthOrderConfigurationType::class])
     ;
 
     $services
@@ -107,8 +119,20 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius.checker.promotion_rule.shipping_country_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.shipping_country')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'shipping_country_per_channel', 'label' => 'sylius.form.promotion_rule.shipping_country_per_channel', 'form_type' => ChannelBasedShippingCountryConfigurationType::class])
+    ;
+
+    $services
         ->set('sylius.checker.promotion_rule.has_taxon', HasTaxonRuleChecker::class)
         ->tag('sylius.promotion_rule_checker', ['type' => 'has_taxon', 'label' => 'sylius.form.promotion_rule.has_at_least_one_from_taxons', 'form_type' => HasTaxonConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.has_taxon_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.has_taxon')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'has_taxon_per_channel', 'label' => 'sylius.form.promotion_rule.has_at_least_one_from_taxons_per_channel', 'form_type' => ChannelBasedHasTaxonConfigurationType::class])
     ;
 
     $services
@@ -123,6 +147,12 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius.checker.promotion_rule.contains_product_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.contains_product')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'contains_product_per_channel', 'label' => 'sylius.form.promotion_rule.contains_product_per_channel', 'form_type' => ChannelBasedContainsProductConfigurationType::class])
+    ;
+
+    $services
         ->set('sylius.checker.promotion_rule.item_total', ItemTotalRuleChecker::class)
         ->tag('sylius.promotion_rule_checker', ['type' => 'item_total', 'label' => 'sylius.form.promotion_rule.item_total', 'form_type' => ChannelBasedItemTotalConfigurationType::class])
     ;
@@ -130,36 +160,6 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius.checker.promotion_rule.cart_quantity', CartQuantityRuleChecker::class)
         ->tag('sylius.promotion_rule_checker', ['type' => 'cart_quantity', 'label' => 'sylius.form.promotion_rule.cart_quantity', 'form_type' => CartQuantityConfigurationType::class])
-    ;
-
-    $services
-        ->set('sylius.checker.promotion_rule.customer_group_per_channel', PerChannelRuleChecker::class)
-        ->args([service('sylius.checker.promotion_rule.customer_group')])
-        ->tag('sylius.promotion_rule_checker', ['type' => 'customer_group_per_channel', 'label' => 'sylius.form.promotion_rule.customer_group_per_channel', 'form_type' => ChannelBasedCustomerGroupConfigurationType::class])
-    ;
-
-    $services
-        ->set('sylius.checker.promotion_rule.nth_order_per_channel', PerChannelRuleChecker::class)
-        ->args([service('sylius.checker.promotion_rule.nth_order')])
-        ->tag('sylius.promotion_rule_checker', ['type' => 'nth_order_per_channel', 'label' => 'sylius.form.promotion_rule.nth_order_per_channel', 'form_type' => ChannelBasedNthOrderConfigurationType::class])
-    ;
-
-    $services
-        ->set('sylius.checker.promotion_rule.shipping_country_per_channel', PerChannelRuleChecker::class)
-        ->args([service('sylius.checker.promotion_rule.shipping_country')])
-        ->tag('sylius.promotion_rule_checker', ['type' => 'shipping_country_per_channel', 'label' => 'sylius.form.promotion_rule.shipping_country_per_channel', 'form_type' => ChannelBasedShippingCountryConfigurationType::class])
-    ;
-
-    $services
-        ->set('sylius.checker.promotion_rule.has_taxon_per_channel', PerChannelRuleChecker::class)
-        ->args([service('sylius.checker.promotion_rule.has_taxon')])
-        ->tag('sylius.promotion_rule_checker', ['type' => 'has_taxon_per_channel', 'label' => 'sylius.form.promotion_rule.has_at_least_one_from_taxons_per_channel', 'form_type' => ChannelBasedHasTaxonConfigurationType::class])
-    ;
-
-    $services
-        ->set('sylius.checker.promotion_rule.contains_product_per_channel', PerChannelRuleChecker::class)
-        ->args([service('sylius.checker.promotion_rule.contains_product')])
-        ->tag('sylius.promotion_rule_checker', ['type' => 'contains_product_per_channel', 'label' => 'sylius.form.promotion_rule.contains_product_per_channel', 'form_type' => ChannelBasedContainsProductConfigurationType::class])
     ;
 
     $services
@@ -202,6 +202,12 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius.command.promotion_action.percentage_discount_per_channel', PerChannelPromotionActionCommand::class)
+        ->args([service('sylius.command.promotion_action.percentage_discount')])
+        ->tag('sylius.promotion_action', ['type' => 'order_percentage_discount_per_channel', 'label' => 'sylius.form.promotion_action.order_percentage_discount_per_channel', 'form_type' => ChannelBasedPercentageDiscountConfigurationType::class])
+    ;
+
+    $services
         ->set('sylius.command.promotion_action.unit_percentage_discount', UnitPercentageDiscountPromotionActionCommand::class)
         ->args([
             service('sylius.factory.adjustment'),
@@ -216,12 +222,6 @@ return static function (ContainerConfigurator $container) {
         ->set('sylius.command.promotion_action.shipping_percentage_discount', ShippingPercentageDiscountPromotionActionCommand::class)
         ->args([service('sylius.factory.adjustment')])
         ->tag('sylius.promotion_action', ['type' => 'shipping_percentage_discount', 'label' => 'sylius.form.promotion_action.shipping_percentage_discount', 'form_type' => PercentageDiscountConfigurationType::class])
-    ;
-
-    $services
-        ->set('sylius.command.promotion_action.percentage_discount_per_channel', PerChannelPromotionActionCommand::class)
-        ->args([service('sylius.command.promotion_action.percentage_discount')])
-        ->tag('sylius.promotion_action', ['type' => 'order_percentage_discount_per_channel', 'label' => 'sylius.form.promotion_action.order_percentage_discount_per_channel', 'form_type' => ChannelBasedPercentageDiscountConfigurationType::class])
     ;
 
     $services

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.php
@@ -15,9 +15,16 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\Promotion\Modifier\AtomicOrderPromotionsUsageModifier;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Action\ChannelBasedFixedDiscountConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Action\ChannelBasedPercentageDiscountConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Action\ChannelBasedUnitFixedDiscountConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Action\ChannelBasedUnitPercentageDiscountConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedCartQuantityConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedContainsProductConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedCustomerGroupConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedHasTaxonConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedItemTotalConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedNthOrderConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedShippingCountryConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ChannelBasedTotalOfItemsFromTaxonConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\ContainsProductConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule\CustomerGroupConfigurationType;
@@ -32,6 +39,7 @@ use Sylius\Component\Core\Factory\PromotionRuleFactory;
 use Sylius\Component\Core\Factory\PromotionRuleFactoryInterface;
 use Sylius\Component\Core\Promotion\Action\FixedDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Action\PercentageDiscountPromotionActionCommand;
+use Sylius\Component\Core\Promotion\Action\PerChannelPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Action\ShippingPercentageDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Action\UnitFixedDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Action\UnitPercentageDiscountPromotionActionCommand;
@@ -46,6 +54,7 @@ use Sylius\Component\Core\Promotion\Checker\Rule\CustomerGroupRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\HasTaxonRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\ItemTotalRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\NthOrderRuleChecker;
+use Sylius\Component\Core\Promotion\Checker\Rule\PerChannelRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\ShippingCountryRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\Rule\TotalOfItemsFromTaxonRuleChecker;
 use Sylius\Component\Core\Promotion\Checker\TaxonInPromotionRuleChecker;
@@ -124,6 +133,42 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius.checker.promotion_rule.customer_group_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.customer_group')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'customer_group_per_channel', 'label' => 'sylius.form.promotion_rule.customer_group_per_channel', 'form_type' => ChannelBasedCustomerGroupConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.nth_order_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.nth_order')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'nth_order_per_channel', 'label' => 'sylius.form.promotion_rule.nth_order_per_channel', 'form_type' => ChannelBasedNthOrderConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.shipping_country_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.shipping_country')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'shipping_country_per_channel', 'label' => 'sylius.form.promotion_rule.shipping_country_per_channel', 'form_type' => ChannelBasedShippingCountryConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.has_taxon_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.has_taxon')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'has_taxon_per_channel', 'label' => 'sylius.form.promotion_rule.has_at_least_one_from_taxons_per_channel', 'form_type' => ChannelBasedHasTaxonConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.contains_product_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.contains_product')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'contains_product_per_channel', 'label' => 'sylius.form.promotion_rule.contains_product_per_channel', 'form_type' => ChannelBasedContainsProductConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.checker.promotion_rule.cart_quantity_per_channel', PerChannelRuleChecker::class)
+        ->args([service('sylius.checker.promotion_rule.cart_quantity')])
+        ->tag('sylius.promotion_rule_checker', ['type' => 'cart_quantity_per_channel', 'label' => 'sylius.form.promotion_rule.cart_quantity_per_channel', 'form_type' => ChannelBasedCartQuantityConfigurationType::class])
+    ;
+
+    $services
         ->set('sylius.command.promotion_action.fixed_discount', FixedDiscountPromotionActionCommand::class)
         ->args([
             service('sylius.distributor.proportional_integer'),
@@ -171,6 +216,18 @@ return static function (ContainerConfigurator $container) {
         ->set('sylius.command.promotion_action.shipping_percentage_discount', ShippingPercentageDiscountPromotionActionCommand::class)
         ->args([service('sylius.factory.adjustment')])
         ->tag('sylius.promotion_action', ['type' => 'shipping_percentage_discount', 'label' => 'sylius.form.promotion_action.shipping_percentage_discount', 'form_type' => PercentageDiscountConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.command.promotion_action.percentage_discount_per_channel', PerChannelPromotionActionCommand::class)
+        ->args([service('sylius.command.promotion_action.percentage_discount')])
+        ->tag('sylius.promotion_action', ['type' => 'order_percentage_discount_per_channel', 'label' => 'sylius.form.promotion_action.order_percentage_discount_per_channel', 'form_type' => ChannelBasedPercentageDiscountConfigurationType::class])
+    ;
+
+    $services
+        ->set('sylius.command.promotion_action.shipping_percentage_discount_per_channel', PerChannelPromotionActionCommand::class)
+        ->args([service('sylius.command.promotion_action.shipping_percentage_discount')])
+        ->tag('sylius.promotion_action', ['type' => 'shipping_percentage_discount_per_channel', 'label' => 'sylius.form.promotion_action.shipping_percentage_discount_per_channel', 'form_type' => ChannelBasedPercentageDiscountConfigurationType::class])
     ;
 
     $services

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.php
@@ -33,6 +33,7 @@ use Sylius\Bundle\CoreBundle\Validator\Constraints\OrderShippingMethodEligibilit
 use Sylius\Bundle\CoreBundle\Validator\Constraints\ProductCodeExistsValidator;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\ProductImageVariantsBelongToOwnerValidator;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\ProductVariantCodeExistsValidator;
+use Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodesValidator;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\ProvinceCodeExistsValidator;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\RegisteredUserValidator;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\ResendOrderConfirmationEmailWithValidOrderStateValidator;
@@ -132,6 +133,12 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius.validator.channel_default_locale_enabled', ChannelDefaultLocaleEnabledValidator::class)
         ->tag('validator.constraint_validator', ['alias' => 'sylius_channel_default_locale_enabled'])
+    ;
+
+    $services
+        ->set('sylius.validator.promotion_configuration_channel_codes', PromotionConfigurationChannelCodesValidator::class)
+        ->args([service('sylius.repository.channel')])
+        ->tag('validator.constraint_validator', ['alias' => 'sylius_promotion_configuration_channel_codes'])
     ;
 
     $services

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionAction.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionAction.xml
@@ -280,6 +280,46 @@
                     </constraint>
                 </option>
             </constraint>
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">
+                    <value>sylius_promotion_action_order_percentage_discount_per_channel</value>
+                    <value>sylius_promotion_action_shipping_percentage_discount_per_channel</value>
+                </option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="fields">
+                            <value key="percentage">
+                                <constraint name="NotBlank">
+                                    <option name="groups">
+                                        <value>sylius_promotion_action_order_percentage_discount_per_channel</value>
+                                        <value>sylius_promotion_action_shipping_percentage_discount_per_channel</value>
+                                    </option>
+                                </constraint>
+                                <constraint name="Type">
+                                    <option name="type">numeric</option>
+                                    <option name="groups">
+                                        <value>sylius_promotion_action_order_percentage_discount_per_channel</value>
+                                        <value>sylius_promotion_action_shipping_percentage_discount_per_channel</value>
+                                    </option>
+                                </constraint>
+                                <constraint name="Range">
+                                    <option name="min">0</option>
+                                    <option name="max">1</option>
+                                    <option name="notInRangeMessage">sylius.promotion_action.percentage_discount_configuration.not_in_range</option>
+                                    <option name="groups">
+                                        <value>sylius_promotion_action_order_percentage_discount_per_channel</value>
+                                        <value>sylius_promotion_action_shipping_percentage_discount_per_channel</value>
+                                    </option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
             <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodes">
                 <option name="groups">
                     <value>sylius</value>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionAction.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionAction.xml
@@ -280,6 +280,11 @@
                     </constraint>
                 </option>
             </constraint>
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodes">
+                <option name="groups">
+                    <value>sylius</value>
+                </option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionRule.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionRule.xml
@@ -178,6 +178,11 @@
                     </constraint>
                 </option>
             </constraint>
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodes">
+                <option name="groups">
+                    <value>sylius</value>
+                </option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionRule.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionRule.xml
@@ -178,6 +178,163 @@
                     </constraint>
                 </option>
             </constraint>
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">sylius_promotion_rule_cart_quantity_per_channel</option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="groups">sylius_promotion_rule_cart_quantity_per_channel</option>
+                        <option name="fields">
+                            <value key="count">
+                                <constraint name="NotBlank">
+                                    <option name="groups">sylius_promotion_rule_cart_quantity_per_channel</option>
+                                </constraint>
+                                <constraint name="Type">
+                                    <option name="type">numeric</option>
+                                    <option name="groups">sylius_promotion_rule_cart_quantity_per_channel</option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
+
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">sylius_promotion_rule_customer_group_per_channel</option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="groups">sylius_promotion_rule_customer_group_per_channel</option>
+                        <option name="fields">
+                            <value key="group_code">
+                                <constraint name="NotBlank">
+                                    <option name="groups">sylius_promotion_rule_customer_group_per_channel</option>
+                                </constraint>
+                                <constraint name="Type">
+                                    <option name="type">string</option>
+                                    <option name="groups">sylius_promotion_rule_customer_group_per_channel</option>
+                                </constraint>
+                                <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\CustomerGroupCodeExists">
+                                    <option name="groups">sylius_promotion_rule_customer_group_per_channel</option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
+
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">sylius_promotion_rule_nth_order_per_channel</option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="groups">sylius_promotion_rule_nth_order_per_channel</option>
+                        <option name="fields">
+                            <value key="nth">
+                                <constraint name="NotBlank">
+                                    <option name="groups">sylius_promotion_rule_nth_order_per_channel</option>
+                                </constraint>
+                                <constraint name="Type">
+                                    <option name="type">numeric</option>
+                                    <option name="groups">sylius_promotion_rule_nth_order_per_channel</option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
+
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">sylius_promotion_rule_shipping_country_per_channel</option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="groups">sylius_promotion_rule_shipping_country_per_channel</option>
+                        <option name="fields">
+                            <value key="country">
+                                <constraint name="NotBlank">
+                                    <option name="groups">sylius_promotion_rule_shipping_country_per_channel</option>
+                                </constraint>
+                                <constraint name="Type">
+                                    <option name="type">string</option>
+                                    <option name="groups">sylius_promotion_rule_shipping_country_per_channel</option>
+                                </constraint>
+                                <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\CountryCodeExists">
+                                    <option name="groups">sylius_promotion_rule_shipping_country_per_channel</option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
+
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">sylius_promotion_rule_has_taxon_per_channel</option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="groups">sylius_promotion_rule_has_taxon_per_channel</option>
+                        <option name="fields">
+                            <value key="taxons">
+                                <constraint name="All">
+                                    <option name="groups">sylius_promotion_rule_has_taxon_per_channel</option>
+                                    <option name="constraints">
+                                        <constraint name="NotBlank">
+                                            <option name="groups">sylius_promotion_rule_has_taxon_per_channel</option>
+                                        </constraint>
+                                        <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\TaxonCodeExists">
+                                            <option name="groups">sylius_promotion_rule_has_taxon_per_channel</option>
+                                        </constraint>
+                                    </option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
+
+            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollection">
+                <option name="allowExtraFields">true</option>
+                <option name="groups">sylius_promotion_rule_contains_product_per_channel</option>
+                <option name="validateAgainstAllChannels">true</option>
+                <option name="channelAwarePropertyPath">promotion</option>
+                <option name="constraints">
+                    <constraint name="Collection">
+                        <option name="allowExtraFields">true</option>
+                        <option name="groups">sylius_promotion_rule_contains_product_per_channel</option>
+                        <option name="fields">
+                            <value key="product_code">
+                                <constraint name="NotBlank">
+                                    <option name="groups">sylius_promotion_rule_contains_product_per_channel</option>
+                                </constraint>
+                                <constraint name="Type">
+                                    <option name="type">string</option>
+                                    <option name="groups">sylius_promotion_rule_contains_product_per_channel</option>
+                                </constraint>
+                                <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\ProductCodeExists">
+                                    <option name="groups">sylius_promotion_rule_contains_product_per_channel</option>
+                                </constraint>
+                            </value>
+                        </option>
+                    </constraint>
+                </option>
+            </constraint>
+
             <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodes">
                 <option name="groups">
                     <value>sylius</value>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -75,6 +75,7 @@ sylius:
         promotion_action:
             add_product_configuration:
                 product: Product
+            channels: Applicable channels
         promotion_coupon:
             per_customer_usage_limit: Per-Customer Usage Limit
             reusable_from_cancelled_orders: Reusable from cancelled orders
@@ -198,6 +199,7 @@ sylius:
             products: Products filter
             taxons: Taxons filter
         promotion_rule:
+            channels: Applicable channels
             customer_group:
                 group: Customer group
             has_taxon:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
@@ -161,6 +161,9 @@ sylius:
             price:
                 not_defined: 'You must define price.'
             existing_code: Channel with code {{ channelCode }} does not exist.
+    promotion:
+        configuration:
+            invalid_channel_code: 'Channel with code "{{ channelCode }}" does not exist.'
     promotion_coupon:
         per_customer_usage_limit:
             min: Coupon usage limit per customer must be at least {{ limit }}.

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -28,6 +28,7 @@ use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CheckStatisticsOrdersT
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CircularDependencyBreakingErrorListenerPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\IgnoreAnnotationsPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\LazyCacheWarmupPass;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\OverridePromotionServicesPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\OverrideResourceControllerStateMachinePass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterTaxCalculationStrategiesPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterUriBasedSectionResolverPass;
@@ -93,6 +94,7 @@ final class SyliusCoreBundle extends AbstractResourceBundle
         $container->addCompilerPass(new Symfony6PrivateServicesPass());
         $container->addCompilerPass(new TranslatableEntityLocalePass());
         $container->addCompilerPass(new CheckStatisticsOrdersTotalsProviderTypePass());
+        $container->addCompilerPass(new OverridePromotionServicesPass());
         $container->addCompilerPass(new OverrideResourceControllerStateMachinePass(), priority: -1024);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollectionValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollectionValidator.php
@@ -17,6 +17,7 @@ use Sylius\Component\Channel\Model\ChannelInterface as BaseChannelInterface;
 use Sylius\Component\Channel\Model\ChannelsAwareInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Collection;
@@ -47,7 +48,10 @@ final class ChannelCodeCollectionValidator extends ConstraintValidator
         }
 
         if ($constraint->validateAgainstAllChannels) {
-            $this->validateInChannelCollection($value, array_keys($this->getAllChannelsCodes()), $constraint);
+            $excludedChannels = $value[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
+            $allCodes = array_keys($this->getAllChannelsCodes());
+            $channelCodes = $excludedChannels !== [] ? array_values(array_diff($allCodes, $excludedChannels)) : $allCodes;
+            $this->validateInChannelCollection($value, $channelCodes, $constraint);
 
             return;
         }

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/PromotionConfigurationChannelCodes.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/PromotionConfigurationChannelCodes.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+final class PromotionConfigurationChannelCodes extends Constraint
+{
+    public string $invalidChannelCodeMessage = 'sylius.promotion.configuration.invalid_channel_code';
+
+    public function validatedBy(): string
+    {
+        return 'sylius_promotion_configuration_channel_codes';
+    }
+
+    public function getTargets(): string
+    {
+        return Constraint::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/PromotionConfigurationChannelCodesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/PromotionConfigurationChannelCodesValidator.php
@@ -33,13 +33,13 @@ final class PromotionConfigurationChannelCodesValidator extends ConstraintValida
             return;
         }
 
-        $channelCodes = $value[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
+        $channelCodes = $value[ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
 
         foreach ($channelCodes as $code) {
             if (!is_string($code) || $this->channelRepository->findOneByCode($code) === null) {
                 $this->context->buildViolation($constraint->invalidChannelCodeMessage)
                     ->setParameter('{{ channelCode }}', (string) $code)
-                    ->atPath('[' . ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY . ']')
+                    ->atPath('[' . ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY . ']')
                     ->addViolation()
                 ;
             }

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/PromotionConfigurationChannelCodesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/PromotionConfigurationChannelCodesValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Webmozart\Assert\Assert;
+
+final class PromotionConfigurationChannelCodesValidator extends ConstraintValidator
+{
+    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        Assert::isInstanceOf($constraint, PromotionConfigurationChannelCodes::class);
+
+        if (!is_array($value)) {
+            return;
+        }
+
+        $channelCodes = $value[ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY] ?? [];
+
+        foreach ($channelCodes as $code) {
+            if (!is_string($code) || $this->channelRepository->findOneByCode($code) === null) {
+                $this->context->buildViolation($constraint->invalidChannelCodeMessage)
+                    ->setParameter('{{ channelCode }}', (string) $code)
+                    ->atPath('[' . ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY . ']')
+                    ->addViolation()
+                ;
+            }
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/Compiler/OverridePromotionServicesPassTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/Compiler/OverridePromotionServicesPassTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\OverridePromotionServicesPass;
+use Sylius\Component\Core\Promotion\Action\ChannelAwarePromotionApplicator;
+use Sylius\Component\Core\Promotion\Checker\Eligibility\ChannelAwarePromotionRulesEligibilityChecker;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+#[CoversClass(OverridePromotionServicesPass::class)]
+final class OverridePromotionServicesPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new OverridePromotionServicesPass());
+    }
+
+    public function testItReplacesClassOfRulesEligibilityChecker(): void
+    {
+        $this->setDefinition('sylius.checker.promotion.rules_eligibility', new Definition(\stdClass::class));
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService(
+            'sylius.checker.promotion.rules_eligibility',
+            ChannelAwarePromotionRulesEligibilityChecker::class,
+        );
+    }
+
+    public function testItReplacesClassOfPromotionApplicator(): void
+    {
+        $this->setDefinition('sylius.action.applicator.promotion', new Definition(\stdClass::class));
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService(
+            'sylius.action.applicator.promotion',
+            ChannelAwarePromotionApplicator::class,
+        );
+    }
+
+    public function testItDoesNothingIfRulesEligibilityCheckerServiceDoesNotExist(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius.checker.promotion.rules_eligibility');
+    }
+
+    public function testItDoesNothingIfPromotionApplicatorServiceDoesNotExist(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius.action.applicator.promotion');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/ChannelCodeCollectionValidatorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/ChannelCodeCollectionValidatorTest.php
@@ -21,6 +21,7 @@ use Sylius\Bundle\CoreBundle\Validator\Constraints\ChannelCodeCollectionValidato
 use Sylius\Component\Channel\Model\ChannelsAwareInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
@@ -252,6 +253,31 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $this->validator->validate($value, new ChannelCodeCollection([
             'constraints' => $constraints,
             'groups' => $groups,
+            'validateAgainstAllChannels' => true,
+        ]));
+    }
+
+    public function testItValidatesCollectionsForRemainingChannelsWhenExcludedChannelsKeyIsPresent(): void
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $contextualValidator = $this->createMock(ContextualValidatorInterface::class);
+
+        $this->channelRepository->method('findAllWithBasicData')->willReturn([
+            ['code' => 'WEB'], ['code' => 'MOBILE'],
+        ]);
+
+        $value = [
+            'WEB' => ['amount' => 1000],
+            ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE'],
+        ];
+
+        $this->executionContext->method('getValidator')->willReturn($validator);
+        $validator->method('inContext')->willReturn($contextualValidator);
+        $contextualValidator->expects($this->once())->method('validate');
+
+        $this->validator->validate($value, new ChannelCodeCollection([
+            'constraints' => [new NotBlank(), new Type('numeric')],
+            'groups' => ['Default'],
             'validateAgainstAllChannels' => true,
         ]));
     }

--- a/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/PromotionConfigurationChannelCodesValidatorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/PromotionConfigurationChannelCodesValidatorTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\CoreBundle\Validator\Constraints;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodes;
+use Sylius\Bundle\CoreBundle\Validator\Constraints\PromotionConfigurationChannelCodesValidator;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+#[CoversClass(PromotionConfigurationChannelCodesValidator::class)]
+final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
+{
+    private ChannelRepositoryInterface&MockObject $channelRepository;
+
+    private ExecutionContextInterface&MockObject $executionContext;
+
+    private PromotionConfigurationChannelCodesValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+        $this->executionContext = $this->createMock(ExecutionContextInterface::class);
+        $this->validator = new PromotionConfigurationChannelCodesValidator($this->channelRepository);
+        $this->validator->initialize($this->executionContext);
+    }
+
+    public function testItIsAConstraintValidator(): void
+    {
+        $this->assertInstanceOf(PromotionConfigurationChannelCodesValidator::class, $this->validator);
+    }
+
+    public function testItThrowsAnExceptionIfConstraintIsWrongType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->channelRepository->expects($this->never())->method('findOneByCode');
+        $this->executionContext->expects($this->never())->method('buildViolation');
+
+        $this->validator->validate([], $this->createMock(Constraint::class));
+    }
+
+    public function testItDoesNothingIfValueIsNotAnArray(): void
+    {
+        $this->channelRepository->expects($this->never())->method('findOneByCode');
+        $this->executionContext->expects($this->never())->method('buildViolation');
+
+        $this->validator->validate('not_an_array', new PromotionConfigurationChannelCodes());
+    }
+
+    public function testItDoesNothingIfChannelsKeyIsMissing(): void
+    {
+        $this->channelRepository->expects($this->never())->method('findOneByCode');
+        $this->executionContext->expects($this->never())->method('buildViolation');
+
+        $this->validator->validate(['count' => 5], new PromotionConfigurationChannelCodes());
+    }
+
+    public function testItDoesNothingIfChannelsListIsEmpty(): void
+    {
+        $this->channelRepository->expects($this->never())->method('findOneByCode');
+        $this->executionContext->expects($this->never())->method('buildViolation');
+
+        $this->validator->validate(
+            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => []],
+            new PromotionConfigurationChannelCodes(),
+        );
+    }
+
+    public function testItDoesNotAddViolationIfAllChannelCodesExist(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->channelRepository
+            ->expects($this->exactly(2))
+            ->method('findOneByCode')
+            ->willReturn($channel);
+
+        $this->executionContext->expects($this->never())->method('buildViolation');
+
+        $this->validator->validate(
+            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB', 'MOBILE']],
+            new PromotionConfigurationChannelCodes(),
+        );
+    }
+
+    public function testItAddsViolationForInvalidChannelCode(): void
+    {
+        $this->channelRepository
+            ->expects($this->once())
+            ->method('findOneByCode')
+            ->with('INVALID_CODE')
+            ->willReturn(null);
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $violationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('{{ channelCode }}', 'INVALID_CODE')
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects($this->once())
+            ->method('atPath')
+            ->with('[' . ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY . ']')
+            ->willReturn($violationBuilder);
+        $violationBuilder->expects($this->once())->method('addViolation');
+
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with((new PromotionConfigurationChannelCodes())->invalidChannelCodeMessage)
+            ->willReturn($violationBuilder);
+
+        $this->validator->validate(
+            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['INVALID_CODE']],
+            new PromotionConfigurationChannelCodes(),
+        );
+    }
+
+    public function testItAddsOneViolationPerInvalidChannelCode(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->channelRepository
+            ->expects($this->exactly(3))
+            ->method('findOneByCode')
+            ->willReturnMap([
+                ['WEB', $channel],
+                ['INVALID_ONE', null],
+                ['INVALID_TWO', null],
+            ]);
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $violationBuilder->method('setParameter')->willReturn($violationBuilder);
+        $violationBuilder->method('atPath')->willReturn($violationBuilder);
+        $violationBuilder->expects($this->exactly(2))->method('addViolation');
+
+        $this->executionContext
+            ->expects($this->exactly(2))
+            ->method('buildViolation')
+            ->willReturn($violationBuilder);
+
+        $this->validator->validate(
+            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB', 'INVALID_ONE', 'INVALID_TWO']],
+            new PromotionConfigurationChannelCodes(),
+        );
+    }
+
+    public function testItAddsViolationForNonStringChannelCode(): void
+    {
+        $this->channelRepository->expects($this->never())->method('findOneByCode');
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $violationBuilder->method('setParameter')->willReturn($violationBuilder);
+        $violationBuilder->method('atPath')->willReturn($violationBuilder);
+        $violationBuilder->expects($this->once())->method('addViolation');
+
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->willReturn($violationBuilder);
+
+        $this->validator->validate(
+            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => [42]],
+            new PromotionConfigurationChannelCodes(),
+        );
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/PromotionConfigurationChannelCodesValidatorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/PromotionConfigurationChannelCodesValidatorTest.php
@@ -79,7 +79,7 @@ final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
         $this->executionContext->expects($this->never())->method('buildViolation');
 
         $this->validator->validate(
-            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => []],
+            [ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => []],
             new PromotionConfigurationChannelCodes(),
         );
     }
@@ -96,7 +96,7 @@ final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
         $this->executionContext->expects($this->never())->method('buildViolation');
 
         $this->validator->validate(
-            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB', 'MOBILE']],
+            [ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['WEB', 'MOBILE']],
             new PromotionConfigurationChannelCodes(),
         );
     }
@@ -118,7 +118,7 @@ final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
         $violationBuilder
             ->expects($this->once())
             ->method('atPath')
-            ->with('[' . ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY . ']')
+            ->with('[' . ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY . ']')
             ->willReturn($violationBuilder);
         $violationBuilder->expects($this->once())->method('addViolation');
 
@@ -129,7 +129,7 @@ final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
             ->willReturn($violationBuilder);
 
         $this->validator->validate(
-            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['INVALID_CODE']],
+            [ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['INVALID_CODE']],
             new PromotionConfigurationChannelCodes(),
         );
     }
@@ -158,7 +158,7 @@ final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
             ->willReturn($violationBuilder);
 
         $this->validator->validate(
-            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB', 'INVALID_ONE', 'INVALID_TWO']],
+            [ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['WEB', 'INVALID_ONE', 'INVALID_TWO']],
             new PromotionConfigurationChannelCodes(),
         );
     }
@@ -178,7 +178,7 @@ final class PromotionConfigurationChannelCodesValidatorTest extends TestCase
             ->willReturn($violationBuilder);
 
         $this->validator->validate(
-            [ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => [42]],
+            [ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => [42]],
             new PromotionConfigurationChannelCodes(),
         );
     }

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -35,7 +35,9 @@ sylius:
             item_percentage_discount: Item percentage discount
             order_fixed_discount: Order fixed discount
             order_percentage_discount: Order percentage discount
+            order_percentage_discount_per_channel: Order percentage discount (per channel)
             shipping_percentage_discount: Shipping percentage discount
+            shipping_percentage_discount_per_channel: Shipping percentage discount (per channel)
             filters: Filters
             fixed_discount_configuration:
                 amount: Amount
@@ -56,12 +58,18 @@ sylius:
             price_range: Price range filter
         promotion_rule:
             cart_quantity: Cart quantity
+            cart_quantity_per_channel: Cart quantity (per channel)
             contains_product: Contains product
+            contains_product_per_channel: Contains product (per channel)
             customer_group: Customer group
+            customer_group_per_channel: Customer group (per channel)
             has_at_least_one_from_taxons: Has at least one from taxons
+            has_at_least_one_from_taxons_per_channel: Has at least one from taxons (per channel)
             item_total: Item total
             nth_order: Nth order
+            nth_order_per_channel: Nth order (per channel)
             shipping_country: Shipping country
+            shipping_country_per_channel: Shipping country (per channel)
             taxonomy: Taxonomy
             total_price_of_items_from_taxon: Total price of items from taxon
             cart_quantity_configuration:

--- a/src/Sylius/Component/Core/Promotion/Action/ChannelAwarePromotionApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ChannelAwarePromotionApplicator.php
@@ -62,8 +62,8 @@ final class ChannelAwarePromotionApplicator implements PromotionApplicatorInterf
 
     private function isActionSkippedForChannel(PromotionActionInterface $action, PromotionSubjectInterface $subject): bool
     {
-        $channels = $action->getConfiguration()[self::CHANNELS_CONFIGURATION_KEY] ?? [];
-        if ($channels === []) {
+        $excludedChannels = $action->getConfiguration()[self::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
+        if ($excludedChannels === []) {
             return false;
         }
 
@@ -71,7 +71,7 @@ final class ChannelAwarePromotionApplicator implements PromotionApplicatorInterf
             return false;
         }
 
-        return !in_array($subject->getChannel()->getCode(), $channels, true);
+        return in_array($subject->getChannel()->getCode(), $excludedChannels, true);
     }
 
     /**
@@ -81,7 +81,7 @@ final class ChannelAwarePromotionApplicator implements PromotionApplicatorInterf
      */
     private function stripChannelKey(array $configuration): array
     {
-        unset($configuration[self::CHANNELS_CONFIGURATION_KEY]);
+        unset($configuration[self::EXCLUDED_CHANNELS_CONFIGURATION_KEY]);
 
         return $configuration;
     }

--- a/src/Sylius/Component/Core/Promotion/Action/ChannelAwarePromotionApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ChannelAwarePromotionApplicator.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Promotion\Action;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Action\PromotionActionCommandInterface;
+use Sylius\Component\Promotion\Action\PromotionApplicatorInterface;
+use Sylius\Component\Promotion\Model\PromotionActionInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+
+final class ChannelAwarePromotionApplicator implements PromotionApplicatorInterface, ChannelAwareConfigurationInterface
+{
+    public function __construct(private ServiceRegistryInterface $registry)
+    {
+    }
+
+    public function apply(PromotionSubjectInterface $subject, PromotionInterface $promotion): void
+    {
+        $applyPromotion = false;
+        foreach ($promotion->getActions() as $action) {
+            if ($this->isActionSkippedForChannel($action, $subject)) {
+                continue;
+            }
+
+            $configuration = $this->stripChannelKey($action->getConfiguration());
+            $result = $this->getActionCommandByType($action->getType())->execute($subject, $configuration, $promotion);
+            $applyPromotion = $applyPromotion || $result;
+        }
+
+        if ($applyPromotion) {
+            $subject->addPromotion($promotion);
+        }
+    }
+
+    public function revert(PromotionSubjectInterface $subject, PromotionInterface $promotion): void
+    {
+        foreach ($promotion->getActions() as $action) {
+            if ($this->isActionSkippedForChannel($action, $subject)) {
+                continue;
+            }
+
+            $configuration = $this->stripChannelKey($action->getConfiguration());
+            $this->getActionCommandByType($action->getType())->revert($subject, $configuration, $promotion);
+        }
+
+        $subject->removePromotion($promotion);
+    }
+
+    private function isActionSkippedForChannel(PromotionActionInterface $action, PromotionSubjectInterface $subject): bool
+    {
+        $channels = $action->getConfiguration()[self::CHANNELS_CONFIGURATION_KEY] ?? [];
+        if ($channels === []) {
+            return false;
+        }
+
+        if (!$subject instanceof OrderInterface) {
+            return false;
+        }
+
+        return !in_array($subject->getChannel()->getCode(), $channels, true);
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     *
+     * @return array<string, mixed>
+     */
+    private function stripChannelKey(array $configuration): array
+    {
+        unset($configuration[self::CHANNELS_CONFIGURATION_KEY]);
+
+        return $configuration;
+    }
+
+    private function getActionCommandByType(string $type): PromotionActionCommandInterface
+    {
+        return $this->registry->get($type);
+    }
+}

--- a/src/Sylius/Component/Core/Promotion/Action/PerChannelPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/PerChannelPromotionActionCommand.php
@@ -32,7 +32,12 @@ final class PerChannelPromotionActionCommand implements PromotionActionCommandIn
             throw new UnexpectedTypeException($subject, OrderInterface::class);
         }
 
-        $channelCode = $subject->getChannel()->getCode();
+        $channel = $subject->getChannel();
+        if ($channel === null) {
+            return false;
+        }
+
+        $channelCode = $channel->getCode();
         if (!isset($configuration[$channelCode])) {
             return false;
         }
@@ -47,7 +52,12 @@ final class PerChannelPromotionActionCommand implements PromotionActionCommandIn
             throw new UnexpectedTypeException($subject, OrderInterface::class);
         }
 
-        $channelCode = $subject->getChannel()->getCode();
+        $channel = $subject->getChannel();
+        if ($channel === null) {
+            return;
+        }
+
+        $channelCode = $channel->getCode();
         if (!isset($configuration[$channelCode])) {
             return;
         }

--- a/src/Sylius/Component/Core/Promotion/Action/PerChannelPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/PerChannelPromotionActionCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Promotion\Action;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Promotion\Action\PromotionActionCommandInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Resource\Exception\UnexpectedTypeException;
+
+final class PerChannelPromotionActionCommand implements PromotionActionCommandInterface
+{
+    public function __construct(private PromotionActionCommandInterface $decorated)
+    {
+    }
+
+    /** @param array<string, mixed> $configuration */
+    public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion): bool
+    {
+        if (!$subject instanceof OrderInterface) {
+            throw new UnexpectedTypeException($subject, OrderInterface::class);
+        }
+
+        $channelCode = $subject->getChannel()->getCode();
+        if (!isset($configuration[$channelCode])) {
+            return false;
+        }
+
+        return $this->decorated->execute($subject, $configuration[$channelCode], $promotion);
+    }
+
+    /** @param array<string, mixed> $configuration */
+    public function revert(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion): void
+    {
+        if (!$subject instanceof OrderInterface) {
+            throw new UnexpectedTypeException($subject, OrderInterface::class);
+        }
+
+        $channelCode = $subject->getChannel()->getCode();
+        if (!isset($configuration[$channelCode])) {
+            return;
+        }
+
+        $this->decorated->revert($subject, $configuration[$channelCode], $promotion);
+    }
+}

--- a/src/Sylius/Component/Core/Promotion/ChannelAwareConfigurationInterface.php
+++ b/src/Sylius/Component/Core/Promotion/ChannelAwareConfigurationInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Promotion;
+
+interface ChannelAwareConfigurationInterface
+{
+    public const CHANNELS_CONFIGURATION_KEY = '_channels';
+}

--- a/src/Sylius/Component/Core/Promotion/ChannelAwareConfigurationInterface.php
+++ b/src/Sylius/Component/Core/Promotion/ChannelAwareConfigurationInterface.php
@@ -15,5 +15,5 @@ namespace Sylius\Component\Core\Promotion;
 
 interface ChannelAwareConfigurationInterface
 {
-    public const CHANNELS_CONFIGURATION_KEY = '_channels';
+    public const EXCLUDED_CHANNELS_CONFIGURATION_KEY = '_excludedChannels';
 }

--- a/src/Sylius/Component/Core/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityChecker.php
@@ -58,7 +58,12 @@ final class ChannelAwarePromotionRulesEligibilityChecker implements PromotionEli
             return false;
         }
 
-        return in_array($subject->getChannel()->getCode(), $excludedChannels, true);
+        $channel = $subject->getChannel();
+        if ($channel === null) {
+            return false;
+        }
+
+        return in_array($channel->getCode(), $excludedChannels, true);
     }
 
     private function isEligibleToRule(PromotionSubjectInterface $subject, PromotionRuleInterface $rule): bool

--- a/src/Sylius/Component/Core/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityChecker.php
@@ -49,8 +49,8 @@ final class ChannelAwarePromotionRulesEligibilityChecker implements PromotionEli
 
     private function isRuleSkippedForChannel(PromotionRuleInterface $rule, PromotionSubjectInterface $subject): bool
     {
-        $channels = $rule->getConfiguration()[self::CHANNELS_CONFIGURATION_KEY] ?? [];
-        if ($channels === []) {
+        $excludedChannels = $rule->getConfiguration()[self::EXCLUDED_CHANNELS_CONFIGURATION_KEY] ?? [];
+        if ($excludedChannels === []) {
             return false;
         }
 
@@ -58,7 +58,7 @@ final class ChannelAwarePromotionRulesEligibilityChecker implements PromotionEli
             return false;
         }
 
-        return !in_array($subject->getChannel()->getCode(), $channels, true);
+        return in_array($subject->getChannel()->getCode(), $excludedChannels, true);
     }
 
     private function isEligibleToRule(PromotionSubjectInterface $subject, PromotionRuleInterface $rule): bool
@@ -67,7 +67,7 @@ final class ChannelAwarePromotionRulesEligibilityChecker implements PromotionEli
         $checker = $this->ruleRegistry->get($rule->getType());
 
         $configuration = $rule->getConfiguration();
-        unset($configuration[self::CHANNELS_CONFIGURATION_KEY]);
+        unset($configuration[self::EXCLUDED_CHANNELS_CONFIGURATION_KEY]);
 
         return $checker->isEligible($subject, $configuration);
     }

--- a/src/Sylius/Component/Core/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityChecker.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Promotion\Checker\Eligibility;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
+use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+
+final class ChannelAwarePromotionRulesEligibilityChecker implements PromotionEligibilityCheckerInterface, ChannelAwareConfigurationInterface
+{
+    public function __construct(private ServiceRegistryInterface $ruleRegistry)
+    {
+    }
+
+    public function isEligible(PromotionSubjectInterface $promotionSubject, PromotionInterface $promotion): bool
+    {
+        if (!$promotion->hasRules()) {
+            return true;
+        }
+
+        foreach ($promotion->getRules() as $rule) {
+            if ($this->isRuleSkippedForChannel($rule, $promotionSubject)) {
+                continue;
+            }
+
+            if (!$this->isEligibleToRule($promotionSubject, $rule)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isRuleSkippedForChannel(PromotionRuleInterface $rule, PromotionSubjectInterface $subject): bool
+    {
+        $channels = $rule->getConfiguration()[self::CHANNELS_CONFIGURATION_KEY] ?? [];
+        if ($channels === []) {
+            return false;
+        }
+
+        if (!$subject instanceof OrderInterface) {
+            return false;
+        }
+
+        return !in_array($subject->getChannel()->getCode(), $channels, true);
+    }
+
+    private function isEligibleToRule(PromotionSubjectInterface $subject, PromotionRuleInterface $rule): bool
+    {
+        /** @var RuleCheckerInterface $checker */
+        $checker = $this->ruleRegistry->get($rule->getType());
+
+        $configuration = $rule->getConfiguration();
+        unset($configuration[self::CHANNELS_CONFIGURATION_KEY]);
+
+        return $checker->isEligible($subject, $configuration);
+    }
+}

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/PerChannelRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/PerChannelRuleChecker.php
@@ -35,7 +35,12 @@ final class PerChannelRuleChecker implements RuleCheckerInterface
             throw new UnsupportedTypeException($subject, OrderInterface::class);
         }
 
-        $channelCode = $subject->getChannel()->getCode();
+        $channel = $subject->getChannel();
+        if ($channel === null) {
+            return false;
+        }
+
+        $channelCode = $channel->getCode();
         if (!isset($configuration[$channelCode])) {
             return false;
         }

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/PerChannelRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/PerChannelRuleChecker.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Promotion\Checker\Rule;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+
+final class PerChannelRuleChecker implements RuleCheckerInterface
+{
+    public function __construct(private RuleCheckerInterface $decorated)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     *
+     * @throws UnsupportedTypeException
+     */
+    public function isEligible(PromotionSubjectInterface $subject, array $configuration): bool
+    {
+        if (!$subject instanceof OrderInterface) {
+            throw new UnsupportedTypeException($subject, OrderInterface::class);
+        }
+
+        $channelCode = $subject->getChannel()->getCode();
+        if (!isset($configuration[$channelCode])) {
+            return false;
+        }
+
+        return $this->decorated->isEligible($subject, $configuration[$channelCode]);
+    }
+}

--- a/src/Sylius/Component/Core/tests/Promotion/Action/ChannelAwarePromotionApplicatorTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Action/ChannelAwarePromotionApplicatorTest.php
@@ -1,0 +1,368 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Core\Promotion\Action;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\Action\ChannelAwarePromotionApplicator;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Promotion\Action\PromotionActionCommandInterface;
+use Sylius\Component\Promotion\Action\PromotionApplicatorInterface;
+use Sylius\Component\Promotion\Model\PromotionActionInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+
+#[CoversClass(ChannelAwarePromotionApplicator::class)]
+final class ChannelAwarePromotionApplicatorTest extends TestCase
+{
+    private MockObject&PromotionActionCommandInterface $actionCommand;
+
+    private MockObject&PromotionActionInterface $action;
+
+    private MockObject&PromotionInterface $promotion;
+
+    private MockObject&OrderInterface $order;
+
+    private MockObject&PromotionSubjectInterface $subject;
+
+    private ChannelInterface&MockObject $channel;
+
+    private MockObject&ServiceRegistryInterface $serviceRegistry;
+
+    private ChannelAwarePromotionApplicator $applicator;
+
+    protected function setUp(): void
+    {
+        $this->actionCommand = $this->createMock(PromotionActionCommandInterface::class);
+        $this->action = $this->createMock(PromotionActionInterface::class);
+        $this->promotion = $this->createMock(PromotionInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->subject = $this->createMock(PromotionSubjectInterface::class);
+        $this->channel = $this->createMock(ChannelInterface::class);
+        $this->serviceRegistry = $this->createMock(ServiceRegistryInterface::class);
+        $this->applicator = new ChannelAwarePromotionApplicator($this->serviceRegistry);
+    }
+
+    public function testShouldImplementPromotionApplicatorInterfaceAndChannelAwareConfigurationInterface(): void
+    {
+        $this->assertInstanceOf(PromotionApplicatorInterface::class, $this->applicator);
+        $this->assertInstanceOf(ChannelAwareConfigurationInterface::class, $this->applicator);
+    }
+
+    public function testShouldExecuteActionAndAddPromotionIfActionReturnsTrue(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->order, [], $this->promotion)
+            ->willReturn(true);
+
+        $this->order->expects($this->once())->method('addPromotion')->with($this->promotion);
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldNotAddPromotionIfActionReturnsFalse(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->order, [], $this->promotion)
+            ->willReturn(false);
+
+        $this->order->expects($this->never())->method('addPromotion');
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldSkipActionDuringApplyIfChannelNotMatching(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('MOBILE');
+
+        $this->serviceRegistry->expects($this->never())->method('get');
+        $this->actionCommand->expects($this->never())->method('execute');
+        $this->order->expects($this->never())->method('addPromotion');
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldExecuteActionDuringApplyIfChannelMatches(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('WEB');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->order, [], $this->promotion)
+            ->willReturn(true);
+
+        $this->order->expects($this->once())->method('addPromotion')->with($this->promotion);
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldExecuteActionIfChannelsListIsEmpty(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => []]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->order, [], $this->promotion)
+            ->willReturn(true);
+
+        $this->order->expects($this->once())->method('addPromotion')->with($this->promotion);
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldNotSkipActionIfSubjectIsNotOrderInterface(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->subject, [], $this->promotion)
+            ->willReturn(true);
+
+        $this->subject->expects($this->once())->method('addPromotion')->with($this->promotion);
+
+        $this->applicator->apply($this->subject, $this->promotion);
+    }
+
+    public function testShouldStripChannelsKeyFromConfigurationDuringApply(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([
+                'amount' => 100,
+                ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB'],
+            ]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_fixed_discount');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('WEB');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->order, ['amount' => 100], $this->promotion)
+            ->willReturn(true);
+
+        $this->order->expects($this->once())->method('addPromotion')->with($this->promotion);
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldAddPromotionIfAtLeastOneActionAppliedDespiteOtherBeingSkipped(): void
+    {
+        $secondAction = $this->createMock(PromotionActionInterface::class);
+
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action, $secondAction]),
+        );
+
+        $this->action
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+
+        $secondAction->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $secondAction->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('MOBILE');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->order, [], $this->promotion)
+            ->willReturn(true);
+
+        $this->order->expects($this->once())->method('addPromotion')->with($this->promotion);
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldNotAddPromotionIfAllActionsSkippedDueToChannel(): void
+    {
+        $secondAction = $this->createMock(PromotionActionInterface::class);
+
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action, $secondAction]),
+        );
+
+        $this->action
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $secondAction
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('MOBILE');
+
+        $this->serviceRegistry->expects($this->never())->method('get');
+        $this->order->expects($this->never())->method('addPromotion');
+
+        $this->applicator->apply($this->order, $this->promotion);
+    }
+
+    public function testShouldSkipActionDuringRevertIfChannelNotMatching(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('MOBILE');
+
+        $this->serviceRegistry->expects($this->never())->method('get');
+        $this->actionCommand->expects($this->never())->method('revert');
+        $this->order->expects($this->once())->method('removePromotion')->with($this->promotion);
+
+        $this->applicator->revert($this->order, $this->promotion);
+    }
+
+    public function testShouldRevertActionIfChannelMatches(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('WEB');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('revert')
+            ->with($this->order, [], $this->promotion);
+
+        $this->order->expects($this->once())->method('removePromotion')->with($this->promotion);
+
+        $this->applicator->revert($this->order, $this->promotion);
+    }
+
+    public function testShouldStripChannelsKeyFromConfigurationDuringRevert(): void
+    {
+        $this->promotion->expects($this->once())->method('getActions')->willReturn(
+            new ArrayCollection([$this->action]),
+        );
+
+        $this->action
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([
+                'amount' => 100,
+                ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB'],
+            ]);
+        $this->action->expects($this->once())->method('getType')->willReturn('order_fixed_discount');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('WEB');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
+        $this->actionCommand
+            ->expects($this->once())
+            ->method('revert')
+            ->with($this->order, ['amount' => 100], $this->promotion);
+
+        $this->order->expects($this->once())->method('removePromotion')->with($this->promotion);
+
+        $this->applicator->revert($this->order, $this->promotion);
+    }
+}

--- a/src/Sylius/Component/Core/tests/Promotion/Action/ChannelAwarePromotionApplicatorTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Action/ChannelAwarePromotionApplicatorTest.php
@@ -116,7 +116,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
 
         $this->order->method('getChannel')->willReturn($this->channel);
         $this->channel->method('getCode')->willReturn('MOBILE');
@@ -137,7 +137,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
 
         $this->order->method('getChannel')->willReturn($this->channel);
@@ -164,7 +164,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => []]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => []]);
         $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
 
         $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
@@ -188,7 +188,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
 
         $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->actionCommand);
@@ -203,7 +203,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->applicator->apply($this->subject, $this->promotion);
     }
 
-    public function testShouldStripChannelsKeyFromConfigurationDuringApply(): void
+    public function testShouldStripExcludedChannelsKeyFromConfigurationDuringApply(): void
     {
         $this->promotion->expects($this->once())->method('getActions')->willReturn(
             new ArrayCollection([$this->action]),
@@ -214,7 +214,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
             ->method('getConfiguration')
             ->willReturn([
                 'amount' => 100,
-                ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB'],
+                ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE'],
             ]);
         $this->action->expects($this->once())->method('getType')->willReturn('order_fixed_discount');
 
@@ -244,7 +244,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
 
         $secondAction->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
         $secondAction->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
@@ -275,11 +275,11 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $secondAction
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
 
         $this->order->method('getChannel')->willReturn($this->channel);
         $this->channel->method('getCode')->willReturn('MOBILE');
@@ -299,7 +299,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
 
         $this->order->method('getChannel')->willReturn($this->channel);
         $this->channel->method('getCode')->willReturn('MOBILE');
@@ -320,7 +320,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->action
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $this->action->expects($this->once())->method('getType')->willReturn('order_percentage_discount');
 
         $this->order->method('getChannel')->willReturn($this->channel);
@@ -337,7 +337,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
         $this->applicator->revert($this->order, $this->promotion);
     }
 
-    public function testShouldStripChannelsKeyFromConfigurationDuringRevert(): void
+    public function testShouldStripExcludedChannelsKeyFromConfigurationDuringRevert(): void
     {
         $this->promotion->expects($this->once())->method('getActions')->willReturn(
             new ArrayCollection([$this->action]),
@@ -348,7 +348,7 @@ final class ChannelAwarePromotionApplicatorTest extends TestCase
             ->method('getConfiguration')
             ->willReturn([
                 'amount' => 100,
-                ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB'],
+                ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE'],
             ]);
         $this->action->expects($this->once())->method('getType')->willReturn('order_fixed_discount');
 

--- a/src/Sylius/Component/Core/tests/Promotion/Action/PerChannelPromotionActionCommandTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Action/PerChannelPromotionActionCommandTest.php
@@ -73,6 +73,14 @@ final class PerChannelPromotionActionCommandTest extends TestCase
         $this->assertFalse($this->command->execute($this->order, ['WEB_EU' => ['percentage' => 0.2]], $this->promotion));
     }
 
+    public function testShouldNotExecuteDecoratedCommandWhenOrderHasNoChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn(null);
+        $this->decorated->expects($this->never())->method('execute');
+
+        $this->assertFalse($this->command->execute($this->order, ['WEB_US' => ['percentage' => 0.2]], $this->promotion));
+    }
+
     public function testShouldThrowExceptionWhenExecutingIfPromotionSubjectIsNotOrder(): void
     {
         $this->expectException(UnexpectedTypeException::class);
@@ -99,6 +107,14 @@ final class PerChannelPromotionActionCommandTest extends TestCase
         $this->decorated->expects($this->never())->method('revert');
 
         $this->command->revert($this->order, ['WEB_EU' => ['percentage' => 0.2]], $this->promotion);
+    }
+
+    public function testShouldNotRevertDecoratedCommandWhenOrderHasNoChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn(null);
+        $this->decorated->expects($this->never())->method('revert');
+
+        $this->command->revert($this->order, ['WEB_US' => ['percentage' => 0.2]], $this->promotion);
     }
 
     public function testShouldThrowExceptionWhenRevertingIfPromotionSubjectIsNotOrder(): void

--- a/src/Sylius/Component/Core/tests/Promotion/Action/PerChannelPromotionActionCommandTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Action/PerChannelPromotionActionCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Core\Promotion\Action;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\Action\PerChannelPromotionActionCommand;
+use Sylius\Component\Promotion\Action\PromotionActionCommandInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Resource\Exception\UnexpectedTypeException;
+
+#[CoversClass(PerChannelPromotionActionCommand::class)]
+final class PerChannelPromotionActionCommandTest extends TestCase
+{
+    private MockObject&PromotionActionCommandInterface $decorated;
+
+    private ChannelInterface&MockObject $channel;
+
+    private MockObject&OrderInterface $order;
+
+    private MockObject&PromotionInterface $promotion;
+
+    private PerChannelPromotionActionCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->decorated = $this->createMock(PromotionActionCommandInterface::class);
+        $this->channel = $this->createMock(ChannelInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->promotion = $this->createMock(PromotionInterface::class);
+        $this->command = new PerChannelPromotionActionCommand($this->decorated);
+    }
+
+    public function testShouldImplementPromotionActionCommandInterface(): void
+    {
+        $this->assertInstanceOf(PromotionActionCommandInterface::class, $this->command);
+    }
+
+    public function testShouldExecuteDecoratedCommandWithTheChannelConfiguration(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->once())
+            ->method('execute')
+            ->with($this->order, ['percentage' => 0.2], $this->promotion)
+            ->willReturn(true)
+        ;
+
+        $this->assertTrue($this->command->execute($this->order, ['WEB_US' => ['percentage' => 0.2]], $this->promotion));
+    }
+
+    public function testShouldNotExecuteDecoratedCommandIfThereIsNoConfigurationForTheOrderChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->never())->method('execute');
+
+        $this->assertFalse($this->command->execute($this->order, ['WEB_EU' => ['percentage' => 0.2]], $this->promotion));
+    }
+
+    public function testShouldThrowExceptionWhenExecutingIfPromotionSubjectIsNotOrder(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->command->execute($this->createMock(PromotionSubjectInterface::class), [], $this->promotion);
+    }
+
+    public function testShouldRevertDecoratedCommandWithTheChannelConfiguration(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->once())
+            ->method('revert')
+            ->with($this->order, ['percentage' => 0.2], $this->promotion)
+        ;
+
+        $this->command->revert($this->order, ['WEB_US' => ['percentage' => 0.2]], $this->promotion);
+    }
+
+    public function testShouldNotRevertDecoratedCommandIfThereIsNoConfigurationForTheOrderChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->never())->method('revert');
+
+        $this->command->revert($this->order, ['WEB_EU' => ['percentage' => 0.2]], $this->promotion);
+    }
+
+    public function testShouldThrowExceptionWhenRevertingIfPromotionSubjectIsNotOrder(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->command->revert($this->createMock(PromotionSubjectInterface::class), [], $this->promotion);
+    }
+}

--- a/src/Sylius/Component/Core/tests/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityCheckerTest.php
@@ -141,7 +141,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->assertFalse($this->checker->isEligible($this->order, $this->promotion));
     }
 
-    public function testShouldSkipRuleIfCurrentChannelNotInChannelsList(): void
+    public function testShouldSkipRuleIfCurrentChannelIsInExcludedChannelsList(): void
     {
         $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
         $this->promotion->expects($this->once())->method('getRules')->willReturn(
@@ -151,7 +151,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->rule
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
 
         $this->order->method('getChannel')->willReturn($this->channel);
         $this->channel->method('getCode')->willReturn('MOBILE');
@@ -161,7 +161,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
     }
 
-    public function testShouldNotSkipRuleIfCurrentChannelIsInChannelsList(): void
+    public function testShouldNotSkipRuleIfCurrentChannelIsNotInExcludedChannelsList(): void
     {
         $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
         $this->promotion->expects($this->once())->method('getRules')->willReturn(
@@ -171,7 +171,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->rule
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
 
         $this->order->method('getChannel')->willReturn($this->channel);
@@ -193,7 +193,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->rule
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => []]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => []]);
         $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
 
         $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
@@ -212,7 +212,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->rule
             ->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
 
         $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
@@ -221,7 +221,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->assertTrue($this->checker->isEligible($this->subject, $this->promotion));
     }
 
-    public function testShouldStripChannelsKeyFromConfigurationBeforePassingToRuleChecker(): void
+    public function testShouldStripExcludedChannelsKeyFromConfigurationBeforePassingToRuleChecker(): void
     {
         $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
         $this->promotion->expects($this->once())->method('getRules')->willReturn(
@@ -233,7 +233,7 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
             ->method('getConfiguration')
             ->willReturn([
                 'count' => 3,
-                ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB'],
+                ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE'],
             ]);
         $this->rule->expects($this->once())->method('getType')->willReturn('cart_quantity');
 
@@ -262,11 +262,11 @@ final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
         $this->rule
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
         $secondRule
             ->expects($this->once())
             ->method('getConfiguration')
-            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+            ->willReturn([ChannelAwareConfigurationInterface::EXCLUDED_CHANNELS_CONFIGURATION_KEY => ['MOBILE']]);
 
         $this->order->method('getChannel')->willReturn($this->channel);
         $this->channel->method('getCode')->willReturn('MOBILE');

--- a/src/Sylius/Component/Core/tests/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Checker/Eligibility/ChannelAwarePromotionRulesEligibilityCheckerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Core\Promotion\Checker\Eligibility;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\ChannelAwareConfigurationInterface;
+use Sylius\Component\Core\Promotion\Checker\Eligibility\ChannelAwarePromotionRulesEligibilityChecker;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
+use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+
+#[CoversClass(ChannelAwarePromotionRulesEligibilityChecker::class)]
+final class ChannelAwarePromotionRulesEligibilityCheckerTest extends TestCase
+{
+    private MockObject&RuleCheckerInterface $ruleChecker;
+
+    private MockObject&PromotionRuleInterface $rule;
+
+    private MockObject&PromotionInterface $promotion;
+
+    private MockObject&OrderInterface $order;
+
+    private MockObject&PromotionSubjectInterface $subject;
+
+    private ChannelInterface&MockObject $channel;
+
+    private MockObject&ServiceRegistryInterface $serviceRegistry;
+
+    private ChannelAwarePromotionRulesEligibilityChecker $checker;
+
+    protected function setUp(): void
+    {
+        $this->ruleChecker = $this->createMock(RuleCheckerInterface::class);
+        $this->rule = $this->createMock(PromotionRuleInterface::class);
+        $this->promotion = $this->createMock(PromotionInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->subject = $this->createMock(PromotionSubjectInterface::class);
+        $this->channel = $this->createMock(ChannelInterface::class);
+        $this->serviceRegistry = $this->createMock(ServiceRegistryInterface::class);
+        $this->checker = new ChannelAwarePromotionRulesEligibilityChecker($this->serviceRegistry);
+    }
+
+    public function testShouldImplementPromotionEligibilityCheckerInterfaceAndChannelAwareConfigurationInterface(): void
+    {
+        $this->assertInstanceOf(PromotionEligibilityCheckerInterface::class, $this->checker);
+        $this->assertInstanceOf(ChannelAwareConfigurationInterface::class, $this->checker);
+    }
+
+    public function testShouldReturnEligibleIfPromotionHasNoRules(): void
+    {
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(false);
+        $this->promotion->expects($this->never())->method('getRules');
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldReturnEligibleIfAllRulesPassWithNoChannelRestriction(): void
+    {
+        $secondRule = $this->createMock(PromotionRuleInterface::class);
+
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule, $secondRule]),
+        );
+
+        $this->rule->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
+        $secondRule->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $secondRule->expects($this->once())->method('getType')->willReturn('cart_quantity');
+
+        $this->serviceRegistry->expects($this->exactly(2))->method('get')->willReturn($this->ruleChecker);
+        $this->ruleChecker->expects($this->exactly(2))->method('isEligible')->willReturn(true);
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldReturnNotEligibleIfAnyRuleFails(): void
+    {
+        $secondRule = $this->createMock(PromotionRuleInterface::class);
+
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule, $secondRule]),
+        );
+
+        $this->rule->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
+        $secondRule->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $secondRule->expects($this->once())->method('getType')->willReturn('cart_quantity');
+
+        $firstRuleChecker = $this->createMock(RuleCheckerInterface::class);
+        $secondRuleChecker = $this->createMock(RuleCheckerInterface::class);
+
+        $this->serviceRegistry
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls($firstRuleChecker, $secondRuleChecker);
+
+        $firstRuleChecker->expects($this->once())->method('isEligible')->willReturn(true);
+        $secondRuleChecker->expects($this->once())->method('isEligible')->willReturn(false);
+
+        $this->assertFalse($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldStopCheckingRulesAfterFirstFailure(): void
+    {
+        $secondRule = $this->createMock(PromotionRuleInterface::class);
+
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule, $secondRule]),
+        );
+
+        $this->rule->expects($this->exactly(2))->method('getConfiguration')->willReturn([]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
+        $secondRule->expects($this->never())->method('getType');
+        $secondRule->expects($this->never())->method('getConfiguration');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
+        $this->ruleChecker->expects($this->once())->method('isEligible')->willReturn(false);
+
+        $this->assertFalse($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldSkipRuleIfCurrentChannelNotInChannelsList(): void
+    {
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule]),
+        );
+
+        $this->rule
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('MOBILE');
+
+        $this->serviceRegistry->expects($this->never())->method('get');
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldNotSkipRuleIfCurrentChannelIsInChannelsList(): void
+    {
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule]),
+        );
+
+        $this->rule
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('WEB');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
+        $this->ruleChecker->expects($this->once())->method('isEligible')->willReturn(true);
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldNotSkipRuleIfChannelsListIsEmpty(): void
+    {
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule]),
+        );
+
+        $this->rule
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => []]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
+        $this->ruleChecker->expects($this->once())->method('isEligible')->willReturn(true);
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldNotSkipRuleIfSubjectIsNotAnOrderInterface(): void
+    {
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule]),
+        );
+
+        $this->rule
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('item_total');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
+        $this->ruleChecker->expects($this->once())->method('isEligible')->willReturn(true);
+
+        $this->assertTrue($this->checker->isEligible($this->subject, $this->promotion));
+    }
+
+    public function testShouldStripChannelsKeyFromConfigurationBeforePassingToRuleChecker(): void
+    {
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule]),
+        );
+
+        $this->rule
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->willReturn([
+                'count' => 3,
+                ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB'],
+            ]);
+        $this->rule->expects($this->once())->method('getType')->willReturn('cart_quantity');
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('WEB');
+
+        $this->serviceRegistry->expects($this->once())->method('get')->willReturn($this->ruleChecker);
+        $this->ruleChecker
+            ->expects($this->once())
+            ->method('isEligible')
+            ->with($this->order, ['count' => 3])
+            ->willReturn(true);
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+
+    public function testShouldReturnEligibleIfAllRulesForCurrentChannelAreSkipped(): void
+    {
+        $secondRule = $this->createMock(PromotionRuleInterface::class);
+
+        $this->promotion->expects($this->once())->method('hasRules')->willReturn(true);
+        $this->promotion->expects($this->once())->method('getRules')->willReturn(
+            new ArrayCollection([$this->rule, $secondRule]),
+        );
+
+        $this->rule
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+        $secondRule
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn([ChannelAwareConfigurationInterface::CHANNELS_CONFIGURATION_KEY => ['WEB']]);
+
+        $this->order->method('getChannel')->willReturn($this->channel);
+        $this->channel->method('getCode')->willReturn('MOBILE');
+
+        $this->serviceRegistry->expects($this->never())->method('get');
+
+        $this->assertTrue($this->checker->isEligible($this->order, $this->promotion));
+    }
+}

--- a/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/PerChannelRuleCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/PerChannelRuleCheckerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Core\Promotion\Checker\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\Checker\Rule\PerChannelRuleChecker;
+use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+
+#[CoversClass(PerChannelRuleChecker::class)]
+final class PerChannelRuleCheckerTest extends TestCase
+{
+    private MockObject&RuleCheckerInterface $decorated;
+
+    private ChannelInterface&MockObject $channel;
+
+    private MockObject&OrderInterface $order;
+
+    private PerChannelRuleChecker $ruleChecker;
+
+    protected function setUp(): void
+    {
+        $this->decorated = $this->createMock(RuleCheckerInterface::class);
+        $this->channel = $this->createMock(ChannelInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->ruleChecker = new PerChannelRuleChecker($this->decorated);
+    }
+
+    public function testShouldImplementRuleCheckerInterface(): void
+    {
+        $this->assertInstanceOf(RuleCheckerInterface::class, $this->ruleChecker);
+    }
+
+    public function testShouldDelegateToDecoratedCheckerWithTheChannelConfiguration(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->once())
+            ->method('isEligible')
+            ->with($this->order, ['nth' => 5])
+            ->willReturn(true)
+        ;
+
+        $this->assertTrue($this->ruleChecker->isEligible($this->order, ['WEB_US' => ['nth' => 5]]));
+    }
+
+    public function testShouldReturnDecoratedCheckerResultForTheOrderChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->once())
+            ->method('isEligible')
+            ->with($this->order, ['nth' => 5])
+            ->willReturn(false)
+        ;
+
+        $this->assertFalse($this->ruleChecker->isEligible($this->order, ['WEB_US' => ['nth' => 5]]));
+    }
+
+    public function testShouldReturnFalseAndNotDelegateIfThereIsNoConfigurationForTheOrderChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->decorated->expects($this->never())->method('isEligible');
+
+        $this->assertFalse($this->ruleChecker->isEligible($this->order, ['WEB_EU' => ['nth' => 5]]));
+    }
+
+    public function testShouldThrowExceptionIfPromotionSubjectIsNotOrder(): void
+    {
+        $this->expectException(UnsupportedTypeException::class);
+
+        $this->ruleChecker->isEligible($this->createMock(PromotionSubjectInterface::class), []);
+    }
+}

--- a/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/PerChannelRuleCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/PerChannelRuleCheckerTest.php
@@ -82,6 +82,14 @@ final class PerChannelRuleCheckerTest extends TestCase
         $this->assertFalse($this->ruleChecker->isEligible($this->order, ['WEB_EU' => ['nth' => 5]]));
     }
 
+    public function testShouldReturnFalseAndNotDelegateWhenOrderHasNoChannel(): void
+    {
+        $this->order->expects($this->once())->method('getChannel')->willReturn(null);
+        $this->decorated->expects($this->never())->method('isEligible');
+
+        $this->assertFalse($this->ruleChecker->isEligible($this->order, ['WEB_US' => ['nth' => 5]]));
+    }
+
     public function testShouldThrowExceptionIfPromotionSubjectIsNotOrder(): void
     {
         $this->expectException(UnsupportedTypeException::class);

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_actions_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_actions_response.json
@@ -38,7 +38,7 @@
         },
         {
             "propertyPath": "actions[5].type",
-            "message": "Promotion action type is invalid. Available action types are order_fixed_discount, unit_fixed_discount, order_percentage_discount, unit_percentage_discount, shipping_percentage_discount, order_percentage_discount_per_channel, shipping_percentage_discount_per_channel.",
+            "message": "Promotion action type is invalid. Available action types are order_fixed_discount, unit_fixed_discount, order_percentage_discount, order_percentage_discount_per_channel, unit_percentage_discount, shipping_percentage_discount, shipping_percentage_discount_per_channel.",
             "code": null
         }
     ],

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_actions_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_actions_response.json
@@ -38,7 +38,7 @@
         },
         {
             "propertyPath": "actions[5].type",
-            "message": "Promotion action type is invalid. Available action types are order_fixed_discount, unit_fixed_discount, order_percentage_discount, unit_percentage_discount, shipping_percentage_discount.",
+            "message": "Promotion action type is invalid. Available action types are order_fixed_discount, unit_fixed_discount, order_percentage_discount, unit_percentage_discount, shipping_percentage_discount, order_percentage_discount_per_channel, shipping_percentage_discount_per_channel.",
             "code": null
         }
     ],

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_rules_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_rules_response.json
@@ -53,7 +53,7 @@
         },
         {
             "propertyPath": "rules[8].type",
-            "message": "Promotion rule type is invalid. Available rule types are customer_group, nth_order, shipping_country, has_taxon, total_of_items_from_taxon, contains_product, item_total, cart_quantity, customer_group_per_channel, nth_order_per_channel, shipping_country_per_channel, has_taxon_per_channel, contains_product_per_channel, cart_quantity_per_channel.",
+            "message": "Promotion rule type is invalid. Available rule types are customer_group, customer_group_per_channel, nth_order, nth_order_per_channel, shipping_country, shipping_country_per_channel, has_taxon, has_taxon_per_channel, total_of_items_from_taxon, contains_product, contains_product_per_channel, item_total, cart_quantity, cart_quantity_per_channel.",
             "code": null
         }
     ],

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_rules_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_rules_response.json
@@ -53,7 +53,7 @@
         },
         {
             "propertyPath": "rules[8].type",
-            "message": "Promotion rule type is invalid. Available rule types are customer_group, nth_order, shipping_country, has_taxon, total_of_items_from_taxon, contains_product, item_total, cart_quantity.",
+            "message": "Promotion rule type is invalid. Available rule types are customer_group, nth_order, shipping_country, has_taxon, total_of_items_from_taxon, contains_product, item_total, cart_quantity, customer_group_per_channel, nth_order_per_channel, shipping_country_per_channel, has_taxon_per_channel, contains_product_per_channel, cart_quantity_per_channel.",
             "code": null
         }
     ],


### PR DESCRIPTION
                                                                                                                                                                                                       
  | Q               | A                                                                                                                                                                                
  |-----------------|-----                                                                                                                                                                             
  | Branch?         | 2.3                                                                                                                                                                              
  | Bug fix?        | no                                                                                                                                                                               
  | New feature?    | yes                                                                                                                                                                              
  | BC breaks?      | no                                                                                                                                                                               
  | Related tickets | #18985                                                                                                                                                                           
  | License         | MIT                                                                                                                                                                              
                                                                                                                                                                                                       
  ## Description                                                                                                                                                                                       
                                                                                                                                                                                                       
  Introduces support for **independent promotion rules and actions per channel**.                                                                                                                      
                                                                                                                                                                                                       
  This feature allows merchants to configure different rule types and conditions for different channels within a single promotion, enabling more flexible multi-channel commerce strategies.           
                                                                                                                                                                                                       
  ### How It Works                                                                                                                                                                                     
                                                                                                                                                                                                       
  **Example:** A single promotion can have:                                                                                                                                                            
  - **Web-US channel**: ItemTotal rule (minimum $100)                                                                                                                                                  
  - **Web-GB channel**: CartQuantity rule (minimum 2 items)                                                                                                                                            
                                                                                                                                                                                                       
  This allows different business logic per channel while maintaining a unified promotion entity.                                                                                                       
                                                                                                                                                                                                       
  ### Implementation Details                                                                                                                                                                           
                                                                                                                                                                                                       
  - `ChannelAwarePromotionRulesEligibilityChecker` - handles channel-aware rule eligibility checking                                                                                                   
  - `ChannelAwarePromotionApplicator` - handles channel-aware action application                                                                                                                       
  - `PromotionConfigurationChannelCodesValidator` - validates referenced channel codes exist                                                                                                           
  - Comprehensive test coverage: 69 PHPUnit tests, 13 Behat scenarios                                                                                                                                  
