### PR TITLE
[Maintenance] Bump branch aliases to 2.3-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -257,7 +257,7 @@
             "require": "^7.4"
         },
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         }
     },
     "autoload": {

--- a/src/Sylius/Abstraction/StateMachine/composer.json
+++ b/src/Sylius/Abstraction/StateMachine/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -63,7 +63,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -52,7 +52,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -52,7 +52,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -47,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -89,7 +89,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -57,7 +57,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -56,7 +56,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -63,7 +63,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -53,7 +53,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -47,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "allow-contrib": false,

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -66,7 +66,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Addressing/composer.json
+++ b/src/Sylius/Component/Addressing/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Attribute/composer.json
+++ b/src/Sylius/Component/Attribute/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Channel/composer.json
+++ b/src/Sylius/Component/Channel/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -71,7 +71,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Currency/composer.json
+++ b/src/Sylius/Component/Currency/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Customer/composer.json
+++ b/src/Sylius/Component/Customer/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Inventory/composer.json
+++ b/src/Sylius/Component/Inventory/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Order/composer.json
+++ b/src/Sylius/Component/Order/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Payment/composer.json
+++ b/src/Sylius/Component/Payment/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -49,7 +49,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Review/composer.json
+++ b/src/Sylius/Component/Review/composer.json
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Taxation/composer.json
+++ b/src/Sylius/Component/Taxation/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/Taxonomy/composer.json
+++ b/src/Sylius/Component/Taxonomy/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"

--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -53,7 +53,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2-dev"
+            "dev-main": "2.3-dev"
         },
         "symfony": {
             "require": "^7.4"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development version aliases across all packages from 2.2-dev to 2.3-dev to align with the upcoming release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->