### PR TITLE
[Payum] Revert PaymentSecurityToken to 2.3 BC version

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -101,7 +101,6 @@
     "Payum\\Core\\Security\\TokenInterface",
     "Payum\\Core\\Security\\Util\\Random",
     "Payum\\Core\\Storage\\AbstractStorage",
-    "Payum\\Core\\Storage\\IdentityInterface",
     "PHPUnit\\Framework\\ExpectationFailedException",
     "PHPUnit\\Framework\\MockObject\\MockObject",
     "PHPUnit\\Framework\\TestCase",

--- a/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
+++ b/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
@@ -13,17 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PayumBundle\Model;
 
-use Payum\Core\Model\Identity;
 use Payum\Core\Security\Util\Random;
-use Payum\Core\Storage\IdentityInterface;
 
 class PaymentSecurityToken implements PaymentSecurityTokenInterface
 {
     /** @var string */
     protected $hash;
 
-    /** @var array<string, mixed>|null */
-    protected ?array $details = null;
+    /** @var object|null */
+    protected $details;
 
     /** @var string|null */
     protected $afterUrl;
@@ -46,28 +44,11 @@ class PaymentSecurityToken implements PaymentSecurityTokenInterface
 
     public function setDetails($details): void
     {
-        if ($details instanceof IdentityInterface) {
-            $this->details = ['id' => $details->getId(), 'class' => $details->getClass()];
-
-            return;
-        }
-
-        if (is_object($details)) {
-            $this->details = (array) $details;
-
-            return;
-        }
-
         $this->details = $details;
     }
 
-    /** @return IdentityInterface|array<string, mixed>|null */
-    public function getDetails(): array|IdentityInterface|null
+    public function getDetails()
     {
-        if (is_array($this->details) && isset($this->details['id'], $this->details['class'])) {
-            return new Identity($this->details['id'], $this->details['class']);
-        }
-
         return $this->details;
     }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | symfony-8
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/pull/19064
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
