### PR TITLE
Replace deprecated Request::get() with explicit request bags

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/payment_request/index/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/payment_request/index/content/header/breadcrumbs.html.twig
@@ -5,6 +5,6 @@
 {{ breadcrumbs([
     { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: 'sylius.ui.payments'|trans, url: path('sylius_admin_payment_index'), active: false },
-    { name: configuration.request.get('paymentId'), active: true },
+    { name: configuration.request.attributes.get('paymentId'), active: true },
     { name: 'sylius.ui.payment_requests'|trans, active: true },
 ]) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
@@ -1,6 +1,6 @@
 <button class="btn primary"
     {{ stimulus_controller('@sylius/admin-bundle/save-positions', {
-        url: path('sylius_admin_ajax_product_taxons_update_position', {taxonId: app.request.get('taxonId')}),
+        url: path('sylius_admin_ajax_product_taxons_update_position', {taxonId: app.request.attributes.get('taxonId')}),
         csrfToken: sylius_csrf_protection_enabled() ? csrf_token('update-product-taxon-position') : null,
         inputSelector: '.sylius-product-taxon-position',
         dataKey: 'productTaxons',

--- a/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumAfterPayResponseProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumAfterPayResponseProvider.php
@@ -64,7 +64,7 @@ final class PayumAfterPayResponseProvider implements AfterPayResponseProviderInt
     public function supports(RequestConfiguration $requestConfiguration): bool
     {
         $request = $requestConfiguration->getRequest();
-        $hash = $request->attributes->get('payum_token', $request->get('payum_token', false));
+        $hash = $request->attributes->get('payum_token', $request->query->get('payum_token', $request->request->get('payum_token', false)));
 
         return false !== $hash;
     }

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/grids/product.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/grids/product.yml
@@ -14,7 +14,7 @@ sylius_grid:
                             channel: "expr:service('sylius.context.channel').getChannel()"
                             taxon: "expr:notFoundOnNull(service('sylius.repository.taxon').findOneBySlug($slug, service('sylius.context.locale').getLocaleCode()))"
                             locale: "expr:service('sylius.context.locale').getLocaleCode()"
-                            sorting: "expr:service('request_stack').getCurrentRequest().get('sorting', [])"
+                            sorting: "expr:service('request_stack').getCurrentRequest().query.all('sorting')"
                             includeAllDescendants: "expr:parameter('sylius_shop.product_grid.include_all_descendants')"
             sorting:
                 position: asc

--- a/src/Sylius/Bundle/ShopBundle/templates/product_review/index/content/main/header/buttons/add_review.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product_review/index/content/main/header/buttons/add_review.html.twig
@@ -1,3 +1,3 @@
-<a class="btn btn-primary" href="{{ path('sylius_shop_product_review_create', {'slug': app.request.get('slug')}) }}">
+<a class="btn btn-primary" href="{{ path('sylius_shop_product_review_create', {'slug': app.request.attributes.get('slug')}) }}">
     {{ 'sylius.ui.add_your_review'|trans }}
 </a>

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/layout/base.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/layout/base.html.twig
@@ -20,7 +20,7 @@
         {% hook 'head' with { _prefixes: prefixes } %}
     </head>
 
-    <body data-route="{{ app.request.get('_route') }}">
+    <body data-route="{{ app.request.attributes.get('_route') }}">
         {% block body %}
             <div class="{% apply escape %}{% hook '#body_classes' with { _prefixes: prefixes } %}{% endapply %}">
                 {% block header %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | extracted from https://github.com/Sylius/Sylius/pull/18803
| License         | MIT

Replaces deprecated `Request::get()` calls with explicit request bags across templates, the shop product grid and the Payum AfterPay provider.

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed payment request breadcrumb navigation
  * Fixed product taxon position update functionality
  * Fixed payment response handling
  * Fixed product grid sorting behavior
  * Fixed product review creation links
  * Fixed route identification in page layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->