### PR TITLE
[Validator] Use named arguments in constraint constructors

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -124,6 +124,21 @@
    +new ProvinceAddressConstraint(message: 'My custom message')
    ```
 
+2. Several constraint message options have been renamed to follow the consistent `*Message` convention. The old option
+   names and public properties are **deprecated** since Sylius 2.3 and will be removed in Sylius 3.0. Both keep working
+   and stay in sync in the meantime; switch to the new `*Message` name:
+
+   | Constraint | Old | New |
+   |------------|-----|-----|
+   | `ApiBundle\...\ChosenPaymentMethodEligibility` | `notAvailable`, `notExist`, `paymentNotFound` | `notAvailableMessage`, `notExistMessage`, `paymentNotFoundMessage` |
+   | `ApiBundle\...\ChosenPaymentRequestActionEligibility` | `notAvailable`, `notExist` | `notAvailableMessage`, `notExistMessage` |
+   | `ApiBundle\...\AddingEligibleProductVariantToCart` | `productVariantNotSufficient` | `productVariantNotSufficientMessage` |
+   | `ApiBundle\...\ChangedItemQuantityInCart` | `productVariantNotLongerAvailable`, `productVariantNotSufficient` | `productVariantNotLongerAvailableMessage`, `productVariantNotSufficientMessage` |
+   | `PromotionBundle\...\PromotionRuleType`, `PromotionActionType`, `CatalogPromotionActionType`, `CatalogPromotionScopeType` | `invalidType` | `invalidTypeMessage` |
+   | `PaymentBundle\...\GatewayFactoryExists` | `invalidGatewayFactory` | `invalidGatewayFactoryMessage` |
+   | `ShippingBundle\...\ShippingMethodCalculatorExists` | `invalidShippingCalculator` | `invalidShippingCalculatorMessage` |
+   | `ShippingBundle\...\ShippingMethodRule` | `invalidType` | `invalidTypeMessage` |
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -108,6 +108,22 @@
    as `type="object"` (`PaymentSecurityToken.details` and `PaymentRequest.payload`), it registers
    a custom `Sylius\Bundle\PaymentBundle\Doctrine\DBAL\Type\ObjectType` to keep them working.
 
+## Validation
+
+1. Passing an array of options to configure a Sylius validation constraint is **deprecated** since Sylius 2.3 
+   and will be removed in Sylius 3.0. Use named arguments instead.
+
+   All Sylius validation constraints now declare explicit constructors with named arguments 
+   (marked with `#[HasNamedArguments]`). The legacy array syntax keeps working, it only triggers deprecation.
+
+   Configuring constraints via **XML / YAML / PHP attributes is not affected** and requires no changes; the validator 
+   loaders pass the options as named arguments automatically. Only **direct instantiation in PHP** should be migrated:
+
+   ```diff
+   -new ProvinceAddressConstraint(['message' => 'My custom message'])
+   +new ProvinceAddressConstraint(message: 'My custom message')
+   ```
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -110,13 +110,13 @@
 
 ## Validation
 
-1. Passing an array of options to configure a Sylius validation constraint is **deprecated** since Sylius 2.3 
+1. Passing an array of options to configure a Sylius validation constraint is **deprecated** since Sylius 2.3
    and will be removed in Sylius 3.0. Use named arguments instead.
 
-   All Sylius validation constraints now declare explicit constructors with named arguments 
+   All Sylius validation constraints now declare explicit constructors with named arguments
    (marked with `#[HasNamedArguments]`). The legacy array syntax keeps working, it only triggers deprecation.
 
-   Configuring constraints via **XML / YAML / PHP attributes is not affected** and requires no changes; the validator 
+   Configuring constraints via **XML / YAML / PHP attributes is not affected** and requires no changes; the validator
    loaders pass the options as named arguments automatically. Only **direct instantiation in PHP** should be migrated:
 
    ```diff

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
@@ -22,9 +22,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class ProvinceAddressConstraint extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.address.province.valid';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -32,7 +29,7 @@ class ProvinceAddressConstraint extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.address.province.valid',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -44,14 +41,12 @@ class ProvinceAddressConstraint extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -23,6 +24,20 @@ class ProvinceAddressConstraint extends Constraint
 {
     /** @var string */
     public $message = 'sylius.address.province.valid';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
@@ -26,14 +26,29 @@ class ProvinceAddressConstraint extends Constraint
     public $message = 'sylius.address.province.valid';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/addressing-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class UniqueProvinceCollection extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.country.unique_provinces',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.country.unique_provinces';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
@@ -25,7 +25,7 @@ final class UniqueProvinceCollection extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.country.unique_provinces',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class UniqueProvinceCollection extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.country.unique_provinces';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UniqueProvinceCollection extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.country.unique_provinces',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/addressing-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.country.unique_provinces';

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
@@ -25,7 +25,7 @@ final class ZoneCannotContainItself extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ZoneCannotContainItself extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ZoneCannotContainItself extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.zone_member.cannot_be_the_same_as_zone',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/addressing-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone';

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ZoneCannotContainItself extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.zone_member.cannot_be_the_same_as_zone',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/AddressingBundle/tests/Validator/Constraints/ProvinceAddressConstraintValidatorTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/tests/Validator/Constraints/ProvinceAddressConstraintValidatorTest.php
@@ -39,7 +39,7 @@ final class ProvinceAddressConstraintValidatorTest extends TestCase
 
     private AddressInterface&MockObject $address;
 
-    private MockObject&ProvinceAddressConstraint $constraint;
+    private ProvinceAddressConstraint $constraint;
 
     private ExecutionContextInterface&MockObject $context;
 
@@ -50,7 +50,7 @@ final class ProvinceAddressConstraintValidatorTest extends TestCase
         $this->countryRepository = $this->createMock(RepositoryInterface::class);
         $this->provinceRepository = $this->createMock(RepositoryInterface::class);
         $this->address = $this->createMock(AddressInterface::class);
-        $this->constraint = $this->createMock(ProvinceAddressConstraint::class);
+        $this->constraint = new ProvinceAddressConstraint();
         $this->context = $this->createMock(ExecutionContextInterface::class);
 
         $this->provinceAddressConstraintValidator = new ProvinceAddressConstraintValidator(

--- a/src/Sylius/Bundle/AddressingBundle/tests/Validator/Constraints/ZoneMemberGroupValidatorTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/tests/Validator/Constraints/ZoneMemberGroupValidatorTest.php
@@ -75,7 +75,7 @@ final class ZoneMemberGroupValidatorTest extends TestCase
         $validator->expects($this->once())->method('inContext')->with($this->context)->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate')->with($zoneMember, null, ['Default', 'zone_two'])->willReturn($contextualValidator);
 
-        $this->zoneMemberGroupValidator->validate($zoneMember, new ZoneMemberGroup(['groups' => ['Default', 'test_group']]));
+        $this->zoneMemberGroupValidator->validate($zoneMember, new ZoneMemberGroup(groups: ['Default', 'test_group']));
     }
 
     public function testCallsValidatorWithDefaultGroupsIfNoneProvidedForZoneMemberType(): void
@@ -95,7 +95,7 @@ final class ZoneMemberGroupValidatorTest extends TestCase
         $validator->expects($this->once())->method('inContext')->with($this->context)->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate')->with($zoneMember, null, ['Default', 'test_group'])->willReturn($contextualValidator);
 
-        $this->zoneMemberGroupValidator->validate($zoneMember, new ZoneMemberGroup(['groups' => ['Default', 'test_group']]));
+        $this->zoneMemberGroupValidator->validate($zoneMember, new ZoneMemberGroup(groups: ['Default', 'test_group']));
     }
 
     public function testCallsValidatorWithDefaultGroupsIfZoneIsNull(): void
@@ -112,6 +112,6 @@ final class ZoneMemberGroupValidatorTest extends TestCase
         $validator->expects($this->once())->method('inContext')->with($this->context)->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate')->with($zoneMember, null, ['Default', 'test_group'])->willReturn($contextualValidator);
 
-        $this->zoneMemberGroupValidator->validate($zoneMember, new ZoneMemberGroup(['groups' => ['Default', 'test_group']]));
+        $this->zoneMemberGroupValidator->validate($zoneMember, new ZoneMemberGroup(groups: ['Default', 'test_group']));
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -19,20 +19,38 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class AddingEligibleProductVariantToCart extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $productNotExistMessage = 'sylius.product.not_exist',
-        string $productVariantNotExistMessage = 'sylius.product_variant.not_exist',
-        string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient',
+        ?array $options = null,
+        ?string $productNotExistMessage = null,
+        ?string $productVariantNotExistMessage = null,
+        ?string $productVariantNotSufficient = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $productNotExistMessage ??= $options['productNotExistMessage'] ?? null;
+            $productVariantNotExistMessage ??= $options['productVariantNotExistMessage'] ?? null;
+            $productVariantNotSufficient ??= $options['productVariantNotSufficient'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->productNotExistMessage = $productNotExistMessage;
-        $this->productVariantNotExistMessage = $productVariantNotExistMessage;
-        $this->productVariantNotSufficient = $productVariantNotSufficient;
+        $this->productNotExistMessage = $productNotExistMessage ?? $this->productNotExistMessage;
+        $this->productVariantNotExistMessage = $productVariantNotExistMessage ?? $this->productVariantNotExistMessage;
+        $this->productVariantNotSufficient = $productVariantNotSufficient ?? $this->productVariantNotSufficient;
     }
 
     public string $productNotExistMessage = 'sylius.product.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -27,6 +27,7 @@ final class AddingEligibleProductVariantToCart extends Constraint
         ?array $options = null,
         ?string $productNotExistMessage = null,
         ?string $productVariantNotExistMessage = null,
+        ?string $productVariantNotSufficientMessage = null,
         ?string $productVariantNotSufficient = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -41,22 +42,38 @@ final class AddingEligibleProductVariantToCart extends Constraint
 
             $productNotExistMessage ??= $options['productNotExistMessage'] ?? null;
             $productVariantNotExistMessage ??= $options['productVariantNotExistMessage'] ?? null;
+            $productVariantNotSufficientMessage ??= $options['productVariantNotSufficientMessage'] ?? null;
             $productVariantNotSufficient ??= $options['productVariantNotSufficient'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
+        }
+
+        if (null !== $productVariantNotSufficient) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "productVariantNotSufficient" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "productVariantNotSufficientMessage" instead.',
+                static::class,
+            );
+
+            $productVariantNotSufficientMessage ??= $productVariantNotSufficient;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->productNotExistMessage = $productNotExistMessage ?? $this->productNotExistMessage;
         $this->productVariantNotExistMessage = $productVariantNotExistMessage ?? $this->productVariantNotExistMessage;
-        $this->productVariantNotSufficient = $productVariantNotSufficient ?? $this->productVariantNotSufficient;
+        $this->productVariantNotSufficientMessage = $productVariantNotSufficientMessage ?? $this->productVariantNotSufficientMessage;
+        $this->productVariantNotSufficient = $this->productVariantNotSufficientMessage;
     }
 
     public string $productNotExistMessage = 'sylius.product.not_exist';
 
     public string $productVariantNotExistMessage = 'sylius.product_variant.not_exist';
 
+    public string $productVariantNotSufficientMessage = 'sylius.product_variant.not_sufficient';
+
+    /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class AddingEligibleProductVariantToCart extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
+    public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -62,9 +65,6 @@ final class AddingEligibleProductVariantToCart extends Constraint
         parent::__construct(groups: $groups, payload: $payload);
         $this->productVariantNotSufficient = $this->productVariantNotSufficientMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
-    public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -25,9 +25,9 @@ final class AddingEligibleProductVariantToCart extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $productNotExistMessage = null,
-        ?string $productVariantNotExistMessage = null,
-        ?string $productVariantNotSufficientMessage = null,
+        public string $productNotExistMessage = 'sylius.product.not_exist',
+        public string $productVariantNotExistMessage = 'sylius.product_variant.not_exist',
+        public string $productVariantNotSufficientMessage = 'sylius.product_variant.not_sufficient',
         ?string $productVariantNotSufficient = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -40,9 +40,9 @@ final class AddingEligibleProductVariantToCart extends Constraint
                 static::class,
             );
 
-            $productNotExistMessage ??= $options['productNotExistMessage'] ?? null;
-            $productVariantNotExistMessage ??= $options['productVariantNotExistMessage'] ?? null;
-            $productVariantNotSufficientMessage ??= $options['productVariantNotSufficientMessage'] ?? null;
+            $this->productNotExistMessage = $options['productNotExistMessage'] ?? $this->productNotExistMessage;
+            $this->productVariantNotExistMessage = $options['productVariantNotExistMessage'] ?? $this->productVariantNotExistMessage;
+            $this->productVariantNotSufficientMessage = $options['productVariantNotSufficientMessage'] ?? $this->productVariantNotSufficientMessage;
             $productVariantNotSufficient ??= $options['productVariantNotSufficient'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -56,22 +56,12 @@ final class AddingEligibleProductVariantToCart extends Constraint
                 static::class,
             );
 
-            $productVariantNotSufficientMessage ??= $productVariantNotSufficient;
+            $this->productVariantNotSufficientMessage = $productVariantNotSufficient;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->productNotExistMessage = $productNotExistMessage ?? $this->productNotExistMessage;
-        $this->productVariantNotExistMessage = $productVariantNotExistMessage ?? $this->productVariantNotExistMessage;
-        $this->productVariantNotSufficientMessage = $productVariantNotSufficientMessage ?? $this->productVariantNotSufficientMessage;
         $this->productVariantNotSufficient = $this->productVariantNotSufficientMessage;
     }
-
-    public string $productNotExistMessage = 'sylius.product.not_exist';
-
-    public string $productVariantNotExistMessage = 'sylius.product_variant.not_exist';
-
-    public string $productVariantNotSufficientMessage = 'sylius.product_variant.not_sufficient';
 
     /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -13,11 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class AddingEligibleProductVariantToCart extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $productNotExistMessage = 'sylius.product.not_exist',
+        string $productVariantNotExistMessage = 'sylius.product_variant.not_exist',
+        string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->productNotExistMessage = $productNotExistMessage;
+        $this->productVariantNotExistMessage = $productVariantNotExistMessage;
+        $this->productVariantNotSufficient = $productVariantNotSufficient;
+    }
+
     public string $productNotExistMessage = 'sylius.product.not_exist';
 
     public string $productVariantNotExistMessage = 'sylius.product_variant.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCartValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCartValidator.php
@@ -92,7 +92,7 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
             $value->quantity + $this->getExistingCartItemQuantityFromCart($cart, $productVariant),
         )) {
             $this->context->addViolation(
-                $constraint->productVariantNotSufficient,
+                $constraint->productVariantNotSufficientMessage,
                 ['%productVariantCode%' => $productVariant->getCode()],
             );
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class AdminResetPasswordTokenNonExpired extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.admin.expired_password_reset_token',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.admin.expired_password_reset_token';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
@@ -25,7 +25,7 @@ final class AdminResetPasswordTokenNonExpired extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.admin.expired_password_reset_token',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class AdminResetPasswordTokenNonExpired extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.admin.expired_password_reset_token';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class AdminResetPasswordTokenNonExpired extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.admin.expired_password_reset_token',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.admin.expired_password_reset_token';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -13,11 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ChangedItemQuantityInCart extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $productNotExistMessage = 'sylius.product.not_exist',
+        string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available',
+        string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->productNotExistMessage = $productNotExistMessage;
+        $this->productVariantNotLongerAvailable = $productVariantNotLongerAvailable;
+        $this->productVariantNotSufficient = $productVariantNotSufficient;
+    }
+
     public string $productNotExistMessage = 'sylius.product.not_exist';
 
     public string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -19,6 +19,12 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChangedItemQuantityInCart extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $productVariantNotLongerAvailableMessage instead. It will be removed in Sylius 3.0. */
+    public string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available';
+
+    /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
+    public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -76,12 +82,6 @@ final class ChangedItemQuantityInCart extends Constraint
         $this->productVariantNotLongerAvailable = $this->productVariantNotLongerAvailableMessage;
         $this->productVariantNotSufficient = $this->productVariantNotSufficientMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $productVariantNotLongerAvailableMessage instead. It will be removed in Sylius 3.0. */
-    public string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available';
-
-    /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
-    public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -25,9 +25,9 @@ final class ChangedItemQuantityInCart extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $productNotExistMessage = null,
-        ?string $productVariantNotLongerAvailableMessage = null,
-        ?string $productVariantNotSufficientMessage = null,
+        public string $productNotExistMessage = 'sylius.product.not_exist',
+        public string $productVariantNotLongerAvailableMessage = 'sylius.product_variant.not_longer_available',
+        public string $productVariantNotSufficientMessage = 'sylius.product_variant.not_sufficient',
         ?string $productVariantNotLongerAvailable = null,
         ?string $productVariantNotSufficient = null,
         ?array $groups = null,
@@ -41,9 +41,9 @@ final class ChangedItemQuantityInCart extends Constraint
                 static::class,
             );
 
-            $productNotExistMessage ??= $options['productNotExistMessage'] ?? null;
-            $productVariantNotLongerAvailableMessage ??= $options['productVariantNotLongerAvailableMessage'] ?? null;
-            $productVariantNotSufficientMessage ??= $options['productVariantNotSufficientMessage'] ?? null;
+            $this->productNotExistMessage = $options['productNotExistMessage'] ?? $this->productNotExistMessage;
+            $this->productVariantNotLongerAvailableMessage = $options['productVariantNotLongerAvailableMessage'] ?? $this->productVariantNotLongerAvailableMessage;
+            $this->productVariantNotSufficientMessage = $options['productVariantNotSufficientMessage'] ?? $this->productVariantNotSufficientMessage;
             $productVariantNotLongerAvailable ??= $options['productVariantNotLongerAvailable'] ?? null;
             $productVariantNotSufficient ??= $options['productVariantNotSufficient'] ?? null;
             $groups ??= $options['groups'] ?? null;
@@ -58,7 +58,7 @@ final class ChangedItemQuantityInCart extends Constraint
                 static::class,
             );
 
-            $productVariantNotLongerAvailableMessage ??= $productVariantNotLongerAvailable;
+            $this->productVariantNotLongerAvailableMessage = $productVariantNotLongerAvailable;
         }
 
         if (null !== $productVariantNotSufficient) {
@@ -69,23 +69,13 @@ final class ChangedItemQuantityInCart extends Constraint
                 static::class,
             );
 
-            $productVariantNotSufficientMessage ??= $productVariantNotSufficient;
+            $this->productVariantNotSufficientMessage = $productVariantNotSufficient;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->productNotExistMessage = $productNotExistMessage ?? $this->productNotExistMessage;
-        $this->productVariantNotLongerAvailableMessage = $productVariantNotLongerAvailableMessage ?? $this->productVariantNotLongerAvailableMessage;
-        $this->productVariantNotSufficientMessage = $productVariantNotSufficientMessage ?? $this->productVariantNotSufficientMessage;
         $this->productVariantNotLongerAvailable = $this->productVariantNotLongerAvailableMessage;
         $this->productVariantNotSufficient = $this->productVariantNotSufficientMessage;
     }
-
-    public string $productNotExistMessage = 'sylius.product.not_exist';
-
-    public string $productVariantNotLongerAvailableMessage = 'sylius.product_variant.not_longer_available';
-
-    public string $productVariantNotSufficientMessage = 'sylius.product_variant.not_sufficient';
 
     /** @deprecated since Sylius 2.3, use $productVariantNotLongerAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -19,20 +19,38 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChangedItemQuantityInCart extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $productNotExistMessage = 'sylius.product.not_exist',
-        string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available',
-        string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient',
+        ?array $options = null,
+        ?string $productNotExistMessage = null,
+        ?string $productVariantNotLongerAvailable = null,
+        ?string $productVariantNotSufficient = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $productNotExistMessage ??= $options['productNotExistMessage'] ?? null;
+            $productVariantNotLongerAvailable ??= $options['productVariantNotLongerAvailable'] ?? null;
+            $productVariantNotSufficient ??= $options['productVariantNotSufficient'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->productNotExistMessage = $productNotExistMessage;
-        $this->productVariantNotLongerAvailable = $productVariantNotLongerAvailable;
-        $this->productVariantNotSufficient = $productVariantNotSufficient;
+        $this->productNotExistMessage = $productNotExistMessage ?? $this->productNotExistMessage;
+        $this->productVariantNotLongerAvailable = $productVariantNotLongerAvailable ?? $this->productVariantNotLongerAvailable;
+        $this->productVariantNotSufficient = $productVariantNotSufficient ?? $this->productVariantNotSufficient;
     }
 
     public string $productNotExistMessage = 'sylius.product.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -26,6 +26,8 @@ final class ChangedItemQuantityInCart extends Constraint
     public function __construct(
         ?array $options = null,
         ?string $productNotExistMessage = null,
+        ?string $productVariantNotLongerAvailableMessage = null,
+        ?string $productVariantNotSufficientMessage = null,
         ?string $productVariantNotLongerAvailable = null,
         ?string $productVariantNotSufficient = null,
         ?array $groups = null,
@@ -40,23 +42,55 @@ final class ChangedItemQuantityInCart extends Constraint
             );
 
             $productNotExistMessage ??= $options['productNotExistMessage'] ?? null;
+            $productVariantNotLongerAvailableMessage ??= $options['productVariantNotLongerAvailableMessage'] ?? null;
+            $productVariantNotSufficientMessage ??= $options['productVariantNotSufficientMessage'] ?? null;
             $productVariantNotLongerAvailable ??= $options['productVariantNotLongerAvailable'] ?? null;
             $productVariantNotSufficient ??= $options['productVariantNotSufficient'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $productVariantNotLongerAvailable) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "productVariantNotLongerAvailable" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "productVariantNotLongerAvailableMessage" instead.',
+                static::class,
+            );
+
+            $productVariantNotLongerAvailableMessage ??= $productVariantNotLongerAvailable;
+        }
+
+        if (null !== $productVariantNotSufficient) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "productVariantNotSufficient" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "productVariantNotSufficientMessage" instead.',
+                static::class,
+            );
+
+            $productVariantNotSufficientMessage ??= $productVariantNotSufficient;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->productNotExistMessage = $productNotExistMessage ?? $this->productNotExistMessage;
-        $this->productVariantNotLongerAvailable = $productVariantNotLongerAvailable ?? $this->productVariantNotLongerAvailable;
-        $this->productVariantNotSufficient = $productVariantNotSufficient ?? $this->productVariantNotSufficient;
+        $this->productVariantNotLongerAvailableMessage = $productVariantNotLongerAvailableMessage ?? $this->productVariantNotLongerAvailableMessage;
+        $this->productVariantNotSufficientMessage = $productVariantNotSufficientMessage ?? $this->productVariantNotSufficientMessage;
+        $this->productVariantNotLongerAvailable = $this->productVariantNotLongerAvailableMessage;
+        $this->productVariantNotSufficient = $this->productVariantNotSufficientMessage;
     }
 
     public string $productNotExistMessage = 'sylius.product.not_exist';
 
+    public string $productVariantNotLongerAvailableMessage = 'sylius.product_variant.not_longer_available';
+
+    public string $productVariantNotSufficientMessage = 'sylius.product_variant.not_sufficient';
+
+    /** @deprecated since Sylius 2.3, use $productVariantNotLongerAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available';
 
+    /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCartValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCartValidator.php
@@ -59,7 +59,7 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
 
         if ($productVariant === null) {
             $this->context->addViolation(
-                $constraint->productVariantNotLongerAvailable,
+                $constraint->productVariantNotLongerAvailableMessage,
                 ['%productVariantName%' => $orderItem->getVariantName()],
             );
 
@@ -81,7 +81,7 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
 
         if (!$productVariant->isEnabled()) {
             $this->context->addViolation(
-                $constraint->productVariantNotLongerAvailable,
+                $constraint->productVariantNotLongerAvailableMessage,
                 ['%productVariantName%' => $orderItem->getVariantName()],
             );
 
@@ -90,7 +90,7 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
 
         if (!$this->availabilityChecker->isStockSufficient($productVariant, $value->quantity)) {
             $this->context->addViolation(
-                $constraint->productVariantNotSufficient,
+                $constraint->productVariantNotSufficientMessage,
                 ['%productVariantCode%' => $productVariantCode],
             );
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class CheckoutCompletion extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.invalid_state_transition',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.invalid_state_transition';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class CheckoutCompletion extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.invalid_state_transition',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.invalid_state_transition';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
@@ -25,7 +25,7 @@ class CheckoutCompletion extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.invalid_state_transition',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ class CheckoutCompletion extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.invalid_state_transition';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -19,6 +19,15 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenPaymentMethodEligibility extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
+    public string $notAvailable = 'sylius.payment_method.not_available';
+
+    /** @deprecated since Sylius 2.3, use $notExistMessage instead. It will be removed in Sylius 3.0. */
+    public string $notExist = 'sylius.payment_method.not_exist';
+
+    /** @deprecated since Sylius 2.3, use $paymentNotFoundMessage instead. It will be removed in Sylius 3.0. */
+    public string $paymentNotFound = 'sylius.payment.not_found';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -90,15 +99,6 @@ final class ChosenPaymentMethodEligibility extends Constraint
         $this->notExist = $this->notExistMessage;
         $this->paymentNotFound = $this->paymentNotFoundMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
-    public string $notAvailable = 'sylius.payment_method.not_available';
-
-    /** @deprecated since Sylius 2.3, use $notExistMessage instead. It will be removed in Sylius 3.0. */
-    public string $notExist = 'sylius.payment_method.not_exist';
-
-    /** @deprecated since Sylius 2.3, use $paymentNotFoundMessage instead. It will be removed in Sylius 3.0. */
-    public string $paymentNotFound = 'sylius.payment.not_found';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -13,11 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ChosenPaymentMethodEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $notAvailable = 'sylius.payment_method.not_available',
+        string $notExist = 'sylius.payment_method.not_exist',
+        string $paymentNotFound = 'sylius.payment.not_found',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->notAvailable = $notAvailable;
+        $this->notExist = $notExist;
+        $this->paymentNotFound = $paymentNotFound;
+    }
+
     public string $notAvailable = 'sylius.payment_method.not_available';
 
     public string $notExist = 'sylius.payment_method.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -25,9 +25,9 @@ final class ChosenPaymentMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $notAvailableMessage = null,
-        ?string $notExistMessage = null,
-        ?string $paymentNotFoundMessage = null,
+        public string $notAvailableMessage = 'sylius.payment_method.not_available',
+        public string $notExistMessage = 'sylius.payment_method.not_exist',
+        public string $paymentNotFoundMessage = 'sylius.payment.not_found',
         ?string $notAvailable = null,
         ?string $notExist = null,
         ?string $paymentNotFound = null,
@@ -42,9 +42,9 @@ final class ChosenPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
-            $notAvailableMessage ??= $options['notAvailableMessage'] ?? null;
-            $notExistMessage ??= $options['notExistMessage'] ?? null;
-            $paymentNotFoundMessage ??= $options['paymentNotFoundMessage'] ?? null;
+            $this->notAvailableMessage = $options['notAvailableMessage'] ?? $this->notAvailableMessage;
+            $this->notExistMessage = $options['notExistMessage'] ?? $this->notExistMessage;
+            $this->paymentNotFoundMessage = $options['paymentNotFoundMessage'] ?? $this->paymentNotFoundMessage;
             $notAvailable ??= $options['notAvailable'] ?? null;
             $notExist ??= $options['notExist'] ?? null;
             $paymentNotFound ??= $options['paymentNotFound'] ?? null;
@@ -60,7 +60,7 @@ final class ChosenPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
-            $notAvailableMessage ??= $notAvailable;
+            $this->notAvailableMessage = $notAvailable;
         }
 
         if (null !== $notExist) {
@@ -71,7 +71,7 @@ final class ChosenPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
-            $notExistMessage ??= $notExist;
+            $this->notExistMessage = $notExist;
         }
 
         if (null !== $paymentNotFound) {
@@ -82,24 +82,14 @@ final class ChosenPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
-            $paymentNotFoundMessage ??= $paymentNotFound;
+            $this->paymentNotFoundMessage = $paymentNotFound;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->notAvailableMessage = $notAvailableMessage ?? $this->notAvailableMessage;
-        $this->notExistMessage = $notExistMessage ?? $this->notExistMessage;
-        $this->paymentNotFoundMessage = $paymentNotFoundMessage ?? $this->paymentNotFoundMessage;
         $this->notAvailable = $this->notAvailableMessage;
         $this->notExist = $this->notExistMessage;
         $this->paymentNotFound = $this->paymentNotFoundMessage;
     }
-
-    public string $notAvailableMessage = 'sylius.payment_method.not_available';
-
-    public string $notExistMessage = 'sylius.payment_method.not_exist';
-
-    public string $paymentNotFoundMessage = 'sylius.payment.not_found';
 
     /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $notAvailable = 'sylius.payment_method.not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -25,6 +25,9 @@ final class ChosenPaymentMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $notAvailableMessage = null,
+        ?string $notExistMessage = null,
+        ?string $paymentNotFoundMessage = null,
         ?string $notAvailable = null,
         ?string $notExist = null,
         ?string $paymentNotFound = null,
@@ -39,6 +42,9 @@ final class ChosenPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
+            $notAvailableMessage ??= $options['notAvailableMessage'] ?? null;
+            $notExistMessage ??= $options['notExistMessage'] ?? null;
+            $paymentNotFoundMessage ??= $options['paymentNotFoundMessage'] ?? null;
             $notAvailable ??= $options['notAvailable'] ?? null;
             $notExist ??= $options['notExist'] ?? null;
             $paymentNotFound ??= $options['paymentNotFound'] ?? null;
@@ -46,17 +52,62 @@ final class ChosenPaymentMethodEligibility extends Constraint
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $notAvailable) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "notAvailable" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "notAvailableMessage" instead.',
+                static::class,
+            );
+
+            $notAvailableMessage ??= $notAvailable;
+        }
+
+        if (null !== $notExist) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "notExist" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "notExistMessage" instead.',
+                static::class,
+            );
+
+            $notExistMessage ??= $notExist;
+        }
+
+        if (null !== $paymentNotFound) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "paymentNotFound" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "paymentNotFoundMessage" instead.',
+                static::class,
+            );
+
+            $paymentNotFoundMessage ??= $paymentNotFound;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->notAvailable = $notAvailable ?? $this->notAvailable;
-        $this->notExist = $notExist ?? $this->notExist;
-        $this->paymentNotFound = $paymentNotFound ?? $this->paymentNotFound;
+        $this->notAvailableMessage = $notAvailableMessage ?? $this->notAvailableMessage;
+        $this->notExistMessage = $notExistMessage ?? $this->notExistMessage;
+        $this->paymentNotFoundMessage = $paymentNotFoundMessage ?? $this->paymentNotFoundMessage;
+        $this->notAvailable = $this->notAvailableMessage;
+        $this->notExist = $this->notExistMessage;
+        $this->paymentNotFound = $this->paymentNotFoundMessage;
     }
 
+    public string $notAvailableMessage = 'sylius.payment_method.not_available';
+
+    public string $notExistMessage = 'sylius.payment_method.not_exist';
+
+    public string $paymentNotFoundMessage = 'sylius.payment.not_found';
+
+    /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $notAvailable = 'sylius.payment_method.not_available';
 
+    /** @deprecated since Sylius 2.3, use $notExistMessage instead. It will be removed in Sylius 3.0. */
     public string $notExist = 'sylius.payment_method.not_exist';
 
+    /** @deprecated since Sylius 2.3, use $paymentNotFoundMessage instead. It will be removed in Sylius 3.0. */
     public string $paymentNotFound = 'sylius.payment.not_found';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -19,20 +19,38 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenPaymentMethodEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $notAvailable = 'sylius.payment_method.not_available',
-        string $notExist = 'sylius.payment_method.not_exist',
-        string $paymentNotFound = 'sylius.payment.not_found',
+        ?array $options = null,
+        ?string $notAvailable = null,
+        ?string $notExist = null,
+        ?string $paymentNotFound = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $notAvailable ??= $options['notAvailable'] ?? null;
+            $notExist ??= $options['notExist'] ?? null;
+            $paymentNotFound ??= $options['paymentNotFound'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->notAvailable = $notAvailable;
-        $this->notExist = $notExist;
-        $this->paymentNotFound = $paymentNotFound;
+        $this->notAvailable = $notAvailable ?? $this->notAvailable;
+        $this->notExist = $notExist ?? $this->notExist;
+        $this->paymentNotFound = $paymentNotFound ?? $this->paymentNotFound;
     }
 
     public string $notAvailable = 'sylius.payment_method.not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibilityValidator.php
@@ -48,7 +48,7 @@ final class ChosenPaymentMethodEligibilityValidator extends ConstraintValidator
         $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $value->paymentMethodCode]);
 
         if ($paymentMethod === null) {
-            $this->context->addViolation($constraint->notExist, ['%code%' => $value->paymentMethodCode]);
+            $this->context->addViolation($constraint->notExistMessage, ['%code%' => $value->paymentMethodCode]);
 
             return;
         }
@@ -57,13 +57,13 @@ final class ChosenPaymentMethodEligibilityValidator extends ConstraintValidator
         $payment = $this->paymentRepository->find($value->paymentId);
 
         if (null === $payment) {
-            $this->context->addViolation($constraint->paymentNotFound);
+            $this->context->addViolation($constraint->paymentNotFoundMessage);
 
             return;
         }
 
         if (!in_array($paymentMethod, $this->paymentMethodsResolver->getSupportedMethods($payment), true)) {
-            $this->context->addViolation($constraint->notAvailable, ['%name%' => $paymentMethod->getName()]);
+            $this->context->addViolation($constraint->notAvailableMessage, ['%name%' => $paymentMethod->getName()]);
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -13,12 +13,27 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /** @experimental  */
 #[\Attribute]
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $notAvailable = 'sylius.payment_request.action_not_available',
+        string $notExist = 'sylius.payment_method.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->notAvailable = $notAvailable;
+        $this->notExist = $notExist;
+    }
+
     public string $notAvailable = 'sylius.payment_request.action_not_available';
 
     public string $notExist = 'sylius.payment_method.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -26,6 +26,8 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $notAvailableMessage = null,
+        ?string $notExistMessage = null,
         ?string $notAvailable = null,
         ?string $notExist = null,
         ?array $groups = null,
@@ -39,20 +41,52 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
                 static::class,
             );
 
+            $notAvailableMessage ??= $options['notAvailableMessage'] ?? null;
+            $notExistMessage ??= $options['notExistMessage'] ?? null;
             $notAvailable ??= $options['notAvailable'] ?? null;
             $notExist ??= $options['notExist'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $notAvailable) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "notAvailable" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "notAvailableMessage" instead.',
+                static::class,
+            );
+
+            $notAvailableMessage ??= $notAvailable;
+        }
+
+        if (null !== $notExist) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'The "notExist" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "notExistMessage" instead.',
+                static::class,
+            );
+
+            $notExistMessage ??= $notExist;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->notAvailable = $notAvailable ?? $this->notAvailable;
-        $this->notExist = $notExist ?? $this->notExist;
+        $this->notAvailableMessage = $notAvailableMessage ?? $this->notAvailableMessage;
+        $this->notExistMessage = $notExistMessage ?? $this->notExistMessage;
+        $this->notAvailable = $this->notAvailableMessage;
+        $this->notExist = $this->notExistMessage;
     }
 
+    public string $notAvailableMessage = 'sylius.payment_request.action_not_available';
+
+    public string $notExistMessage = 'sylius.payment_method.not_exist';
+
+    /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $notAvailable = 'sylius.payment_request.action_not_available';
 
+    /** @deprecated since Sylius 2.3, use $notExistMessage instead. It will be removed in Sylius 3.0. */
     public string $notExist = 'sylius.payment_method.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -20,6 +20,12 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
+    public string $notAvailable = 'sylius.payment_request.action_not_available';
+
+    /** @deprecated since Sylius 2.3, use $notExistMessage instead. It will be removed in Sylius 3.0. */
+    public string $notExist = 'sylius.payment_method.not_exist';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -75,12 +81,6 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
         $this->notAvailable = $this->notAvailableMessage;
         $this->notExist = $this->notExistMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
-    public string $notAvailable = 'sylius.payment_request.action_not_available';
-
-    /** @deprecated since Sylius 2.3, use $notExistMessage instead. It will be removed in Sylius 3.0. */
-    public string $notExist = 'sylius.payment_method.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -26,8 +26,8 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $notAvailableMessage = null,
-        ?string $notExistMessage = null,
+        public string $notAvailableMessage = 'sylius.payment_request.action_not_available',
+        public string $notExistMessage = 'sylius.payment_method.not_exist',
         ?string $notAvailable = null,
         ?string $notExist = null,
         ?array $groups = null,
@@ -41,8 +41,8 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
                 static::class,
             );
 
-            $notAvailableMessage ??= $options['notAvailableMessage'] ?? null;
-            $notExistMessage ??= $options['notExistMessage'] ?? null;
+            $this->notAvailableMessage = $options['notAvailableMessage'] ?? $this->notAvailableMessage;
+            $this->notExistMessage = $options['notExistMessage'] ?? $this->notExistMessage;
             $notAvailable ??= $options['notAvailable'] ?? null;
             $notExist ??= $options['notExist'] ?? null;
             $groups ??= $options['groups'] ?? null;
@@ -57,7 +57,7 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
                 static::class,
             );
 
-            $notAvailableMessage ??= $notAvailable;
+            $this->notAvailableMessage = $notAvailable;
         }
 
         if (null !== $notExist) {
@@ -68,20 +68,13 @@ final class ChosenPaymentRequestActionEligibility extends Constraint
                 static::class,
             );
 
-            $notExistMessage ??= $notExist;
+            $this->notExistMessage = $notExist;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->notAvailableMessage = $notAvailableMessage ?? $this->notAvailableMessage;
-        $this->notExistMessage = $notExistMessage ?? $this->notExistMessage;
         $this->notAvailable = $this->notAvailableMessage;
         $this->notExist = $this->notExistMessage;
     }
-
-    public string $notAvailableMessage = 'sylius.payment_request.action_not_available';
-
-    public string $notExistMessage = 'sylius.payment_method.not_exist';
 
     /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $notAvailable = 'sylius.payment_request.action_not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -20,18 +20,35 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $notAvailable = 'sylius.payment_request.action_not_available',
-        string $notExist = 'sylius.payment_method.not_exist',
+        ?array $options = null,
+        ?string $notAvailable = null,
+        ?string $notExist = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $notAvailable ??= $options['notAvailable'] ?? null;
+            $notExist ??= $options['notExist'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->notAvailable = $notAvailable;
-        $this->notExist = $notExist;
+        $this->notAvailable = $notAvailable ?? $this->notAvailable;
+        $this->notExist = $notExist ?? $this->notExist;
     }
 
     public string $notAvailable = 'sylius.payment_request.action_not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibilityValidator.php
@@ -49,7 +49,7 @@ final class ChosenPaymentRequestActionEligibilityValidator extends ConstraintVal
         /** @var PaymentMethodInterface|null $paymentMethod */
         $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $value->paymentMethodCode]);
         if ($paymentMethod?->getGatewayConfig() === null) {
-            $this->context->addViolation($constraint->notExist, ['%code%' => $value->paymentMethodCode]);
+            $this->context->addViolation($constraint->notExistMessage, ['%code%' => $value->paymentMethodCode]);
 
             return;
         }
@@ -57,7 +57,7 @@ final class ChosenPaymentRequestActionEligibilityValidator extends ConstraintVal
         $factoryName = $this->gatewayFactoryNameProvider->provide($paymentMethod);
         $gatewayFactoryCommandProvider = $this->gatewayFactoryCommandProvider->getCommandProvider($factoryName);
         if (null === $gatewayFactoryCommandProvider) {
-            $this->context->addViolation($constraint->notAvailable, [
+            $this->context->addViolation($constraint->notAvailableMessage, [
                 '%code%' => $value->paymentMethodCode,
                 '%id%' => $value->paymentId,
             ]);
@@ -72,7 +72,7 @@ final class ChosenPaymentRequestActionEligibilityValidator extends ConstraintVal
             return;
         }
 
-        $this->context->addViolation($constraint->notAvailable, [
+        $this->context->addViolation($constraint->notAvailableMessage, [
             '%code%' => $value->paymentMethodCode,
             '%id%' => $value->paymentId,
         ]);

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -25,10 +25,10 @@ final class ChosenShippingMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
-        ?string $notFoundMessage = null,
-        ?string $shipmentNotFoundMessage = null,
-        ?string $shippingAddressNotFoundMessage = null,
+        public string $message = 'sylius.shipping_method.not_available',
+        public string $notFoundMessage = 'sylius.shipping_method.not_found',
+        public string $shipmentNotFoundMessage = 'sylius.shipment.not_found',
+        public string $shippingAddressNotFoundMessage = 'sylius.shipping_method.shipping_address_not_found',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -40,30 +40,16 @@ final class ChosenShippingMethodEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
-            $notFoundMessage ??= $options['notFoundMessage'] ?? null;
-            $shipmentNotFoundMessage ??= $options['shipmentNotFoundMessage'] ?? null;
-            $shippingAddressNotFoundMessage ??= $options['shippingAddressNotFoundMessage'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
+            $this->notFoundMessage = $options['notFoundMessage'] ?? $this->notFoundMessage;
+            $this->shipmentNotFoundMessage = $options['shipmentNotFoundMessage'] ?? $this->shipmentNotFoundMessage;
+            $this->shippingAddressNotFoundMessage = $options['shippingAddressNotFoundMessage'] ?? $this->shippingAddressNotFoundMessage;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
-        $this->notFoundMessage = $notFoundMessage ?? $this->notFoundMessage;
-        $this->shipmentNotFoundMessage = $shipmentNotFoundMessage ?? $this->shipmentNotFoundMessage;
-        $this->shippingAddressNotFoundMessage = $shippingAddressNotFoundMessage ?? $this->shippingAddressNotFoundMessage;
     }
-
-    public string $message = 'sylius.shipping_method.not_available';
-
-    public string $notFoundMessage = 'sylius.shipping_method.not_found';
-
-    public string $shipmentNotFoundMessage = 'sylius.shipment.not_found';
-
-    /** @var string */
-    public $shippingAddressNotFoundMessage = 'sylius.shipping_method.shipping_address_not_found';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -19,20 +19,38 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenShippingMethodEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.shipping_method.not_available',
-        string $notFoundMessage = 'sylius.shipping_method.not_found',
-        string $shipmentNotFoundMessage = 'sylius.shipment.not_found',
+        ?array $options = null,
+        ?string $message = null,
+        ?string $notFoundMessage = null,
+        ?string $shipmentNotFoundMessage = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $notFoundMessage ??= $options['notFoundMessage'] ?? null;
+            $shipmentNotFoundMessage ??= $options['shipmentNotFoundMessage'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
-        $this->notFoundMessage = $notFoundMessage;
-        $this->shipmentNotFoundMessage = $shipmentNotFoundMessage;
+        $this->message = $message ?? $this->message;
+        $this->notFoundMessage = $notFoundMessage ?? $this->notFoundMessage;
+        $this->shipmentNotFoundMessage = $shipmentNotFoundMessage ?? $this->shipmentNotFoundMessage;
     }
 
     public string $message = 'sylius.shipping_method.not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -28,6 +28,7 @@ final class ChosenShippingMethodEligibility extends Constraint
         ?string $message = null,
         ?string $notFoundMessage = null,
         ?string $shipmentNotFoundMessage = null,
+        ?string $shippingAddressNotFoundMessage = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -42,6 +43,7 @@ final class ChosenShippingMethodEligibility extends Constraint
             $message ??= $options['message'] ?? null;
             $notFoundMessage ??= $options['notFoundMessage'] ?? null;
             $shipmentNotFoundMessage ??= $options['shipmentNotFoundMessage'] ?? null;
+            $shippingAddressNotFoundMessage ??= $options['shippingAddressNotFoundMessage'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
@@ -51,6 +53,7 @@ final class ChosenShippingMethodEligibility extends Constraint
         $this->message = $message ?? $this->message;
         $this->notFoundMessage = $notFoundMessage ?? $this->notFoundMessage;
         $this->shipmentNotFoundMessage = $shipmentNotFoundMessage ?? $this->shipmentNotFoundMessage;
+        $this->shippingAddressNotFoundMessage = $shippingAddressNotFoundMessage ?? $this->shippingAddressNotFoundMessage;
     }
 
     public string $message = 'sylius.shipping_method.not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -13,11 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ChosenShippingMethodEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.shipping_method.not_available',
+        string $notFoundMessage = 'sylius.shipping_method.not_found',
+        string $shipmentNotFoundMessage = 'sylius.shipment.not_found',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+        $this->notFoundMessage = $notFoundMessage;
+        $this->shipmentNotFoundMessage = $shipmentNotFoundMessage;
+    }
+
     public string $message = 'sylius.shipping_method.not_available';
 
     public string $notFoundMessage = 'sylius.shipping_method.not_found';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/Code.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/Code.php
@@ -28,7 +28,7 @@ final class Code extends Compound
         return [
             new NotBlank(message: 'sylius.code.not_blank'),
             new Type('string'),
-            new Regex(['pattern' => '/^[\w-]*$/'], message: 'sylius.code.invalid'),
+            new Regex(pattern: '/^[\w-]*$/', message: 'sylius.code.invalid'),
         ];
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
@@ -23,14 +23,29 @@ final class ConfirmResetPassword extends Constraint
     public $message = 'sylius.user.plainPassword.mismatch';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ConfirmResetPassword extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.user.plainPassword.mismatch';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -29,7 +26,7 @@ final class ConfirmResetPassword extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.user.plainPassword.mismatch',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,14 +38,12 @@ final class ConfirmResetPassword extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -20,6 +21,20 @@ final class ConfirmResetPassword extends Constraint
 {
     /** @var string */
     public $message = 'sylius.user.plainPassword.mismatch';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CorrectChangeShopUserConfirmPassword extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.user.plainPassword.mismatch';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -29,7 +26,7 @@ final class CorrectChangeShopUserConfirmPassword extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.user.plainPassword.mismatch',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,14 +38,12 @@ final class CorrectChangeShopUserConfirmPassword extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -20,6 +21,20 @@ final class CorrectChangeShopUserConfirmPassword extends Constraint
 {
     /** @var string */
     public $message = 'sylius.user.plainPassword.mismatch';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
@@ -23,14 +23,29 @@ final class CorrectChangeShopUserConfirmPassword extends Constraint
     public $message = 'sylius.user.plainPassword.mismatch';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
@@ -19,18 +19,35 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CorrectOrderAddress extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $countryCodeNotExistMessage = 'sylius.country.not_exist',
-        string $addressWithoutCountryCodeCanNotExistMessage = 'sylius.address.without_country',
+        ?array $options = null,
+        ?string $countryCodeNotExistMessage = null,
+        ?string $addressWithoutCountryCodeCanNotExistMessage = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $countryCodeNotExistMessage ??= $options['countryCodeNotExistMessage'] ?? null;
+            $addressWithoutCountryCodeCanNotExistMessage ??= $options['addressWithoutCountryCodeCanNotExistMessage'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->countryCodeNotExistMessage = $countryCodeNotExistMessage;
-        $this->addressWithoutCountryCodeCanNotExistMessage = $addressWithoutCountryCodeCanNotExistMessage;
+        $this->countryCodeNotExistMessage = $countryCodeNotExistMessage ?? $this->countryCodeNotExistMessage;
+        $this->addressWithoutCountryCodeCanNotExistMessage = $addressWithoutCountryCodeCanNotExistMessage ?? $this->addressWithoutCountryCodeCanNotExistMessage;
     }
 
     public string $countryCodeNotExistMessage = 'sylius.country.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
@@ -25,8 +25,8 @@ final class CorrectOrderAddress extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $countryCodeNotExistMessage = null,
-        ?string $addressWithoutCountryCodeCanNotExistMessage = null,
+        public string $countryCodeNotExistMessage = 'sylius.country.not_exist',
+        public string $addressWithoutCountryCodeCanNotExistMessage = 'sylius.address.without_country',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -38,21 +38,14 @@ final class CorrectOrderAddress extends Constraint
                 static::class,
             );
 
-            $countryCodeNotExistMessage ??= $options['countryCodeNotExistMessage'] ?? null;
-            $addressWithoutCountryCodeCanNotExistMessage ??= $options['addressWithoutCountryCodeCanNotExistMessage'] ?? null;
+            $this->countryCodeNotExistMessage = $options['countryCodeNotExistMessage'] ?? $this->countryCodeNotExistMessage;
+            $this->addressWithoutCountryCodeCanNotExistMessage = $options['addressWithoutCountryCodeCanNotExistMessage'] ?? $this->addressWithoutCountryCodeCanNotExistMessage;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->countryCodeNotExistMessage = $countryCodeNotExistMessage ?? $this->countryCodeNotExistMessage;
-        $this->addressWithoutCountryCodeCanNotExistMessage = $addressWithoutCountryCodeCanNotExistMessage ?? $this->addressWithoutCountryCodeCanNotExistMessage;
     }
-
-    public string $countryCodeNotExistMessage = 'sylius.country.not_exist';
-
-    public string $addressWithoutCountryCodeCanNotExistMessage = 'sylius.address.without_country';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
@@ -13,11 +13,26 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CorrectOrderAddress extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $countryCodeNotExistMessage = 'sylius.country.not_exist',
+        string $addressWithoutCountryCodeCanNotExistMessage = 'sylius.address.without_country',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->countryCodeNotExistMessage = $countryCodeNotExistMessage;
+        $this->addressWithoutCountryCodeCanNotExistMessage = $addressWithoutCountryCodeCanNotExistMessage;
+    }
+
     public string $countryCodeNotExistMessage = 'sylius.country.not_exist';
 
     public string $addressWithoutCountryCodeCanNotExistMessage = 'sylius.address.without_country';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
@@ -25,7 +25,7 @@ final class OrderAddressRequirement extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.address_requirement',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderAddressRequirement extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.address_requirement';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderAddressRequirement extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.address_requirement',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.address_requirement';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderAddressRequirement extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.address_requirement',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.address_requirement';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderItemAvailability extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderItemAvailability extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
@@ -25,7 +25,7 @@ final class OrderItemAvailability extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderItemAvailability extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderNotEmpty extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.not_empty',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.not_empty';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
@@ -25,7 +25,7 @@ final class OrderNotEmpty extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.not_empty',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderNotEmpty extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.not_empty';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderNotEmpty extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.not_empty',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.not_empty';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.payment_method_eligibility',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.payment_method_eligibility';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -25,7 +25,7 @@ final class OrderPaymentMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.payment_method_eligibility',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.payment_method_eligibility';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.payment_method_eligibility',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.payment_method_eligibility';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.product_eligibility',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.product_eligibility';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.product_eligibility',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.product_eligibility';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
@@ -25,7 +25,7 @@ final class OrderProductEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.product_eligibility',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderProductEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.product_eligibility';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -19,10 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
-    public string $message = 'sylius.order.shipping_method_eligibility';
-
-    public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -30,8 +26,8 @@ final class OrderShippingMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
-        ?string $methodNotAvailableMessage = null,
+        public string $message = 'sylius.order.shipping_method_eligibility',
+        public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -43,16 +39,13 @@ final class OrderShippingMethodEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
-            $methodNotAvailableMessage ??= $options['methodNotAvailableMessage'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
+            $this->methodNotAvailableMessage = $options['methodNotAvailableMessage'] ?? $this->methodNotAvailableMessage;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
-        $this->methodNotAvailableMessage = $methodNotAvailableMessage ?? $this->methodNotAvailableMessage;
     }
 
     public function getMessage(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -13,22 +13,20 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
-    /**
-     * @param array<array-key, mixed> $options
-     */
+    #[HasNamedArguments]
     public function __construct(
-        array $options = [],
         public string $message = 'sylius.order.shipping_method_eligibility',
         public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available',
-        mixed $groups = null,
+        ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct($options, $groups, $payload);
+        parent::__construct(groups: $groups, payload: $payload);
     }
 
     public function getMessage(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -19,14 +19,40 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
+    public string $message = 'sylius.order.shipping_method_eligibility';
+
+    public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available';
+
+    /**
+     * @param array<string, mixed>|null $options
+     * @param array<string>|null $groups
+     */
     #[HasNamedArguments]
     public function __construct(
-        public string $message = 'sylius.order.shipping_method_eligibility',
-        public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available',
+        ?array $options = null,
+        ?string $message = null,
+        ?string $methodNotAvailableMessage = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $methodNotAvailableMessage ??= $options['methodNotAvailableMessage'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->methodNotAvailableMessage = $methodNotAvailableMessage ?? $this->methodNotAvailableMessage;
     }
 
     public function getMessage(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
@@ -25,7 +25,7 @@ final class PlacedOrderCartItemsImmutable extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.cart_items_immutable',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class PlacedOrderCartItemsImmutable extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.cart_items_immutable';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PlacedOrderCartItemsImmutable extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.cart_items_immutable',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.cart_items_immutable';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class PlacedOrderCartItemsImmutable extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.cart_items_immutable',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.cart_items_immutable';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionCouponEligibility extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.promotion_coupon.is_invalid';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -29,7 +26,7 @@ final class PromotionCouponEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.promotion_coupon.is_invalid',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,14 +38,12 @@ final class PromotionCouponEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -20,6 +21,20 @@ final class PromotionCouponEligibility extends Constraint
 {
     /** @var string */
     public $message = 'sylius.promotion_coupon.is_invalid';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
@@ -23,14 +23,29 @@ final class PromotionCouponEligibility extends Constraint
     public $message = 'sylius.promotion_coupon.is_invalid';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
@@ -25,7 +25,7 @@ final class ShipmentAlreadyShipped extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.shipment.shipped',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ShipmentAlreadyShipped extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.shipment.shipped';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShipmentAlreadyShipped extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.shipment.shipped',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.shipment.shipped';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShipmentAlreadyShipped extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.shipment.shipped',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.shipment.shipped';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShopUserNotVerified extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.account.is_verified',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.account.is_verified';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
@@ -25,7 +25,7 @@ final class ShopUserNotVerified extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.account.is_verified',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ShopUserNotVerified extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.account.is_verified';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserNotVerified extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.account.is_verified',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.account.is_verified';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserResetPasswordTokenExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.reset_password.invalid_token',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.reset_password.invalid_token';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
@@ -25,7 +25,7 @@ final class ShopUserResetPasswordTokenExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.reset_password.invalid_token',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ShopUserResetPasswordTokenExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.reset_password.invalid_token';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShopUserResetPasswordTokenExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.reset_password.invalid_token',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.reset_password.invalid_token';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserResetPasswordTokenNotExpired extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.reset_password.token_expired',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.reset_password.token_expired';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShopUserResetPasswordTokenNotExpired extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.reset_password.token_expired',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.reset_password.token_expired';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
@@ -25,7 +25,7 @@ final class ShopUserResetPasswordTokenNotExpired extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.reset_password.token_expired',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ShopUserResetPasswordTokenNotExpired extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.reset_password.token_expired';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
@@ -25,7 +25,7 @@ final class ShopUserVerificationTokenEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.account.invalid_verification_token',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ShopUserVerificationTokenEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.account.invalid_verification_token';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserVerificationTokenEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.account.invalid_verification_token',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.account.invalid_verification_token';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShopUserVerificationTokenEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.account.invalid_verification_token',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.account.invalid_verification_token';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class SingleValueForProductVariantOption extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_variant.option_values.single_value',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product_variant.option_values.single_value';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
@@ -25,7 +25,7 @@ final class SingleValueForProductVariantOption extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.option_values.single_value',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class SingleValueForProductVariantOption extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product_variant.option_values.single_value';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class SingleValueForProductVariantOption extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_variant.option_values.single_value',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product_variant.option_values.single_value';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class UniqueReviewerEmail extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.review.author.already_exists',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.review.author.already_exists';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UniqueReviewerEmail extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.review.author.already_exists',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.review.author.already_exists';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -25,7 +25,7 @@ final class UniqueReviewerEmail extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.review.author.already_exists',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class UniqueReviewerEmail extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.review.author.already_exists';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class UniqueShopUserEmail extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.user.email.unique',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.user.email.unique';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UniqueShopUserEmail extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.user.email.unique',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.user.email.unique';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
@@ -25,7 +25,7 @@ final class UniqueShopUserEmail extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.user.email.unique',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class UniqueShopUserEmail extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.user.email.unique';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UpdateCartEmailNotAllowed extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.checkout.email.not_changeable',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.checkout.email.not_changeable';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
@@ -25,7 +25,7 @@ final class UpdateCartEmailNotAllowed extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.checkout.email.not_changeable',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class UpdateCartEmailNotAllowed extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.checkout.email.not_changeable';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class UpdateCartEmailNotAllowed extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.checkout.email.not_changeable',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.checkout.email.not_changeable';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AttributeType extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->unregisteredAttributeTypeMessage = $unregisteredAttributeTypeMessage;
+    }
+
     public string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class AttributeType extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered',
+        ?array $options = null,
+        ?string $unregisteredAttributeTypeMessage = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/attribute-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $unregisteredAttributeTypeMessage ??= $options['unregisteredAttributeTypeMessage'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->unregisteredAttributeTypeMessage = $unregisteredAttributeTypeMessage;
+        $this->unregisteredAttributeTypeMessage = $unregisteredAttributeTypeMessage ?? $this->unregisteredAttributeTypeMessage;
     }
 
     public string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
@@ -25,7 +25,7 @@ class AttributeType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $unregisteredAttributeTypeMessage = null,
+        public string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ class AttributeType extends Constraint
                 static::class,
             );
 
-            $unregisteredAttributeTypeMessage ??= $options['unregisteredAttributeTypeMessage'] ?? null;
+            $this->unregisteredAttributeTypeMessage = $options['unregisteredAttributeTypeMessage'] ?? $this->unregisteredAttributeTypeMessage;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->unregisteredAttributeTypeMessage = $unregisteredAttributeTypeMessage ?? $this->unregisteredAttributeTypeMessage;
     }
-
-    public string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
@@ -25,9 +25,9 @@ final class ValidSelectAttributeConfiguration extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $messageMultiple = null,
-        ?string $messageMinEntries = null,
-        ?string $messageMaxEntries = null,
+        public string $messageMultiple = 'sylius.attribute.configuration.multiple',
+        public string $messageMinEntries = 'sylius.attribute.configuration.min_entries',
+        public string $messageMaxEntries = 'sylius.attribute.configuration.max_entries',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -39,25 +39,15 @@ final class ValidSelectAttributeConfiguration extends Constraint
                 static::class,
             );
 
-            $messageMultiple ??= $options['messageMultiple'] ?? null;
-            $messageMinEntries ??= $options['messageMinEntries'] ?? null;
-            $messageMaxEntries ??= $options['messageMaxEntries'] ?? null;
+            $this->messageMultiple = $options['messageMultiple'] ?? $this->messageMultiple;
+            $this->messageMinEntries = $options['messageMinEntries'] ?? $this->messageMinEntries;
+            $this->messageMaxEntries = $options['messageMaxEntries'] ?? $this->messageMaxEntries;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->messageMultiple = $messageMultiple ?? $this->messageMultiple;
-        $this->messageMinEntries = $messageMinEntries ?? $this->messageMinEntries;
-        $this->messageMaxEntries = $messageMaxEntries ?? $this->messageMaxEntries;
     }
-
-    public string $messageMultiple = 'sylius.attribute.configuration.multiple';
-
-    public string $messageMinEntries = 'sylius.attribute.configuration.min_entries';
-
-    public string $messageMaxEntries = 'sylius.attribute.configuration.max_entries';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
@@ -13,11 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ValidSelectAttributeConfiguration extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $messageMultiple = 'sylius.attribute.configuration.multiple',
+        string $messageMinEntries = 'sylius.attribute.configuration.min_entries',
+        string $messageMaxEntries = 'sylius.attribute.configuration.max_entries',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->messageMultiple = $messageMultiple;
+        $this->messageMinEntries = $messageMinEntries;
+        $this->messageMaxEntries = $messageMaxEntries;
+    }
+
     public string $messageMultiple = 'sylius.attribute.configuration.multiple';
 
     public string $messageMinEntries = 'sylius.attribute.configuration.min_entries';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
@@ -19,20 +19,38 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ValidSelectAttributeConfiguration extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $messageMultiple = 'sylius.attribute.configuration.multiple',
-        string $messageMinEntries = 'sylius.attribute.configuration.min_entries',
-        string $messageMaxEntries = 'sylius.attribute.configuration.max_entries',
+        ?array $options = null,
+        ?string $messageMultiple = null,
+        ?string $messageMinEntries = null,
+        ?string $messageMaxEntries = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/attribute-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $messageMultiple ??= $options['messageMultiple'] ?? null;
+            $messageMinEntries ??= $options['messageMinEntries'] ?? null;
+            $messageMaxEntries ??= $options['messageMaxEntries'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->messageMultiple = $messageMultiple;
-        $this->messageMinEntries = $messageMinEntries;
-        $this->messageMaxEntries = $messageMaxEntries;
+        $this->messageMultiple = $messageMultiple ?? $this->messageMultiple;
+        $this->messageMinEntries = $messageMinEntries ?? $this->messageMinEntries;
+        $this->messageMaxEntries = $messageMaxEntries ?? $this->messageMaxEntries;
     }
 
     public string $messageMultiple = 'sylius.attribute.configuration.multiple';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ValidTextAttributeConfiguration extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.attribute.configuration.max_length',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/attribute-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.attribute.configuration.max_length';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ValidTextAttributeConfiguration extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.attribute.configuration.max_length',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.attribute.configuration.max_length';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
@@ -25,7 +25,7 @@ final class ValidTextAttributeConfiguration extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.attribute.configuration.max_length',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ValidTextAttributeConfiguration extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.attribute.configuration.max_length';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
@@ -42,12 +42,12 @@ final class CartItemTypeExtension extends AbstractTypeExtension
             'attr' => ['min' => 1],
             'label' => 'sylius.ui.quantity',
             'constraints' => [
-                new Range([
-                    'min' => 1,
-                    'max' => $this->orderItemQuantityModifierLimit,
-                    'notInRangeMessage' => 'sylius.cart_item.quantity.not_in_range',
-                    'groups' => 'sylius',
-                ]),
+                new Range(
+                    min: 1,
+                    max: $this->orderItemQuantityModifierLimit,
+                    notInRangeMessage: 'sylius.cart_item.quantity.not_in_range',
+                    groups: ['sylius'],
+                ),
             ],
         ]);
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/AmountType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/AmountType.php
@@ -32,9 +32,9 @@ final class AmountType extends AbstractType
                 'label' => false,
                 'currency' => $options['channel']->getBaseCurrency()->getCode(),
                 'constraints' => [
-                    new NotBlank(['groups' => ['sylius']]),
+                    new NotBlank(groups: ['sylius']),
                     new Type(type: 'integer', groups: ['sylius']),
-                    new GreaterThan(['value' => 0, 'groups' => ['sylius']]),
+                    new GreaterThan(value: 0, groups: ['sylius']),
                 ],
             ])
         ;

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ContactType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ContactType.php
@@ -31,20 +31,14 @@ final class ContactType extends AbstractType
             ->add('email', EmailType::class, [
                 'label' => 'sylius.ui.email',
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'sylius.contact.email.not_blank',
-                    ]),
-                    new Email([
-                        'message' => 'sylius.contact.email.invalid',
-                    ]),
+                    new NotBlank(message: 'sylius.contact.email.not_blank'),
+                    new Email(message: 'sylius.contact.email.invalid'),
                 ],
             ])
             ->add('message', TextareaType::class, [
                 'label' => 'sylius.ui.message',
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'sylius.contact.message.not_blank',
-                    ]),
+                    new NotBlank(message: 'sylius.contact.message.not_blank'),
                 ],
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options): void {

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/CustomerGroupConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/CustomerGroupConfigurationType.php
@@ -27,7 +27,7 @@ final class CustomerGroupConfigurationType extends AbstractType
             ->add('group_code', CustomerGroupCodeChoiceType::class, [
                 'label' => 'sylius.form.promotion_rule.customer_group.group',
                 'constraints' => [
-                    new NotBlank(['groups' => ['sylius']]),
+                    new NotBlank(groups: ['sylius']),
                     new Type(type: 'string', groups: ['sylius']),
                 ],
             ])

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class AllowedImageMimeTypes extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.image.file.allowed_mime_types',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.image.file.allowed_mime_types';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
@@ -25,7 +25,7 @@ final class AllowedImageMimeTypes extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.image.file.allowed_mime_types',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class AllowedImageMimeTypes extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.image.file.allowed_mime_types';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class AllowedImageMimeTypes extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.image.file.allowed_mime_types',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.image.file.allowed_mime_types';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CartItemAvailability extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.cart_item.not_available',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.cart_item.not_available';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
@@ -13,12 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CartItemAvailability extends Constraint
 {
-    public string $message;
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.cart_item.not_available',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
+    public string $message = 'sylius.cart_item.not_available';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
@@ -25,7 +25,7 @@ final class CartItemAvailability extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.cart_item.not_available',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class CartItemAvailability extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.cart_item.not_available';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CartItemVariantEnabled extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.cart_item.variant.not_available',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.cart_item.variant.not_available';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
@@ -25,7 +25,7 @@ final class CartItemVariantEnabled extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.cart_item.variant.not_available',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class CartItemVariantEnabled extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.cart_item.variant.not_available';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CartItemVariantEnabled extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.cart_item.variant.not_available',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.cart_item.variant.not_available';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
@@ -27,13 +27,13 @@ final class ChannelCodeCollection extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        public ?string $extraFieldsMessage = null,
+        public ?string $missingFieldsMessage = null,
+        public string $invalidChannelMessage = 'sylius.channel_code_collection.invalid_channel',
         public array $constraints = [],
         public bool $allowExtraFields = false,
         public bool $allowMissingFields = false,
         public ?string $channelAwarePropertyPath = null,
-        public ?string $extraFieldsMessage = null,
-        public ?string $missingFieldsMessage = null,
-        public string $invalidChannelMessage = 'sylius.channel_code_collection.invalid_channel',
         public bool $validateAgainstAllChannels = false,
         ?array $groups = null,
         mixed $payload = null,

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -36,30 +37,32 @@ final class ChannelCodeCollection extends Constraint
     public bool $validateAgainstAllChannels = false;
 
     /**
-     * @param array<Constraint> $constraints
+     * @param array<Constraint>|null $constraints
+     * @param array<string>|null $groups
      */
+    #[HasNamedArguments]
     public function __construct(
-        array $constraints = [],
-        bool $allowExtraFields = false,
-        bool $allowMissingFields = false,
+        ?array $constraints = null,
+        ?bool $allowExtraFields = null,
+        ?bool $allowMissingFields = null,
         ?string $channelAwarePropertyPath = null,
         ?string $extraFieldsMessage = null,
         ?string $missingFieldsMessage = null,
-        string $invalidChannelMessage = 'sylius.channel_code_collection.invalid_channel',
-        bool $validateAgainstAllChannels = false,
+        ?string $invalidChannelMessage = null,
+        ?bool $validateAgainstAllChannels = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->constraints = $constraints;
-        $this->allowExtraFields = $allowExtraFields;
-        $this->allowMissingFields = $allowMissingFields;
-        $this->channelAwarePropertyPath = $channelAwarePropertyPath;
-        $this->extraFieldsMessage = $extraFieldsMessage;
-        $this->missingFieldsMessage = $missingFieldsMessage;
-        $this->invalidChannelMessage = $invalidChannelMessage;
-        $this->validateAgainstAllChannels = $validateAgainstAllChannels;
+        $this->constraints = $constraints ?? $this->constraints;
+        $this->allowExtraFields = $allowExtraFields ?? $this->allowExtraFields;
+        $this->allowMissingFields = $allowMissingFields ?? $this->allowMissingFields;
+        $this->channelAwarePropertyPath = $channelAwarePropertyPath ?? $this->channelAwarePropertyPath;
+        $this->extraFieldsMessage = $extraFieldsMessage ?? $this->extraFieldsMessage;
+        $this->missingFieldsMessage = $missingFieldsMessage ?? $this->missingFieldsMessage;
+        $this->invalidChannelMessage = $invalidChannelMessage ?? $this->invalidChannelMessage;
+        $this->validateAgainstAllChannels = $validateAgainstAllChannels ?? $this->validateAgainstAllChannels;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
@@ -19,39 +19,22 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChannelCodeCollection extends Constraint
 {
-    /** @var array<Constraint> */
-    public array $constraints = [];
-
-    public bool $allowExtraFields = false;
-
-    public bool $allowMissingFields = false;
-
-    public ?string $channelAwarePropertyPath = null;
-
-    public ?string $extraFieldsMessage = null;
-
-    public ?string $missingFieldsMessage = null;
-
-    public string $invalidChannelMessage = 'sylius.channel_code_collection.invalid_channel';
-
-    public bool $validateAgainstAllChannels = false;
-
     /**
      * @param array<string, mixed>|null $options
-     * @param array<Constraint>|null $constraints
+     * @param array<Constraint> $constraints
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?array $constraints = null,
-        ?bool $allowExtraFields = null,
-        ?bool $allowMissingFields = null,
-        ?string $channelAwarePropertyPath = null,
-        ?string $extraFieldsMessage = null,
-        ?string $missingFieldsMessage = null,
-        ?string $invalidChannelMessage = null,
-        ?bool $validateAgainstAllChannels = null,
+        public array $constraints = [],
+        public bool $allowExtraFields = false,
+        public bool $allowMissingFields = false,
+        public ?string $channelAwarePropertyPath = null,
+        public ?string $extraFieldsMessage = null,
+        public ?string $missingFieldsMessage = null,
+        public string $invalidChannelMessage = 'sylius.channel_code_collection.invalid_channel',
+        public bool $validateAgainstAllChannels = false,
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -63,28 +46,19 @@ final class ChannelCodeCollection extends Constraint
                 static::class,
             );
 
-            $constraints ??= $options['constraints'] ?? null;
-            $allowExtraFields ??= $options['allowExtraFields'] ?? null;
-            $allowMissingFields ??= $options['allowMissingFields'] ?? null;
-            $channelAwarePropertyPath ??= $options['channelAwarePropertyPath'] ?? null;
-            $extraFieldsMessage ??= $options['extraFieldsMessage'] ?? null;
-            $missingFieldsMessage ??= $options['missingFieldsMessage'] ?? null;
-            $invalidChannelMessage ??= $options['invalidChannelMessage'] ?? null;
-            $validateAgainstAllChannels ??= $options['validateAgainstAllChannels'] ?? null;
+            $this->constraints = $options['constraints'] ?? $this->constraints;
+            $this->allowExtraFields = $options['allowExtraFields'] ?? $this->allowExtraFields;
+            $this->allowMissingFields = $options['allowMissingFields'] ?? $this->allowMissingFields;
+            $this->channelAwarePropertyPath = $options['channelAwarePropertyPath'] ?? $this->channelAwarePropertyPath;
+            $this->extraFieldsMessage = $options['extraFieldsMessage'] ?? $this->extraFieldsMessage;
+            $this->missingFieldsMessage = $options['missingFieldsMessage'] ?? $this->missingFieldsMessage;
+            $this->invalidChannelMessage = $options['invalidChannelMessage'] ?? $this->invalidChannelMessage;
+            $this->validateAgainstAllChannels = $options['validateAgainstAllChannels'] ?? $this->validateAgainstAllChannels;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->constraints = $constraints ?? $this->constraints;
-        $this->allowExtraFields = $allowExtraFields ?? $this->allowExtraFields;
-        $this->allowMissingFields = $allowMissingFields ?? $this->allowMissingFields;
-        $this->channelAwarePropertyPath = $channelAwarePropertyPath ?? $this->channelAwarePropertyPath;
-        $this->extraFieldsMessage = $extraFieldsMessage ?? $this->extraFieldsMessage;
-        $this->missingFieldsMessage = $missingFieldsMessage ?? $this->missingFieldsMessage;
-        $this->invalidChannelMessage = $invalidChannelMessage ?? $this->invalidChannelMessage;
-        $this->validateAgainstAllChannels = $validateAgainstAllChannels ?? $this->validateAgainstAllChannels;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
@@ -37,11 +37,13 @@ final class ChannelCodeCollection extends Constraint
     public bool $validateAgainstAllChannels = false;
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<Constraint>|null $constraints
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?array $constraints = null,
         ?bool $allowExtraFields = null,
         ?bool $allowMissingFields = null,
@@ -53,6 +55,26 @@ final class ChannelCodeCollection extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $constraints ??= $options['constraints'] ?? null;
+            $allowExtraFields ??= $options['allowExtraFields'] ?? null;
+            $allowMissingFields ??= $options['allowMissingFields'] ?? null;
+            $channelAwarePropertyPath ??= $options['channelAwarePropertyPath'] ?? null;
+            $extraFieldsMessage ??= $options['extraFieldsMessage'] ?? null;
+            $missingFieldsMessage ??= $options['missingFieldsMessage'] ?? null;
+            $invalidChannelMessage ??= $options['invalidChannelMessage'] ?? null;
+            $validateAgainstAllChannels ??= $options['validateAgainstAllChannels'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->constraints = $constraints ?? $this->constraints;

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
@@ -35,6 +35,33 @@ final class ChannelCodeCollection extends Constraint
 
     public bool $validateAgainstAllChannels = false;
 
+    /**
+     * @param array<Constraint> $constraints
+     */
+    public function __construct(
+        array $constraints = [],
+        bool $allowExtraFields = false,
+        bool $allowMissingFields = false,
+        ?string $channelAwarePropertyPath = null,
+        ?string $extraFieldsMessage = null,
+        ?string $missingFieldsMessage = null,
+        string $invalidChannelMessage = 'sylius.channel_code_collection.invalid_channel',
+        bool $validateAgainstAllChannels = false,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->constraints = $constraints;
+        $this->allowExtraFields = $allowExtraFields;
+        $this->allowMissingFields = $allowMissingFields;
+        $this->channelAwarePropertyPath = $channelAwarePropertyPath;
+        $this->extraFieldsMessage = $extraFieldsMessage;
+        $this->missingFieldsMessage = $missingFieldsMessage;
+        $this->invalidChannelMessage = $invalidChannelMessage;
+        $this->validateAgainstAllChannels = $validateAgainstAllChannels;
+    }
+
     public function validatedBy(): string
     {
         return 'sylius_channel_code_collection';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
@@ -25,7 +25,7 @@ final class ChannelDefaultLocaleEnabled extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.channel.default_locale.enabled',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ChannelDefaultLocaleEnabled extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.channel.default_locale.enabled';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ChannelDefaultLocaleEnabled extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.channel.default_locale.enabled',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.channel.default_locale.enabled';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChannelDefaultLocaleEnabled extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.channel.default_locale.enabled',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.channel.default_locale.enabled';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CountryCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.country.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.country.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
@@ -25,7 +25,7 @@ final class CountryCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.country.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class CountryCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.country.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CountryCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.country.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.country.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CustomerGroupCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.customer_group.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.customer_group.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CustomerGroupCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.customer_group.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.customer_group.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
@@ -25,7 +25,7 @@ final class CustomerGroupCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.customer_group.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class CustomerGroupCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.customer_group.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
@@ -25,7 +25,7 @@ final class ExistingChannelCode extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.channel_pricing.existing_code',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ExistingChannelCode extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product_variant.channel_pricing.existing_code';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ExistingChannelCode extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_variant.channel_pricing.existing_code',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product_variant.channel_pricing.existing_code';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ExistingChannelCode extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_variant.channel_pricing.existing_code',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product_variant.channel_pricing.existing_code';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class HasAllPricesDefined extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_variant.channel_pricing.price.not_defined',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product_variant.channel_pricing.price.not_defined';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
@@ -25,7 +25,7 @@ final class HasAllPricesDefined extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.channel_pricing.price.not_defined',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class HasAllPricesDefined extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product_variant.channel_pricing.price.not_defined';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class HasAllPricesDefined extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_variant.channel_pricing.price.not_defined',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product_variant.channel_pricing.price.not_defined';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
@@ -25,7 +25,7 @@ final class HasAllVariantPricesDefined extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product.variants.all_prices_defined',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class HasAllVariantPricesDefined extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product.variants.all_prices_defined';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class HasAllVariantPricesDefined extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product.variants.all_prices_defined',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product.variants.all_prices_defined';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class HasAllVariantPricesDefined extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product.variants.all_prices_defined',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product.variants.all_prices_defined';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
@@ -13,11 +13,32 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class HasEnabledEntity extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $objectManager = null,
+        string $message = 'Must have at least one enabled entity',
+        string $repositoryMethod = 'findBy',
+        ?string $errorPath = null,
+        string $enabledPath = 'enabled',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->objectManager = $objectManager;
+        $this->message = $message;
+        $this->repositoryMethod = $repositoryMethod;
+        $this->errorPath = $errorPath;
+        $this->enabledPath = $enabledPath;
+    }
+
     public ?string $objectManager = null;
 
     public string $message = 'Must have at least one enabled entity';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
@@ -25,11 +25,11 @@ final class HasEnabledEntity extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $objectManager = null,
-        ?string $message = null,
-        ?string $repositoryMethod = null,
-        ?string $errorPath = null,
-        ?string $enabledPath = null,
+        public ?string $objectManager = null,
+        public string $message = 'Must have at least one enabled entity',
+        public string $repositoryMethod = 'findBy',
+        public ?string $errorPath = null,
+        public string $enabledPath = 'enabled',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,33 +41,17 @@ final class HasEnabledEntity extends Constraint
                 static::class,
             );
 
-            $objectManager ??= $options['objectManager'] ?? null;
-            $message ??= $options['message'] ?? null;
-            $repositoryMethod ??= $options['repositoryMethod'] ?? null;
-            $errorPath ??= $options['errorPath'] ?? null;
-            $enabledPath ??= $options['enabledPath'] ?? null;
+            $this->objectManager = $options['objectManager'] ?? $this->objectManager;
+            $this->message = $options['message'] ?? $this->message;
+            $this->repositoryMethod = $options['repositoryMethod'] ?? $this->repositoryMethod;
+            $this->errorPath = $options['errorPath'] ?? $this->errorPath;
+            $this->enabledPath = $options['enabledPath'] ?? $this->enabledPath;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->objectManager = $objectManager ?? $this->objectManager;
-        $this->message = $message ?? $this->message;
-        $this->repositoryMethod = $repositoryMethod ?? $this->repositoryMethod;
-        $this->errorPath = $errorPath ?? $this->errorPath;
-        $this->enabledPath = $enabledPath ?? $this->enabledPath;
     }
-
-    public ?string $objectManager = null;
-
-    public string $message = 'Must have at least one enabled entity';
-
-    public string $repositoryMethod = 'findBy';
-
-    public ?string $errorPath = null;
-
-    public string $enabledPath = 'enabled';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
@@ -25,8 +25,8 @@ final class HasEnabledEntity extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        public ?string $objectManager = null,
         public string $message = 'Must have at least one enabled entity',
+        public ?string $objectManager = null,
         public string $repositoryMethod = 'findBy',
         public ?string $errorPath = null,
         public string $enabledPath = 'enabled',

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
@@ -19,24 +19,44 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class HasEnabledEntity extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $objectManager = null,
-        string $message = 'Must have at least one enabled entity',
-        string $repositoryMethod = 'findBy',
+        ?string $message = null,
+        ?string $repositoryMethod = null,
         ?string $errorPath = null,
-        string $enabledPath = 'enabled',
+        ?string $enabledPath = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $objectManager ??= $options['objectManager'] ?? null;
+            $message ??= $options['message'] ?? null;
+            $repositoryMethod ??= $options['repositoryMethod'] ?? null;
+            $errorPath ??= $options['errorPath'] ?? null;
+            $enabledPath ??= $options['enabledPath'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->objectManager = $objectManager;
-        $this->message = $message;
-        $this->repositoryMethod = $repositoryMethod;
-        $this->errorPath = $errorPath;
-        $this->enabledPath = $enabledPath;
+        $this->objectManager = $objectManager ?? $this->objectManager;
+        $this->message = $message ?? $this->message;
+        $this->repositoryMethod = $repositoryMethod ?? $this->repositoryMethod;
+        $this->errorPath = $errorPath ?? $this->errorPath;
+        $this->enabledPath = $enabledPath ?? $this->enabledPath;
     }
 
     public ?string $objectManager = null;

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
@@ -25,7 +25,7 @@ final class MaxInteger extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.max_integer',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class MaxInteger extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.max_integer';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class MaxInteger extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.max_integer',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.max_integer';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class MaxInteger extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.max_integer',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.max_integer';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -25,7 +25,7 @@ final class OrderPaymentMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.payment_method_eligibility',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderPaymentMethodEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.payment_method_eligibility';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.payment_method_eligibility',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.payment_method_eligibility';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.payment_method_eligibility',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.payment_method_eligibility';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.order.product_eligibility',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.order.product_eligibility';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
@@ -25,7 +25,7 @@ final class OrderProductEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.order.product_eligibility',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class OrderProductEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.order.product_eligibility';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.order.product_eligibility',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.order.product_eligibility';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -13,22 +13,20 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
-    /**
-     * @param array<array-key, mixed> $options
-     */
+    #[HasNamedArguments]
     public function __construct(
-        array $options = [],
         public string $message = 'sylius.order.shipping_method_eligibility',
         public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available',
-        mixed $groups = null,
+        ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct($options, $groups, $payload);
+        parent::__construct(groups: $groups, payload: $payload);
     }
 
     public function getMessage(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -19,14 +19,40 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
+    public string $message = 'sylius.order.shipping_method_eligibility';
+
+    public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available';
+
+    /**
+     * @param array<string, mixed>|null $options
+     * @param array<string>|null $groups
+     */
     #[HasNamedArguments]
     public function __construct(
-        public string $message = 'sylius.order.shipping_method_eligibility',
-        public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available',
+        ?array $options = null,
+        ?string $message = null,
+        ?string $methodNotAvailableMessage = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $methodNotAvailableMessage ??= $options['methodNotAvailableMessage'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->methodNotAvailableMessage = $methodNotAvailableMessage ?? $this->methodNotAvailableMessage;
     }
 
     public function getMessage(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -19,10 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
-    public string $message = 'sylius.order.shipping_method_eligibility';
-
-    public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -30,8 +26,8 @@ final class OrderShippingMethodEligibility extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
-        ?string $methodNotAvailableMessage = null,
+        public string $message = 'sylius.order.shipping_method_eligibility',
+        public string $methodNotAvailableMessage = 'sylius.order.shipping_method_not_available',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -43,16 +39,13 @@ final class OrderShippingMethodEligibility extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
-            $methodNotAvailableMessage ??= $options['methodNotAvailableMessage'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
+            $this->methodNotAvailableMessage = $options['methodNotAvailableMessage'] ?? $this->methodNotAvailableMessage;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
-        $this->methodNotAvailableMessage = $methodNotAvailableMessage ?? $this->methodNotAvailableMessage;
     }
 
     public function getMessage(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ProductCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ProductCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
@@ -25,7 +25,7 @@ final class ProductCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ProductCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ProductImageVariantsBelongToOwner extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_image.product_variant.not_belong_to_owner',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product_image.product_variant.not_belong_to_owner';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
@@ -25,7 +25,7 @@ final class ProductImageVariantsBelongToOwner extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_image.product_variant.not_belong_to_owner',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ProductImageVariantsBelongToOwner extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product_image.product_variant.not_belong_to_owner';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ProductImageVariantsBelongToOwner extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_image.product_variant.not_belong_to_owner',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product_image.product_variant.not_belong_to_owner';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ProductVariantCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_variant.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.product_variant.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
@@ -25,7 +25,7 @@ final class ProductVariantCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ProductVariantCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.product_variant.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ProductVariantCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_variant.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.product_variant.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ProvinceCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.province.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.province.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
@@ -25,7 +25,7 @@ final class ProvinceCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.province.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ProvinceCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.province.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ProvinceCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.province.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.province.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class RegisteredUser extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'This email is already registered. Please log in.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'This email is already registered. Please log in.';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
@@ -25,7 +25,7 @@ final class RegisteredUser extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'This email is already registered. Please log in.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class RegisteredUser extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'This email is already registered. Please log in.';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class RegisteredUser extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'This email is already registered. Please log in.',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'This email is already registered. Please log in.';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
@@ -25,7 +25,7 @@ final class ResendOrderConfirmationEmailWithValidOrderState extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.resend_order_confirmation_email.invalid_order_state',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ResendOrderConfirmationEmailWithValidOrderState extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.resend_order_confirmation_email.invalid_order_state';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ResendOrderConfirmationEmailWithValidOrderState extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.resend_order_confirmation_email.invalid_order_state',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.resend_order_confirmation_email.invalid_order_state';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ResendOrderConfirmationEmailWithValidOrderState extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.resend_order_confirmation_email.invalid_order_state',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.resend_order_confirmation_email.invalid_order_state';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ResendShipmentConfirmationEmailWithValidShipmentState extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ResendShipmentConfirmationEmailWithValidShipmentState extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
@@ -25,7 +25,7 @@ final class ResendShipmentConfirmationEmailWithValidShipmentState extends Constr
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ResendShipmentConfirmationEmailWithValidShipmentState extends Constr
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
@@ -25,7 +25,7 @@ final class TaxonCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.taxon.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class TaxonCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.taxon.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class TaxonCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.taxon.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.taxon.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class TaxonCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.taxon.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.taxon.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class TranslationForExistingLocales extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.translation.locale_code.invalid',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.translation.locale_code.invalid';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class TranslationForExistingLocales extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.translation.locale_code.invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.translation.locale_code.invalid';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
@@ -25,7 +25,7 @@ final class TranslationForExistingLocales extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.translation.locale_code.invalid',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class TranslationForExistingLocales extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.translation.locale_code.invalid';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -20,6 +21,20 @@ class UniqueReviewerEmail extends Constraint
 {
     /** @var string */
     public $message = 'sylius.review.author.already_exists';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -23,14 +23,29 @@ class UniqueReviewerEmail extends Constraint
     public $message = 'sylius.review.author.already_exists';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class UniqueReviewerEmail extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.review.author.already_exists';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -29,7 +26,7 @@ class UniqueReviewerEmail extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.review.author.already_exists',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,14 +38,12 @@ class UniqueReviewerEmail extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ZoneCodeExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.zone.code.not_exist',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.zone.code.not_exist';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ZoneCodeExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.zone.code.not_exist',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.zone.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
@@ -25,7 +25,7 @@ final class ZoneCodeExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.zone.code.not_exist',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class ZoneCodeExists extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.zone.code.not_exist';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/ChannelCodeCollectionValidatorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/ChannelCodeCollectionValidatorTest.php
@@ -75,10 +75,10 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
 
         $this->expectException(\LogicException::class);
 
-        $this->validator->validate([], new ChannelCodeCollection([
-            'validateAgainstAllChannels' => false,
-            'channelAwarePropertyPath' => 'promotion',
-        ]));
+        $this->validator->validate([], new ChannelCodeCollection(
+            validateAgainstAllChannels: false,
+            channelAwarePropertyPath: 'promotion',
+        ));
     }
 
     public function testItValidatesTheValueChannelsExistence(): void
@@ -99,11 +99,11 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $groups = ['Default', 'test_group'];
         $value = ['does_not_exist' => ['one']];
 
-        $constraint = new ChannelCodeCollection([
-            'constraints' => $constraints,
-            'groups' => $groups,
-            'channelAwarePropertyPath' => 'shippingMethod',
-        ]);
+        $constraint = new ChannelCodeCollection(
+            constraints: $constraints,
+            groups: $groups,
+            channelAwarePropertyPath: 'shippingMethod',
+        );
 
         $this->executionContext->expects($this->once())
             ->method('buildViolation')
@@ -144,11 +144,11 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $validator->method('inContext')->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate');
 
-        $this->validator->validate($value, new ChannelCodeCollection([
-            'constraints' => $constraints,
-            'groups' => $groups,
-            'channelAwarePropertyPath' => 'shippingMethod',
-        ]));
+        $this->validator->validate($value, new ChannelCodeCollection(
+            constraints: $constraints,
+            groups: $groups,
+            channelAwarePropertyPath: 'shippingMethod',
+        ));
     }
 
     public function testItValidatesCollectionsForChannelsFromValue(): void
@@ -174,11 +174,11 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $validator->method('inContext')->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate');
 
-        $this->validator->validate($value, new ChannelCodeCollection([
-            'constraints' => $constraints,
-            'groups' => $groups,
-            'channelAwarePropertyPath' => 'promotion',
-        ]));
+        $this->validator->validate($value, new ChannelCodeCollection(
+            constraints: $constraints,
+            groups: $groups,
+            channelAwarePropertyPath: 'promotion',
+        ));
     }
 
     public function testItValidatesCollectionsForLocalChannelsAndFromValue(): void
@@ -206,11 +206,11 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $validator->method('inContext')->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate');
 
-        $this->validator->validate($value, new ChannelCodeCollection([
-            'constraints' => $constraints,
-            'groups' => $groups,
-            'channelAwarePropertyPath' => 'promotion',
-        ]));
+        $this->validator->validate($value, new ChannelCodeCollection(
+            constraints: $constraints,
+            groups: $groups,
+            channelAwarePropertyPath: 'promotion',
+        ));
     }
 
     public function testItDoesNothingWhenLocalCollectionIfChannelsIsEmpty(): void
@@ -226,10 +226,10 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $this->executionContext->expects($this->never())->method('buildViolation');
         $this->executionContext->expects($this->never())->method('getValidator');
 
-        $this->validator->validate([], new ChannelCodeCollection([
-            'validateAgainstAllChannels' => false,
-            'channelAwarePropertyPath' => 'promotion',
-        ]));
+        $this->validator->validate([], new ChannelCodeCollection(
+            validateAgainstAllChannels: false,
+            channelAwarePropertyPath: 'promotion',
+        ));
     }
 
     public function testItValidatesCollectionsForAllChannels(): void
@@ -249,10 +249,10 @@ final class ChannelCodeCollectionValidatorTest extends TestCase
         $validator->method('inContext')->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate');
 
-        $this->validator->validate($value, new ChannelCodeCollection([
-            'constraints' => $constraints,
-            'groups' => $groups,
-            'validateAgainstAllChannels' => true,
-        ]));
+        $this->validator->validate($value, new ChannelCodeCollection(
+            constraints: $constraints,
+            groups: $groups,
+            validateAgainstAllChannels: true,
+        ));
     }
 }

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
@@ -23,14 +23,29 @@ class DifferentSourceTargetCurrency extends Constraint
     public $message = 'sylius.exchange_rate.different_source_target_currency';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/currency-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class DifferentSourceTargetCurrency extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.exchange_rate.different_source_target_currency';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -29,7 +26,7 @@ class DifferentSourceTargetCurrency extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.exchange_rate.different_source_target_currency',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,14 +38,12 @@ class DifferentSourceTargetCurrency extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CurrencyBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -20,6 +21,20 @@ class DifferentSourceTargetCurrency extends Constraint
 {
     /** @var string */
     public $message = 'sylius.exchange_rate.different_source_target_currency';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
@@ -23,14 +23,29 @@ class UniqueCurrencyPair extends Constraint
     public $message = 'sylius.exchange_rate.unique_currency_pair';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/currency-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class UniqueCurrencyPair extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.exchange_rate.unique_currency_pair';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -29,7 +26,7 @@ class UniqueCurrencyPair extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.exchange_rate.unique_currency_pair',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -41,14 +38,12 @@ class UniqueCurrencyPair extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CurrencyBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -20,6 +21,20 @@ class UniqueCurrencyPair extends Constraint
 {
     /** @var string */
     public $message = 'sylius.exchange_rate.unique_currency_pair';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
+++ b/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
@@ -19,22 +19,41 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class InStock extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.cart_item.not_available',
-        string $shortMessage = 'sylius.cart_item.insufficient_stock',
-        string $stockablePath = 'stockable',
-        string $quantityPath = 'quantity',
+        ?array $options = null,
+        ?string $message = null,
+        ?string $shortMessage = null,
+        ?string $stockablePath = null,
+        ?string $quantityPath = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/inventory-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $shortMessage ??= $options['shortMessage'] ?? null;
+            $stockablePath ??= $options['stockablePath'] ?? null;
+            $quantityPath ??= $options['quantityPath'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
-        $this->shortMessage = $shortMessage;
-        $this->stockablePath = $stockablePath;
-        $this->quantityPath = $quantityPath;
+        $this->message = $message ?? $this->message;
+        $this->shortMessage = $shortMessage ?? $this->shortMessage;
+        $this->stockablePath = $stockablePath ?? $this->stockablePath;
+        $this->quantityPath = $quantityPath ?? $this->quantityPath;
     }
 
     public string $message = 'sylius.cart_item.not_available';

--- a/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
+++ b/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
@@ -13,11 +13,30 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\InventoryBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class InStock extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.cart_item.not_available',
+        string $shortMessage = 'sylius.cart_item.insufficient_stock',
+        string $stockablePath = 'stockable',
+        string $quantityPath = 'quantity',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+        $this->shortMessage = $shortMessage;
+        $this->stockablePath = $stockablePath;
+        $this->quantityPath = $quantityPath;
+    }
+
     public string $message = 'sylius.cart_item.not_available';
 
     public string $shortMessage = 'sylius.cart_item.insufficient_stock';

--- a/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
+++ b/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
@@ -25,10 +25,10 @@ final class InStock extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
-        ?string $shortMessage = null,
-        ?string $stockablePath = null,
-        ?string $quantityPath = null,
+        public string $message = 'sylius.cart_item.not_available',
+        public string $shortMessage = 'sylius.cart_item.insufficient_stock',
+        public string $stockablePath = 'stockable',
+        public string $quantityPath = 'quantity',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -40,29 +40,16 @@ final class InStock extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
-            $shortMessage ??= $options['shortMessage'] ?? null;
-            $stockablePath ??= $options['stockablePath'] ?? null;
-            $quantityPath ??= $options['quantityPath'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
+            $this->shortMessage = $options['shortMessage'] ?? $this->shortMessage;
+            $this->stockablePath = $options['stockablePath'] ?? $this->stockablePath;
+            $this->quantityPath = $options['quantityPath'] ?? $this->quantityPath;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
-        $this->shortMessage = $shortMessage ?? $this->shortMessage;
-        $this->stockablePath = $stockablePath ?? $this->stockablePath;
-        $this->quantityPath = $quantityPath ?? $this->quantityPath;
     }
-
-    public string $message = 'sylius.cart_item.not_available';
-
-    public string $shortMessage = 'sylius.cart_item.insufficient_stock';
-
-    public string $stockablePath = 'stockable';
-
-    public string $quantityPath = 'quantity';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/validation/Locale.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/validation/Locale.xml
@@ -24,15 +24,17 @@
                 <option name="groups">sylius</option>
             </constraint>
             <constraint name="Sequentially">
-                <constraint name="Length">
-                    <option name="max">10</option>
-                    <option name="maxMessage">sylius.locale.code.max_length</option>
-                    <option name="groups">sylius</option>
-                </constraint>
-                <constraint name="Locale">
-                    <option name="message">sylius.locale.code.locale</option>
-                    <option name="groups">sylius</option>
-                </constraint>
+                <option name="constraints">
+                    <constraint name="Length">
+                        <option name="max">10</option>
+                        <option name="maxMessage">sylius.locale.code.max_length</option>
+                        <option name="groups">sylius</option>
+                    </constraint>
+                    <constraint name="Locale">
+                        <option name="message">sylius.locale.code.locale</option>
+                        <option name="groups">sylius</option>
+                    </constraint>
+                </option>
             </constraint>
         </property>
     </class>

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class GatewayFactoryExists extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $invalidGatewayFactoryMessage instead. It will be removed in Sylius 3.0. */
+    public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -58,9 +61,6 @@ final class GatewayFactoryExists extends Constraint
         parent::__construct(groups: $groups, payload: $payload);
         $this->invalidGatewayFactory = $this->invalidGatewayFactoryMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $invalidGatewayFactoryMessage instead. It will be removed in Sylius 3.0. */
-    public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class GatewayFactoryExists extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory',
+        ?array $options = null,
+        ?string $invalidGatewayFactory = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/payment-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidGatewayFactory ??= $options['invalidGatewayFactory'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidGatewayFactory = $invalidGatewayFactory;
+        $this->invalidGatewayFactory = $invalidGatewayFactory ?? $this->invalidGatewayFactory;
     }
 
     public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
@@ -25,6 +25,7 @@ final class GatewayFactoryExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidGatewayFactoryMessage = null,
         ?string $invalidGatewayFactory = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -37,16 +38,32 @@ final class GatewayFactoryExists extends Constraint
                 static::class,
             );
 
+            $invalidGatewayFactoryMessage ??= $options['invalidGatewayFactoryMessage'] ?? null;
             $invalidGatewayFactory ??= $options['invalidGatewayFactory'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidGatewayFactory) {
+            trigger_deprecation(
+                'sylius/payment-bundle',
+                '2.3',
+                'The "invalidGatewayFactory" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidGatewayFactoryMessage" instead.',
+                static::class,
+            );
+
+            $invalidGatewayFactoryMessage ??= $invalidGatewayFactory;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidGatewayFactory = $invalidGatewayFactory ?? $this->invalidGatewayFactory;
+        $this->invalidGatewayFactoryMessage = $invalidGatewayFactoryMessage ?? $this->invalidGatewayFactoryMessage;
+        $this->invalidGatewayFactory = $this->invalidGatewayFactoryMessage;
     }
 
+    public string $invalidGatewayFactoryMessage = 'sylius.gateway_config.invalid_gateway_factory';
+
+    /** @deprecated since Sylius 2.3, use $invalidGatewayFactoryMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
@@ -25,7 +25,7 @@ final class GatewayFactoryExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidGatewayFactoryMessage = null,
+        public string $invalidGatewayFactoryMessage = 'sylius.gateway_config.invalid_gateway_factory',
         ?string $invalidGatewayFactory = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -38,7 +38,7 @@ final class GatewayFactoryExists extends Constraint
                 static::class,
             );
 
-            $invalidGatewayFactoryMessage ??= $options['invalidGatewayFactoryMessage'] ?? null;
+            $this->invalidGatewayFactoryMessage = $options['invalidGatewayFactoryMessage'] ?? $this->invalidGatewayFactoryMessage;
             $invalidGatewayFactory ??= $options['invalidGatewayFactory'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -52,16 +52,12 @@ final class GatewayFactoryExists extends Constraint
                 static::class,
             );
 
-            $invalidGatewayFactoryMessage ??= $invalidGatewayFactory;
+            $this->invalidGatewayFactoryMessage = $invalidGatewayFactory;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidGatewayFactoryMessage = $invalidGatewayFactoryMessage ?? $this->invalidGatewayFactoryMessage;
         $this->invalidGatewayFactory = $this->invalidGatewayFactoryMessage;
     }
-
-    public string $invalidGatewayFactoryMessage = 'sylius.gateway_config.invalid_gateway_factory';
 
     /** @deprecated since Sylius 2.3, use $invalidGatewayFactoryMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PaymentBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class GatewayFactoryExists extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidGatewayFactory = $invalidGatewayFactory;
+    }
+
     public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExistsValidator.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExistsValidator.php
@@ -36,7 +36,7 @@ final class GatewayFactoryExistsValidator extends ConstraintValidator
         }
 
         if (!in_array($value, array_keys($this->factoryNames), true)) {
-            $this->context->buildViolation($constraint->invalidGatewayFactory)
+            $this->context->buildViolation($constraint->invalidGatewayFactoryMessage)
                 ->setParameter('{{ available_factories }}', implode(', ', array_keys($this->factoryNames)))
                 ->addViolation()
             ;

--- a/src/Sylius/Bundle/PaymentBundle/tests/Validator/Constraints/GatewayFactoryExistsValidatorTest.php
+++ b/src/Sylius/Bundle/PaymentBundle/tests/Validator/Constraints/GatewayFactoryExistsValidatorTest.php
@@ -58,7 +58,7 @@ final class GatewayFactoryExistsValidatorTest extends TestCase
         $this->executionContext
             ->expects(self::once())
             ->method('buildViolation')
-            ->with((new GatewayFactoryExists())->invalidGatewayFactory)
+            ->with((new GatewayFactoryExists())->invalidGatewayFactoryMessage)
             ->willReturn($constraintViolationBuilder);
 
         $constraintViolationBuilder

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ProductVariantCombination extends Constraint
 {
-    public string $message = 'sylius.product_variant.combination';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -28,7 +26,7 @@ final class ProductVariantCombination extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.combination',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -40,14 +38,12 @@ final class ProductVariantCombination extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
@@ -22,14 +22,29 @@ final class ProductVariantCombination extends Constraint
     public string $message = 'sylius.product_variant.combination';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/product-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
@@ -13,12 +13,27 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ProductBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ProductVariantCombination extends Constraint
 {
     public string $message = 'sylius.product_variant.combination';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
@@ -13,12 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ProductBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ProductVariantOptionValuesConfiguration extends Constraint
 {
     public string $message = 'sylius.product_variant.option_values.not_configured';
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.product_variant.option_values.not_configured',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
@@ -21,15 +21,32 @@ final class ProductVariantOptionValuesConfiguration extends Constraint
 {
     public string $message = 'sylius.product_variant.option_values.not_configured';
 
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.product_variant.option_values.not_configured',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/product-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
@@ -19,15 +19,13 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ProductVariantOptionValuesConfiguration extends Constraint
 {
-    public string $message = 'sylius.product_variant.option_values.not_configured';
-
     /**
      * @param array<string, mixed>|null $options
      */
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.product_variant.option_values.not_configured',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -39,14 +37,12 @@ final class ProductVariantOptionValuesConfiguration extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
@@ -13,12 +13,27 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ProductBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class UniqueSimpleProductCode extends Constraint
 {
     public string $message = 'sylius.simple_product.code.unique';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UniqueSimpleProductCode extends Constraint
 {
-    public string $message = 'sylius.simple_product.code.unique';
-
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
@@ -28,7 +26,7 @@ final class UniqueSimpleProductCode extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.simple_product.code.unique',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -40,14 +38,12 @@ final class UniqueSimpleProductCode extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
@@ -22,14 +22,29 @@ final class UniqueSimpleProductCode extends Constraint
     public string $message = 'sylius.simple_product.code.unique';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/product-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/Sylius/Bundle/ProductBundle/tests/Validator/ProductVariantCombinationValidatorTest.php
+++ b/src/Sylius/Bundle/ProductBundle/tests/Validator/ProductVariantCombinationValidatorTest.php
@@ -52,7 +52,7 @@ final class ProductVariantCombinationValidatorTest extends TestCase
         /** @var ProductVariantInterface&MockObject $variant */
         $variant = $this->createMock(ProductVariantInterface::class);
 
-        $constraint = new ProductVariantCombination(['message' => 'Variant with given options already exists']);
+        $constraint = new ProductVariantCombination(message: 'Variant with given options already exists');
 
         $variant->expects($this->once())->method('getProduct')->willReturn(null);
         $product->expects($this->never())->method('hasVariants');
@@ -70,7 +70,7 @@ final class ProductVariantCombinationValidatorTest extends TestCase
         /** @var ProductVariantInterface&MockObject $variant */
         $variant = $this->createMock(ProductVariantInterface::class);
 
-        $constraint = new ProductVariantCombination(['message' => 'Variant with given options already exists']);
+        $constraint = new ProductVariantCombination(message: 'Variant with given options already exists');
 
         $variant->expects($this->once())->method('getProduct')->willReturn($product);
         $product->expects($this->once())->method('hasVariants')->willReturn(true);
@@ -88,7 +88,7 @@ final class ProductVariantCombinationValidatorTest extends TestCase
         /** @var ProductVariantInterface&MockObject $variant */
         $variant = $this->createMock(ProductVariantInterface::class);
 
-        $constraint = new ProductVariantCombination(['message' => 'Variant with given options already exists']);
+        $constraint = new ProductVariantCombination(message: 'Variant with given options already exists');
 
         $variant->expects($this->once())->method('getProduct')->willReturn($product);
         $product->expects($this->once())->method('hasVariants')->willReturn(false);
@@ -106,7 +106,7 @@ final class ProductVariantCombinationValidatorTest extends TestCase
         /** @var ProductVariantInterface&MockObject $variant */
         $variant = $this->createMock(ProductVariantInterface::class);
 
-        $constraint = new ProductVariantCombination(['message' => 'Variant with given options already exists']);
+        $constraint = new ProductVariantCombination(message: 'Variant with given options already exists');
 
         $variant->expects($this->once())->method('getProduct')->willReturn($product);
         $product->expects($this->once())->method('hasVariants')->willReturn(true);

--- a/src/Sylius/Bundle/ProductBundle/tests/Validator/UniqueSimpleProductCodeValidatorTest.php
+++ b/src/Sylius/Bundle/ProductBundle/tests/Validator/UniqueSimpleProductCodeValidatorTest.php
@@ -51,7 +51,7 @@ final class UniqueSimpleProductCodeValidatorTest extends TestCase
         /** @var ProductInterface&MockObject $product */
         $product = $this->createMock(ProductInterface::class);
 
-        $constraint = new UniqueSimpleProductCode(['message' => 'Simple product code has to be unique']);
+        $constraint = new UniqueSimpleProductCode(message: 'Simple product code has to be unique');
 
         $product->expects($this->once())->method('isSimple')->willReturn(false);
         $this->context->expects($this->never())->method('buildViolation');
@@ -64,7 +64,7 @@ final class UniqueSimpleProductCodeValidatorTest extends TestCase
         /** @var ProductInterface&MockObject $product */
         $product = $this->createMock(ProductInterface::class);
 
-        $constraint = new UniqueSimpleProductCode(['message' => 'Simple product code has to be unique']);
+        $constraint = new UniqueSimpleProductCode(message: 'Simple product code has to be unique');
 
         $product->expects($this->once())->method('isSimple')->willReturn(true);
         $product->expects($this->once())->method('getCode')->willReturn('AWESOME_PRODUCT');
@@ -81,7 +81,7 @@ final class UniqueSimpleProductCodeValidatorTest extends TestCase
         /** @var ProductVariantInterface&MockObject $existingProductVariant */
         $existingProductVariant = $this->createMock(ProductVariantInterface::class);
 
-        $constraint = new UniqueSimpleProductCode(['message' => 'Simple product code has to be unique']);
+        $constraint = new UniqueSimpleProductCode(message: 'Simple product code has to be unique');
 
         $product->expects($this->once())->method('isSimple')->willReturn(true);
         $product->expects($this->once())->method('getCode')->willReturn('AWESOME_PRODUCT');
@@ -109,7 +109,7 @@ final class UniqueSimpleProductCodeValidatorTest extends TestCase
         /** @var ConstraintViolationBuilderInterface&MockObject $constraintViolationBuilder */
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
 
-        $constraint = new UniqueSimpleProductCode(['message' => 'Simple product code has to be unique']);
+        $constraint = new UniqueSimpleProductCode(message: 'Simple product code has to be unique');
 
         $product->expects($this->once())->method('isSimple')->willReturn(true);
         $product->expects($this->once())->method('getCode')->willReturn('AWESOME_PRODUCT');

--- a/src/Sylius/Bundle/PromotionBundle/Validator/CatalogPromotionActionTypeValidator.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/CatalogPromotionActionTypeValidator.php
@@ -43,7 +43,7 @@ final class CatalogPromotionActionTypeValidator extends ConstraintValidator
         }
 
         if (!in_array($type, $this->actionTypes, true)) {
-            $this->context->buildViolation($constraint->invalidType)
+            $this->context->buildViolation($constraint->invalidTypeMessage)
                 ->setParameter('{{ available_action_types }}', implode(', ', $this->actionTypes))
                 ->atPath('type')
                 ->addViolation()

--- a/src/Sylius/Bundle/PromotionBundle/Validator/CatalogPromotionScopeTypeValidator.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/CatalogPromotionScopeTypeValidator.php
@@ -42,7 +42,7 @@ final class CatalogPromotionScopeTypeValidator extends ConstraintValidator
         }
 
         if (!in_array($type, $this->scopeTypes, true)) {
-            $this->context->buildViolation($constraint->invalidType)
+            $this->context->buildViolation($constraint->invalidTypeMessage)
                 ->setParameter('{{ available_scope_types }}', implode(', ', $this->scopeTypes))
                 ->atPath('type')
                 ->addViolation()

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CatalogPromotionActionType extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
+    public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -58,9 +61,6 @@ final class CatalogPromotionActionType extends Constraint
         parent::__construct(groups: $groups, payload: $payload);
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
-    public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CatalogPromotionActionType extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $invalidType = 'sylius.catalog_promotion_action.type.invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidType = $invalidType;
+    }
+
     public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
@@ -25,7 +25,7 @@ final class CatalogPromotionActionType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidTypeMessage = null,
+        public string $invalidTypeMessage = 'sylius.catalog_promotion_action.type.invalid',
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -38,7 +38,7 @@ final class CatalogPromotionActionType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
+            $this->invalidTypeMessage = $options['invalidTypeMessage'] ?? $this->invalidTypeMessage;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -52,16 +52,12 @@ final class CatalogPromotionActionType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $invalidType;
+            $this->invalidTypeMessage = $invalidType;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    public string $invalidTypeMessage = 'sylius.catalog_promotion_action.type.invalid';
 
     /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
@@ -25,6 +25,7 @@ final class CatalogPromotionActionType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidTypeMessage = null,
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -37,16 +38,32 @@ final class CatalogPromotionActionType extends Constraint
                 static::class,
             );
 
+            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidType) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'The "invalidType" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidTypeMessage" instead.',
+                static::class,
+            );
+
+            $invalidTypeMessage ??= $invalidType;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType ?? $this->invalidType;
+        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
+        $this->invalidType = $this->invalidTypeMessage;
     }
 
+    public string $invalidTypeMessage = 'sylius.catalog_promotion_action.type.invalid';
+
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CatalogPromotionActionType extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $invalidType = 'sylius.catalog_promotion_action.type.invalid',
+        ?array $options = null,
+        ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidType ??= $options['invalidType'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType;
+        $this->invalidType = $invalidType ?? $this->invalidType;
     }
 
     public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
@@ -25,7 +25,7 @@ final class CatalogPromotionScopeType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidTypeMessage = null,
+        public string $invalidTypeMessage = 'sylius.catalog_promotion_scope.type.invalid',
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -38,7 +38,7 @@ final class CatalogPromotionScopeType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
+            $this->invalidTypeMessage = $options['invalidTypeMessage'] ?? $this->invalidTypeMessage;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -52,16 +52,12 @@ final class CatalogPromotionScopeType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $invalidType;
+            $this->invalidTypeMessage = $invalidType;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    public string $invalidTypeMessage = 'sylius.catalog_promotion_scope.type.invalid';
 
     /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CatalogPromotionScopeType extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $invalidType = 'sylius.catalog_promotion_scope.type.invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidType = $invalidType;
+    }
+
     public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CatalogPromotionScopeType extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
+    public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -58,9 +61,6 @@ final class CatalogPromotionScopeType extends Constraint
         parent::__construct(groups: $groups, payload: $payload);
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
-    public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
@@ -25,6 +25,7 @@ final class CatalogPromotionScopeType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidTypeMessage = null,
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -37,16 +38,32 @@ final class CatalogPromotionScopeType extends Constraint
                 static::class,
             );
 
+            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidType) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'The "invalidType" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidTypeMessage" instead.',
+                static::class,
+            );
+
+            $invalidTypeMessage ??= $invalidType;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType ?? $this->invalidType;
+        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
+        $this->invalidType = $this->invalidTypeMessage;
     }
 
+    public string $invalidTypeMessage = 'sylius.catalog_promotion_scope.type.invalid';
+
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CatalogPromotionScopeType extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $invalidType = 'sylius.catalog_promotion_scope.type.invalid',
+        ?array $options = null,
+        ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidType ??= $options['invalidType'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType;
+        $this->invalidType = $invalidType ?? $this->invalidType;
     }
 
     public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class CouponPossibleGenerationAmount extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
@@ -25,7 +25,7 @@ final class CouponPossibleGenerationAmount extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class CouponPossibleGenerationAmount extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CouponPossibleGenerationAmount extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
@@ -25,7 +25,7 @@ final class PromotionActionType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidTypeMessage = null,
+        public string $invalidTypeMessage = 'sylius.promotion_action.invalid_type',
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -38,7 +38,7 @@ final class PromotionActionType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
+            $this->invalidTypeMessage = $options['invalidTypeMessage'] ?? $this->invalidTypeMessage;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -52,16 +52,12 @@ final class PromotionActionType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $invalidType;
+            $this->invalidTypeMessage = $invalidType;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    public string $invalidTypeMessage = 'sylius.promotion_action.invalid_type';
 
     /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.promotion_action.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionActionType extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $invalidType = 'sylius.promotion_action.invalid_type',
+        ?array $options = null,
+        ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidType ??= $options['invalidType'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType;
+        $this->invalidType = $invalidType ?? $this->invalidType;
     }
 
     public string $invalidType = 'sylius.promotion_action.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class PromotionActionType extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $invalidType = 'sylius.promotion_action.invalid_type',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidType = $invalidType;
+    }
+
     public string $invalidType = 'sylius.promotion_action.invalid_type';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
@@ -25,6 +25,7 @@ final class PromotionActionType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidTypeMessage = null,
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -37,16 +38,32 @@ final class PromotionActionType extends Constraint
                 static::class,
             );
 
+            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidType) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'The "invalidType" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidTypeMessage" instead.',
+                static::class,
+            );
+
+            $invalidTypeMessage ??= $invalidType;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType ?? $this->invalidType;
+        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
+        $this->invalidType = $this->invalidTypeMessage;
     }
 
+    public string $invalidTypeMessage = 'sylius.promotion_action.invalid_type';
+
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.promotion_action.invalid_type';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionActionType extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
+    public string $invalidType = 'sylius.promotion_action.invalid_type';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -58,9 +61,6 @@ final class PromotionActionType extends Constraint
         parent::__construct(groups: $groups, payload: $payload);
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
-    public string $invalidType = 'sylius.promotion_action.invalid_type';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class PromotionDateRange extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionDateRange extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
@@ -25,7 +25,7 @@ final class PromotionDateRange extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class PromotionDateRange extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
@@ -25,7 +25,7 @@ final class PromotionNotCouponBased extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.promotion_coupon.promotion.not_coupon_based',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class PromotionNotCouponBased extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.promotion_coupon.promotion.not_coupon_based';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class PromotionNotCouponBased extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.promotion_coupon.promotion.not_coupon_based',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.promotion_coupon.promotion.not_coupon_based';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionNotCouponBased extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.promotion_coupon.promotion.not_coupon_based',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.promotion_coupon.promotion.not_coupon_based';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
@@ -25,6 +25,7 @@ final class PromotionRuleType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidTypeMessage = null,
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -37,16 +38,32 @@ final class PromotionRuleType extends Constraint
                 static::class,
             );
 
+            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidType) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'The "invalidType" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidTypeMessage" instead.',
+                static::class,
+            );
+
+            $invalidTypeMessage ??= $invalidType;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType ?? $this->invalidType;
+        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
+        $this->invalidType = $this->invalidTypeMessage;
     }
 
+    public string $invalidTypeMessage = 'sylius.promotion_rule.invalid_type';
+
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.promotion_rule.invalid_type';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionRuleType extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $invalidType = 'sylius.promotion_rule.invalid_type',
+        ?array $options = null,
+        ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidType ??= $options['invalidType'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType;
+        $this->invalidType = $invalidType ?? $this->invalidType;
     }
 
     public string $invalidType = 'sylius.promotion_rule.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class PromotionRuleType extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $invalidType = 'sylius.promotion_rule.invalid_type',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidType = $invalidType;
+    }
+
     public string $invalidType = 'sylius.promotion_rule.invalid_type';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionRuleType extends Constraint
 {
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
+    public string $invalidType = 'sylius.promotion_rule.invalid_type';
+
     /**
      * @param array<string, mixed>|null $options
      */
@@ -58,9 +61,6 @@ final class PromotionRuleType extends Constraint
         parent::__construct(groups: $groups, payload: $payload);
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
-    public string $invalidType = 'sylius.promotion_rule.invalid_type';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
@@ -25,7 +25,7 @@ final class PromotionRuleType extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidTypeMessage = null,
+        public string $invalidTypeMessage = 'sylius.promotion_rule.invalid_type',
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -38,7 +38,7 @@ final class PromotionRuleType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
+            $this->invalidTypeMessage = $options['invalidTypeMessage'] ?? $this->invalidTypeMessage;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -52,16 +52,12 @@ final class PromotionRuleType extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $invalidType;
+            $this->invalidTypeMessage = $invalidType;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
         $this->invalidType = $this->invalidTypeMessage;
     }
-
-    public string $invalidTypeMessage = 'sylius.promotion_rule.invalid_type';
 
     /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.promotion_rule.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
@@ -25,7 +25,7 @@ final class PromotionSubjectCoupon extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.promotion_coupon.is_invalid',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -37,17 +37,13 @@ final class PromotionSubjectCoupon extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.promotion_coupon.is_invalid';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
@@ -19,16 +19,32 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionSubjectCoupon extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.promotion_coupon.is_invalid',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/promotion-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.promotion_coupon.is_invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class PromotionSubjectCoupon extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.promotion_coupon.is_invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.promotion_coupon.is_invalid';
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/PromotionActionTypeValidator.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/PromotionActionTypeValidator.php
@@ -38,7 +38,7 @@ final class PromotionActionTypeValidator extends ConstraintValidator
         }
 
         if (!array_key_exists($value->getType(), $this->actionTypes)) {
-            $this->context->buildViolation($constraint->invalidType)
+            $this->context->buildViolation($constraint->invalidTypeMessage)
                 ->setParameter('{{ available_action_types }}', implode(', ', array_keys($this->actionTypes)))
                 ->atPath('type')
                 ->addViolation();

--- a/src/Sylius/Bundle/PromotionBundle/Validator/PromotionRuleTypeValidator.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/PromotionRuleTypeValidator.php
@@ -38,7 +38,7 @@ final class PromotionRuleTypeValidator extends ConstraintValidator
         }
 
         if (!array_key_exists($value->getType(), $this->ruleTypes)) {
-            $this->context->buildViolation($constraint->invalidType)
+            $this->context->buildViolation($constraint->invalidTypeMessage)
                 ->setParameter('{{ available_rule_types }}', implode(', ', array_keys($this->ruleTypes)))
                 ->atPath('type')
                 ->addViolation();

--- a/src/Sylius/Bundle/PromotionBundle/tests/Validator/CatalogPromotionActionTypeValidatorTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/tests/Validator/CatalogPromotionActionTypeValidatorTest.php
@@ -102,7 +102,7 @@ final class CatalogPromotionActionTypeValidatorTest extends TestCase
 
         $this->context->expects(self::once())
             ->method('buildViolation')
-            ->with($constraint->invalidType)
+            ->with($constraint->invalidTypeMessage)
             ->willReturn($violationBuilder);
 
         $violationBuilder->expects(self::once())

--- a/src/Sylius/Bundle/PromotionBundle/tests/Validator/CatalogPromotionScopeTypeValidatorTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/tests/Validator/CatalogPromotionScopeTypeValidatorTest.php
@@ -102,7 +102,7 @@ final class CatalogPromotionScopeTypeValidatorTest extends TestCase
 
         $this->context->expects(self::once())
             ->method('buildViolation')
-            ->with($constraint->invalidType)
+            ->with($constraint->invalidTypeMessage)
             ->willReturn($violationBuilder);
 
         $violationBuilder->expects(self::once())

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShippingMethodCalculatorExists extends Constraint
 {
+    public string $invalidShippingCalculatorMessage = 'sylius.shipping_method.calculator.invalid';
+
+    /** @deprecated since Sylius 2.3, use $invalidShippingCalculatorMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidShippingCalculator = 'sylius.shipping_method.calculator.invalid';
 
     /**
@@ -28,6 +31,7 @@ final class ShippingMethodCalculatorExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidShippingCalculatorMessage = null,
         ?string $invalidShippingCalculator = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -40,14 +44,27 @@ final class ShippingMethodCalculatorExists extends Constraint
                 static::class,
             );
 
+            $invalidShippingCalculatorMessage ??= $options['invalidShippingCalculatorMessage'] ?? null;
             $invalidShippingCalculator ??= $options['invalidShippingCalculator'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidShippingCalculator) {
+            trigger_deprecation(
+                'sylius/shipping-bundle',
+                '2.3',
+                'The "invalidShippingCalculator" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidShippingCalculatorMessage" instead.',
+                static::class,
+            );
+
+            $invalidShippingCalculatorMessage ??= $invalidShippingCalculator;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidShippingCalculator = $invalidShippingCalculator ?? $this->invalidShippingCalculator;
+        $this->invalidShippingCalculatorMessage = $invalidShippingCalculatorMessage ?? $this->invalidShippingCalculatorMessage;
+        $this->invalidShippingCalculator = $this->invalidShippingCalculatorMessage;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShippingMethodCalculatorExists extends Constraint
 {
-    public string $invalidShippingCalculatorMessage = 'sylius.shipping_method.calculator.invalid';
-
     /** @deprecated since Sylius 2.3, use $invalidShippingCalculatorMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidShippingCalculator = 'sylius.shipping_method.calculator.invalid';
 
@@ -31,7 +29,7 @@ final class ShippingMethodCalculatorExists extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidShippingCalculatorMessage = null,
+        public string $invalidShippingCalculatorMessage = 'sylius.shipping_method.calculator.invalid',
         ?string $invalidShippingCalculator = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -44,7 +42,7 @@ final class ShippingMethodCalculatorExists extends Constraint
                 static::class,
             );
 
-            $invalidShippingCalculatorMessage ??= $options['invalidShippingCalculatorMessage'] ?? null;
+            $this->invalidShippingCalculatorMessage = $options['invalidShippingCalculatorMessage'] ?? $this->invalidShippingCalculatorMessage;
             $invalidShippingCalculator ??= $options['invalidShippingCalculator'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -58,12 +56,10 @@ final class ShippingMethodCalculatorExists extends Constraint
                 static::class,
             );
 
-            $invalidShippingCalculatorMessage ??= $invalidShippingCalculator;
+            $this->invalidShippingCalculatorMessage = $invalidShippingCalculator;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidShippingCalculatorMessage = $invalidShippingCalculatorMessage ?? $this->invalidShippingCalculatorMessage;
         $this->invalidShippingCalculator = $this->invalidShippingCalculatorMessage;
     }
 

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
@@ -13,12 +13,27 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShippingBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShippingMethodCalculatorExists extends Constraint
 {
     public string $invalidShippingCalculator = 'sylius.shipping_method.calculator.invalid';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $invalidShippingCalculator = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidShippingCalculator = $invalidShippingCalculator ?? $this->invalidShippingCalculator;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
@@ -22,14 +22,29 @@ final class ShippingMethodCalculatorExists extends Constraint
     public string $invalidShippingCalculator = 'sylius.shipping_method.calculator.invalid';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $invalidShippingCalculator = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/shipping-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidShippingCalculator ??= $options['invalidShippingCalculator'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->invalidShippingCalculator = $invalidShippingCalculator ?? $this->invalidShippingCalculator;

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
@@ -13,12 +13,27 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShippingBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ShippingMethodRule extends Constraint
 {
     public string $invalidType = 'sylius.shipping_method.rule.invalid_type';
+
+    /**
+     * @param array<string>|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $invalidType = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->invalidType = $invalidType ?? $this->invalidType;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShippingMethodRule extends Constraint
 {
+    public string $invalidTypeMessage = 'sylius.shipping_method.rule.invalid_type';
+
+    /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.shipping_method.rule.invalid_type';
 
     /**
@@ -28,6 +31,7 @@ final class ShippingMethodRule extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
+        ?string $invalidTypeMessage = null,
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -40,14 +44,27 @@ final class ShippingMethodRule extends Constraint
                 static::class,
             );
 
+            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
+        if (null !== $invalidType) {
+            trigger_deprecation(
+                'sylius/shipping-bundle',
+                '2.3',
+                'The "invalidType" option of the "%s" constraint is deprecated and will be removed in Sylius 3.0, use "invalidTypeMessage" instead.',
+                static::class,
+            );
+
+            $invalidTypeMessage ??= $invalidType;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->invalidType = $invalidType ?? $this->invalidType;
+        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
+        $this->invalidType = $this->invalidTypeMessage;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
@@ -22,14 +22,29 @@ final class ShippingMethodRule extends Constraint
     public string $invalidType = 'sylius.shipping_method.rule.invalid_type';
 
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string>|null $groups
      */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/shipping-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $invalidType ??= $options['invalidType'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->invalidType = $invalidType ?? $this->invalidType;

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShippingMethodRule extends Constraint
 {
-    public string $invalidTypeMessage = 'sylius.shipping_method.rule.invalid_type';
-
     /** @deprecated since Sylius 2.3, use $invalidTypeMessage instead. It will be removed in Sylius 3.0. */
     public string $invalidType = 'sylius.shipping_method.rule.invalid_type';
 
@@ -31,7 +29,7 @@ final class ShippingMethodRule extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $invalidTypeMessage = null,
+        public string $invalidTypeMessage = 'sylius.shipping_method.rule.invalid_type',
         ?string $invalidType = null,
         ?array $groups = null,
         mixed $payload = null,
@@ -44,7 +42,7 @@ final class ShippingMethodRule extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $options['invalidTypeMessage'] ?? null;
+            $this->invalidTypeMessage = $options['invalidTypeMessage'] ?? $this->invalidTypeMessage;
             $invalidType ??= $options['invalidType'] ?? null;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
@@ -58,12 +56,10 @@ final class ShippingMethodRule extends Constraint
                 static::class,
             );
 
-            $invalidTypeMessage ??= $invalidType;
+            $this->invalidTypeMessage = $invalidType;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->invalidTypeMessage = $invalidTypeMessage ?? $this->invalidTypeMessage;
         $this->invalidType = $this->invalidTypeMessage;
     }
 

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ValidDeliveryTimeRange.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ValidDeliveryTimeRange.php
@@ -19,15 +19,13 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ValidDeliveryTimeRange extends Constraint
 {
-    public string $message = 'sylius.form.shipping_method.max_delivery_time_days.greater_or_equal_min';
-
     /**
      * @param array<string, mixed>|null $options
      */
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.form.shipping_method.max_delivery_time_days.greater_or_equal_min',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -39,14 +37,12 @@ final class ValidDeliveryTimeRange extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ValidDeliveryTimeRange.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ValidDeliveryTimeRange.php
@@ -13,12 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShippingBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class ValidDeliveryTimeRange extends Constraint
 {
     public string $message = 'sylius.form.shipping_method.max_delivery_time_days.greater_or_equal_min';
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.form.shipping_method.max_delivery_time_days.greater_or_equal_min',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ValidDeliveryTimeRange.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ValidDeliveryTimeRange.php
@@ -21,15 +21,32 @@ final class ValidDeliveryTimeRange extends Constraint
 {
     public string $message = 'sylius.form.shipping_method.max_delivery_time_days.greater_or_equal_min';
 
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.form.shipping_method.max_delivery_time_days.greater_or_equal_min',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/shipping-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ShippingBundle/Validator/ShippingMethodCalculatorExistsValidator.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/ShippingMethodCalculatorExistsValidator.php
@@ -37,7 +37,7 @@ final class ShippingMethodCalculatorExistsValidator extends ConstraintValidator
         }
 
         if (!in_array($value, array_keys($this->calculators), true)) {
-            $this->context->buildViolation($constraint->invalidShippingCalculator)
+            $this->context->buildViolation($constraint->invalidShippingCalculatorMessage)
                 ->setParameter('{{ available_calculators }}', implode(', ', array_keys($this->calculators)))
                 ->addViolation()
             ;

--- a/src/Sylius/Bundle/ShippingBundle/Validator/ShippingMethodRuleValidator.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/ShippingMethodRuleValidator.php
@@ -44,7 +44,7 @@ final class ShippingMethodRuleValidator extends ConstraintValidator
 
         $type = $value->getType();
         if (!array_key_exists($type, $this->ruleTypes)) {
-            $this->context->buildViolation($constraint->invalidType)
+            $this->context->buildViolation($constraint->invalidTypeMessage)
                 ->setParameter('{{ available_rule_types }}', implode(', ', array_keys($this->ruleTypes)))
                 ->atPath('type')
                 ->addViolation()

--- a/src/Sylius/Bundle/ShippingBundle/tests/Validator/ShippingMethodCalculatorExistsValidatorTest.php
+++ b/src/Sylius/Bundle/ShippingBundle/tests/Validator/ShippingMethodCalculatorExistsValidatorTest.php
@@ -58,7 +58,7 @@ final class ShippingMethodCalculatorExistsValidatorTest extends TestCase
 
         $this->executionContext
             ->expects($this->once())->method('buildViolation')
-            ->with((new ShippingMethodCalculatorExists())->invalidShippingCalculator)
+            ->with((new ShippingMethodCalculatorExists())->invalidShippingCalculatorMessage)
             ->willReturn($constraintViolationBuilder)
         ;
         $constraintViolationBuilder->expects($this->once())->method('setParameter')->willReturn($constraintViolationBuilder);

--- a/src/Sylius/Bundle/ShippingBundle/tests/Validator/ShippingMethodRuleValidatorTest.php
+++ b/src/Sylius/Bundle/ShippingBundle/tests/Validator/ShippingMethodRuleValidatorTest.php
@@ -65,7 +65,7 @@ final class ShippingMethodRuleValidatorTest extends TestCase
         $shippingMethodRule = $this->createMock(ShippingMethodRuleInterface::class);
 
         $shippingMethodRule->expects($this->once())->method('getType')->willReturn('wrong_rule');
-        $this->executionContext->expects($this->once())->method('buildViolation')->with((new ShippingMethodRule())->invalidType)->willReturn($constraintViolationBuilder);
+        $this->executionContext->expects($this->once())->method('buildViolation')->with((new ShippingMethodRule())->invalidTypeMessage)->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->expects($this->once())->method('setParameter')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->expects($this->once())->method('atPath')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->expects($this->once())->method('addViolation');

--- a/src/Sylius/Bundle/ShippingBundle/tests/Validator/ShippingMethodRuleValidatorTest.php
+++ b/src/Sylius/Bundle/ShippingBundle/tests/Validator/ShippingMethodRuleValidatorTest.php
@@ -87,7 +87,7 @@ final class ShippingMethodRuleValidatorTest extends TestCase
         $validator->expects($this->once())->method('inContext')->with($this->executionContext)->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate')->with($shippingMethodRule, null, ['sylius', 'total_weight'])->willReturn($contextualValidator);
 
-        $this->shippingMethodRuleValidator->validate($shippingMethodRule, new ShippingMethodRule(['groups' => ['sylius', 'total_weight']]));
+        $this->shippingMethodRuleValidator->validate($shippingMethodRule, new ShippingMethodRule(groups: ['sylius', 'total_weight']));
     }
 
     public function testCallsValidatorWithDefaultGroupsIfNoneAssignedToShippingMethodRule(): void
@@ -104,6 +104,6 @@ final class ShippingMethodRuleValidatorTest extends TestCase
         $validator->expects($this->once())->method('inContext')->with($this->executionContext)->willReturn($contextualValidator);
         $contextualValidator->expects($this->once())->method('validate')->with($shippingMethodRule, null, ['sylius'])->willReturn($contextualValidator);
 
-        $this->shippingMethodRuleValidator->validate($shippingMethodRule, new ShippingMethodRule(['groups' => ['sylius']]));
+        $this->shippingMethodRuleValidator->validate($shippingMethodRule, new ShippingMethodRule(groups: ['sylius']));
     }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/Validator/Constraints/TaxonParentRelation.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Validator/Constraints/TaxonParentRelation.php
@@ -24,7 +24,7 @@ final class TaxonParentRelation extends Constraint
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
-        ?string $message = null,
+        public string $message = 'sylius.taxon.parent.invalid_relation',
         ?array $groups = null,
         mixed $payload = null,
     ) {
@@ -36,17 +36,13 @@ final class TaxonParentRelation extends Constraint
                 static::class,
             );
 
-            $message ??= $options['message'] ?? null;
+            $this->message = $options['message'] ?? $this->message;
             $groups ??= $options['groups'] ?? null;
             $payload ??= $options['payload'] ?? null;
         }
 
         parent::__construct(groups: $groups, payload: $payload);
-
-        $this->message = $message ?? $this->message;
     }
-
-    public string $message = 'sylius.taxon.parent.invalid_relation';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/TaxonomyBundle/Validator/Constraints/TaxonParentRelation.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Validator/Constraints/TaxonParentRelation.php
@@ -13,10 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\TaxonomyBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 final class TaxonParentRelation extends Constraint
 {
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.taxon.parent.invalid_relation',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
+
     public string $message = 'sylius.taxon.parent.invalid_relation';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/TaxonomyBundle/Validator/Constraints/TaxonParentRelation.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Validator/Constraints/TaxonParentRelation.php
@@ -18,16 +18,32 @@ use Symfony\Component\Validator\Constraint;
 
 final class TaxonParentRelation extends Constraint
 {
-
+    /**
+     * @param array<string, mixed>|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
-        string $message = 'sylius.taxon.parent.invalid_relation',
+        ?array $options = null,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/taxonomy-bundle',
+                '2.3',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in Sylius 3.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message ??= $options['message'] ?? null;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
-        $this->message = $message;
+        $this->message = $message ?? $this->message;
     }
 
     public string $message = 'sylius.taxon.parent.invalid_relation';

--- a/src/Sylius/Bundle/TaxonomyBundle/tests/Validator/Constraints/TaxonParentRelationValidatorTest.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/tests/Validator/Constraints/TaxonParentRelationValidatorTest.php
@@ -50,7 +50,7 @@ final class TaxonParentRelationValidatorTest extends TestCase
     {
         $this->context->expects($this->never())->method('buildViolation');
 
-        $constraint = new TaxonParentRelation(['message' => 'Invalid relation']);
+        $constraint = new TaxonParentRelation(message: 'Invalid relation');
         $this->validator->validate('not_a_taxon', $constraint);
     }
 
@@ -60,7 +60,7 @@ final class TaxonParentRelationValidatorTest extends TestCase
 
         $this->context->expects($this->never())->method('buildViolation');
 
-        $constraint = new TaxonParentRelation(['message' => 'Invalid relation']);
+        $constraint = new TaxonParentRelation(message: 'Invalid relation');
         $this->validator->validate($this->taxon, $constraint);
     }
 
@@ -77,7 +77,7 @@ final class TaxonParentRelationValidatorTest extends TestCase
             ->with('Invalid relation')
             ->willReturn($this->builder);
 
-        $constraint = new TaxonParentRelation(['message' => 'Invalid relation']);
+        $constraint = new TaxonParentRelation(message: 'Invalid relation');
         $this->validator->validate($this->taxon, $constraint);
     }
 
@@ -98,7 +98,7 @@ final class TaxonParentRelationValidatorTest extends TestCase
             ->with('Invalid relation')
             ->willReturn($this->builder);
 
-        $constraint = new TaxonParentRelation(['message' => 'Invalid relation']);
+        $constraint = new TaxonParentRelation(message: 'Invalid relation');
         $this->validator->validate($this->taxon, $constraint);
     }
 
@@ -121,7 +121,7 @@ final class TaxonParentRelationValidatorTest extends TestCase
             ->with('Invalid relation')
             ->willReturn($this->builder);
 
-        $constraint = new TaxonParentRelation(['message' => 'Invalid relation']);
+        $constraint = new TaxonParentRelation(message: 'Invalid relation');
         $this->validator->validate($this->taxon, $constraint);
     }
 
@@ -137,7 +137,7 @@ final class TaxonParentRelationValidatorTest extends TestCase
 
         $this->context->expects($this->never())->method('buildViolation');
 
-        $constraint = new TaxonParentRelation(['message' => 'Invalid relation']);
+        $constraint = new TaxonParentRelation(message: 'Invalid relation');
         $this->validator->validate($this->taxon, $constraint);
     }
 }

--- a/src/Sylius/Component/Attribute/AttributeType/FloatAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/FloatAttributeType.php
@@ -54,6 +54,6 @@ final class FloatAttributeType implements AttributeTypeInterface
 
     private function getValidationErrors(ExecutionContextInterface $context, ?float $value): ConstraintViolationListInterface
     {
-        return $context->getValidator()->validate($value, [new NotBlank([])]);
+        return $context->getValidator()->validate($value, [new NotBlank()]);
     }
 }

--- a/src/Sylius/Component/Attribute/AttributeType/IntegerAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/IntegerAttributeType.php
@@ -54,6 +54,6 @@ final class IntegerAttributeType implements AttributeTypeInterface
 
     private function getValidationErrors(ExecutionContextInterface $context, ?int $value): ConstraintViolationListInterface
     {
-        return $context->getValidator()->validate($value, [new NotBlank([])]);
+        return $context->getValidator()->validate($value, [new NotBlank()]);
     }
 }

--- a/src/Sylius/Component/Attribute/AttributeType/PercentAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/PercentAttributeType.php
@@ -54,6 +54,6 @@ final class PercentAttributeType implements AttributeTypeInterface
 
     private function getValidationErrors(ExecutionContextInterface $context, ?float $value): ConstraintViolationListInterface
     {
-        return $context->getValidator()->validate($value, [new NotBlank([])]);
+        return $context->getValidator()->validate($value, [new NotBlank()]);
     }
 }

--- a/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
@@ -73,19 +73,19 @@ final class SelectAttributeType implements AttributeTypeInterface
         ];
 
         if (isset($validationConfiguration['required'])) {
-            $constraints[] = new NotBlank([]);
+            $constraints[] = new NotBlank();
         }
 
         if (isset($validationConfiguration['min']) && !empty($validationConfiguration['min'])) {
-            $constraints[] = new Count([
-                'min' => $validationConfiguration['min'],
-            ]);
+            $constraints[] = new Count(
+                min: $validationConfiguration['min'],
+            );
         }
 
         if (isset($validationConfiguration['max']) && !empty($validationConfiguration['max'])) {
-            $constraints[] = new Count([
-                'max' => $validationConfiguration['max'],
-            ]);
+            $constraints[] = new Count(
+                max: $validationConfiguration['max'],
+            );
         }
 
         return $validator->validate($value, $constraints);

--- a/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
@@ -78,13 +78,13 @@ final class SelectAttributeType implements AttributeTypeInterface
 
         if (isset($validationConfiguration['min']) && !empty($validationConfiguration['min'])) {
             $constraints[] = new Count(
-                min: $validationConfiguration['min'],
+                min: (int) $validationConfiguration['min'],
             );
         }
 
         if (isset($validationConfiguration['max']) && !empty($validationConfiguration['max'])) {
             $constraints[] = new Count(
-                max: $validationConfiguration['max'],
+                max: (int) $validationConfiguration['max'],
             );
         }
 

--- a/src/Sylius/Component/Attribute/AttributeType/TextAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/TextAttributeType.php
@@ -63,15 +63,13 @@ final class TextAttributeType implements AttributeTypeInterface
         $constraints = [];
 
         if (isset($validationConfiguration['required'])) {
-            $constraints = [new NotBlank([])];
+            $constraints = [new NotBlank()];
         }
 
         if (isset($validationConfiguration['min'], $validationConfiguration['max'])) {
             $constraints[] = new Length(
-                [
-                    'min' => $validationConfiguration['min'],
-                    'max' => $validationConfiguration['max'],
-                ],
+                min: $validationConfiguration['min'],
+                max: $validationConfiguration['max'],
             );
         }
 

--- a/src/Sylius/Component/Attribute/AttributeType/TextAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/TextAttributeType.php
@@ -68,8 +68,8 @@ final class TextAttributeType implements AttributeTypeInterface
 
         if (isset($validationConfiguration['min'], $validationConfiguration['max'])) {
             $constraints[] = new Length(
-                min: $validationConfiguration['min'],
-                max: $validationConfiguration['max'],
+                min: (int) $validationConfiguration['min'],
+                max: (int) $validationConfiguration['max'],
             );
         }
 

--- a/src/Sylius/Component/Attribute/AttributeType/TextareaAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/TextareaAttributeType.php
@@ -61,7 +61,7 @@ final class TextareaAttributeType implements AttributeTypeInterface
         return $validator->validate(
             $value,
             [
-                new NotBlank([]),
+                new NotBlank(),
             ],
         );
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | partially #9693, extracted from https://github.com/Sylius/Sylius/pull/18803
| License         | MIT

Gives all Sylius validation constraints explicit constructors with named arguments (marked with `#[HasNamedArguments]`) that initialize their properties themselves, instead of relying on the base `Constraint` class to evaluate an array of options (evaluating options in `Constraint::__construct()` is deprecated since Symfony 7.4 and removed in Symfony 8).

To avoid a BC break, the legacy array-options syntax is **kept working** as a backward-compatibility layer (a leading `?array $options` argument) and now triggers a **deprecation** instead of failing. It will be removed in Sylius 3.0.

As a result:
  - It works on all supported Symfony versions (6.4, 7.4 and 8.0).
  - Configuring constraints via XML / YAML / PHP attributes is **not affected** - the validator loaders pass options as named arguments automatically (no deprecation).
  - Only **direct PHP instantiation** using the array syntax (`new SomeConstraint(['message' => '...'])`) emits a deprecation; switch to named arguments (`new SomeConstraint(message: '...')`).

Most of the constructor changes are cherry-picked from the `symfony-8` branch (PR #18803) and adapted to preserve backward compatibility with the deprecation layer. On top of that, this PR also covers several remaining constraints with configurable options that were missed there.

Documented in `UPGRADE-2.3.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Symfony validator named-arguments support across many constraint classes for clearer configuration.

* **Deprecated**
  * Array-based constraint configuration is deprecated (removal planned for Sylius 3.0); use named arguments instead.
  * Constraint message option/property names have been normalized to `*Message` variants; legacy names remain temporarily but are deprecated.

* **Bug Fixes**
  * Validator violation messages now consistently use the new `*Message` properties.

* **Documentation**
  * Updated upgrade guide with migration examples and the message option rename mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->