### PR TITLE
[PaymentRequest] Remove experimental tag from the classes

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -139,6 +139,16 @@
    | `ShippingBundle\...\ShippingMethodCalculatorExists` | `invalidShippingCalculator` | `invalidShippingCalculatorMessage` |
    | `ShippingBundle\...\ShippingMethodRule` | `invalidType` | `invalidTypeMessage` |
 
+## Payment
+
+1. The **Payment Request** feature is no longer **experimental**.
+
+   The `@experimental` annotation has now been removed from all classes, interfaces, traits and attributes belonging
+   to this feature across `Sylius\Component\Payment`, `Sylius\Bundle\PaymentBundle`, `Sylius\Bundle\PayumBundle`,
+   the order pay flow in `Sylius\Bundle\CoreBundle\OrderPay` and `Sylius\Bundle\PayumBundle\OrderPay`, and the
+   Payment Request layer in `Sylius\Bundle\ApiBundle`. These classes are now covered by the Sylius Backward
+   Compatibility policy.
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/src/Sylius/Bundle/ApiBundle/Command/Payment/AddPaymentRequest.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Payment/AddPaymentRequest.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\ApiBundle\Attribute\OrderTokenValueAware;
 use Sylius\Bundle\ApiBundle\Attribute\PaymentRequestActionAware;
 use Sylius\Bundle\ApiBundle\Command\IriToIdentifierConversionAwareInterface;
 
-/** @experimental */
 #[OrderTokenValueAware]
 #[PaymentRequestActionAware]
 class AddPaymentRequest implements IriToIdentifierConversionAwareInterface

--- a/src/Sylius/Bundle/ApiBundle/Command/Payment/UpdatePaymentRequest.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Payment/UpdatePaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\ApiBundle\Command\Payment;
 use Sylius\Bundle\ApiBundle\Attribute\PaymentRequestHashAware;
 use Sylius\Bundle\ApiBundle\Command\IriToIdentifierConversionAwareInterface;
 
-/** @experimental */
 #[PaymentRequestHashAware]
 class UpdatePaymentRequest implements IriToIdentifierConversionAwareInterface
 {

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Payment/AddPaymentRequestHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Payment/AddPaymentRequestHandler.php
@@ -32,7 +32,6 @@ use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/** @experimental */
 #[AsMessageHandler]
 final class AddPaymentRequestHandler
 {

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Payment/UpdatePaymentRequestHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Payment/UpdatePaymentRequestHandler.php
@@ -19,7 +19,6 @@ use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-/** @experimental */
 #[AsMessageHandler]
 final class UpdatePaymentRequestHandler
 {

--- a/src/Sylius/Bundle/ApiBundle/EventSubscriber/PaymentRequestEventSubscriber.php
+++ b/src/Sylius/Bundle/ApiBundle/EventSubscriber/PaymentRequestEventSubscriber.php
@@ -21,7 +21,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-/** @experimental */
 final class PaymentRequestEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(private PaymentRequestAnnouncerInterface $paymentRequestAnnouncer)

--- a/src/Sylius/Bundle/ApiBundle/StateProvider/Shop/Payment/PaymentRequest/ItemProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/StateProvider/Shop/Payment/PaymentRequest/ItemProvider.php
@@ -30,8 +30,6 @@ use Webmozart\Assert\Assert;
 
 /**
  * @implements ProviderInterface<PaymentRequestInterface>
- *
- * @experimental
  */
 final readonly class ItemProvider implements ProviderInterface
 {

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-/** @experimental  */
 #[\Attribute]
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Controller/OrderPayController.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Controller/OrderPayController.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-/** @experimental */
 final class OrderPayController
 {
     /**

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Handler/PaymentStateFlashHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Handler/PaymentStateFlashHandler.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 
-/** @experimental */
 final class PaymentStateFlashHandler implements PaymentStateFlashHandlerInterface
 {
     public function __construct(private string $format = 'sylius.payment.%s')

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Handler/PaymentStateFlashHandlerInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Handler/PaymentStateFlashHandlerInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\CoreBundle\OrderPay\Handler;
 
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 
-/** @experimental */
 interface PaymentStateFlashHandlerInterface
 {
     public function handle(RequestConfiguration $requestConfiguration, string $state): void;

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Processor/RouteParametersProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Processor/RouteParametersProcessor.php
@@ -17,7 +17,6 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-/** @experimental */
 final class RouteParametersProcessor implements RouteParametersProcessorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Processor/RouteParametersProcessorInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Processor/RouteParametersProcessorInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\CoreBundle\OrderPay\Processor;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-/** @experimental */
 interface RouteParametersProcessorInterface
 {
     /**

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/AfterPayResponseProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/AfterPayResponseProviderInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\CoreBundle\OrderPay\Provider;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 interface AfterPayResponseProviderInterface
 {
     public function getResponse(RequestConfiguration $requestConfiguration): Response;

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/FinalUrlProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/FinalUrlProvider.php
@@ -18,7 +18,6 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-/** @experimental */
 final class FinalUrlProvider implements FinalUrlProviderInterface
 {
     /**

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/FinalUrlProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/FinalUrlProviderInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\CoreBundle\OrderPay\Provider;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-/** @experimental */
 interface FinalUrlProviderInterface
 {
     public function getUrl(

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/NoPaymentPayResponseProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/NoPaymentPayResponseProvider.php
@@ -19,7 +19,6 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 final class NoPaymentPayResponseProvider implements PayResponseProviderInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/Offline/StatusHttpResponseProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/Offline/StatusHttpResponseProvider.php
@@ -20,7 +20,6 @@ use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 final class StatusHttpResponseProvider implements HttpResponseProviderInterface
 {
     public function __construct(private FinalUrlProviderInterface $finalUrlProvider)

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PayResponseProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PayResponseProviderInterface.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 interface PayResponseProviderInterface
 {
     public function getResponse(RequestConfiguration $requestConfiguration, OrderInterface $order): Response;

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestAfterPayResponseProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestAfterPayResponseProvider.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Webmozart\Assert\Assert;
 
-/** @experimental */
 final class PaymentRequestAfterPayResponseProvider implements AfterPayResponseProviderInterface
 {
     /**

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestPayResponseProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestPayResponseProvider.php
@@ -28,7 +28,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
-/** @experimental */
 final class PaymentRequestPayResponseProvider implements PayResponseProviderInterface
 {
     /**

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Resolver/PaymentToPayResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Resolver/PaymentToPayResolver.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\CoreBundle\OrderPay\Resolver;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 
-/** @experimental */
 final class PaymentToPayResolver implements PaymentToPayResolverInterface
 {
     public function __construct(private string $state)

--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Resolver/PaymentToPayResolverInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Resolver/PaymentToPayResolverInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\CoreBundle\OrderPay\Resolver;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 
-/** @experimental */
 interface PaymentToPayResolverInterface
 {
     public function getPayment(OrderInterface $order): ?PaymentInterface;

--- a/src/Sylius/Bundle/PaymentBundle/Action/PaymentMethodNotifyAction.php
+++ b/src/Sylius/Bundle/PaymentBundle/Action/PaymentMethodNotifyAction.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-/** @experimental */
 final class PaymentMethodNotifyAction
 {
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Action/PaymentRequestNotifyAction.php
+++ b/src/Sylius/Bundle/PaymentBundle/Action/PaymentRequestNotifyAction.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-/** @experimental */
 final class PaymentRequestNotifyAction
 {
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Announcer/PaymentRequestAnnouncer.php
+++ b/src/Sylius/Bundle/PaymentBundle/Announcer/PaymentRequestAnnouncer.php
@@ -18,7 +18,6 @@ use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInt
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-/** @experimental */
 final readonly class PaymentRequestAnnouncer implements PaymentRequestAnnouncerInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/PaymentBundle/Announcer/PaymentRequestAnnouncerInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Announcer/PaymentRequestAnnouncerInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Announcer;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface PaymentRequestAnnouncerInterface
 {
     public function dispatchPaymentRequestCommand(PaymentRequestInterface $paymentRequest): void;

--- a/src/Sylius/Bundle/PaymentBundle/Attribute/AsNotifyPaymentProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Attribute/AsNotifyPaymentProvider.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PaymentBundle\Attribute;
 
-/** @experimental */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsNotifyPaymentProvider
 {

--- a/src/Sylius/Bundle/PaymentBundle/Canceller/PaymentRequestCanceller.php
+++ b/src/Sylius/Bundle/PaymentBundle/Canceller/PaymentRequestCanceller.php
@@ -20,7 +20,6 @@ use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\PaymentRequestTransitions;
 use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 
-/** @experimental */
 final class PaymentRequestCanceller implements PaymentRequestCancellerInterface
 {
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Checker/FinalizedPaymentRequestChecker.php
+++ b/src/Sylius/Bundle/PaymentBundle/Checker/FinalizedPaymentRequestChecker.php
@@ -17,7 +17,6 @@ use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\PaymentRequestTransitions;
 
-/** @experimental */
 final class FinalizedPaymentRequestChecker implements FinalizedPaymentRequestCheckerInterface
 {
     public function __construct(private StateMachineInterface $stateMachine)

--- a/src/Sylius/Bundle/PaymentBundle/Checker/FinalizedPaymentRequestCheckerInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Checker/FinalizedPaymentRequestCheckerInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Checker;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface FinalizedPaymentRequestCheckerInterface
 {
     public function isFinal(PaymentRequestInterface $paymentRequest): bool;

--- a/src/Sylius/Bundle/PaymentBundle/Checker/PaymentRequestDuplicationChecker.php
+++ b/src/Sylius/Bundle/PaymentBundle/Checker/PaymentRequestDuplicationChecker.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Checker;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 
-/** @experimental */
 final class PaymentRequestDuplicationChecker implements PaymentRequestDuplicationCheckerInterface
 {
     /** @param PaymentRequestRepositoryInterface<PaymentRequestInterface> $paymentRequestRepository */

--- a/src/Sylius/Bundle/PaymentBundle/Checker/PaymentRequestDuplicationCheckerInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Checker/PaymentRequestDuplicationCheckerInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Checker;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface PaymentRequestDuplicationCheckerInterface
 {
     public function hasDuplicates(PaymentRequestInterface $paymentRequest): bool;

--- a/src/Sylius/Bundle/PaymentBundle/Command/Offline/CapturePaymentRequest.php
+++ b/src/Sylius/Bundle/PaymentBundle/Command/Offline/CapturePaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Command\Offline;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareInterface;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareTrait;
 
-/** @experimental */
 class CapturePaymentRequest implements PaymentRequestHashAwareInterface
 {
     use PaymentRequestHashAwareTrait;

--- a/src/Sylius/Bundle/PaymentBundle/Command/PaymentRequestHashAwareInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Command/PaymentRequestHashAwareInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PaymentBundle\Command;
 
-/** @experimental */
 interface PaymentRequestHashAwareInterface
 {
     public function getHash(): string;

--- a/src/Sylius/Bundle/PaymentBundle/Command/PaymentRequestHashAwareTrait.php
+++ b/src/Sylius/Bundle/PaymentBundle/Command/PaymentRequestHashAwareTrait.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PaymentBundle\Command;
 
-/** @experimental */
 trait PaymentRequestHashAwareTrait
 {
     protected ?string $hash;

--- a/src/Sylius/Bundle/PaymentBundle/CommandHandler/Offline/CapturePaymentRequestHandler.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandHandler/Offline/CapturePaymentRequestHandler.php
@@ -19,7 +19,6 @@ use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
 use Sylius\Component\Payment\PaymentRequestTransitions;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-/** @experimental */
 #[AsMessageHandler]
 final readonly class CapturePaymentRequestHandler
 {

--- a/src/Sylius/Bundle/PaymentBundle/CommandProvider/AbstractServiceCommandProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandProvider/AbstractServiceCommandProvider.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\Exception\PaymentRequestNotSupportedException;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @experimental */
 abstract class AbstractServiceCommandProvider implements ServiceProviderAwareCommandProviderInterface
 {
     /** @var ServiceProviderInterface<PaymentRequestCommandProviderInterface> */

--- a/src/Sylius/Bundle/PaymentBundle/CommandProvider/ActionsCommandProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandProvider/ActionsCommandProvider.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\CommandProvider;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @experimental */
 final class ActionsCommandProvider extends AbstractServiceCommandProvider
 {
     /** @param ServiceProviderInterface<PaymentRequestCommandProviderInterface> $locator */

--- a/src/Sylius/Bundle/PaymentBundle/CommandProvider/GatewayFactoryCommandProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandProvider/GatewayFactoryCommandProvider.php
@@ -18,7 +18,6 @@ use Sylius\Bundle\PaymentBundle\Provider\GatewayFactoryNameProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @experimental */
 final class GatewayFactoryCommandProvider extends AbstractServiceCommandProvider
 {
     /** @param ServiceProviderInterface<PaymentRequestCommandProviderInterface> $locator */

--- a/src/Sylius/Bundle/PaymentBundle/CommandProvider/Offline/CapturePaymentRequestCommandProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandProvider/Offline/CapturePaymentRequestCommandProvider.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\Command\Offline\CapturePaymentRequest;
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class CapturePaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Sylius/Bundle/PaymentBundle/CommandProvider/PaymentRequestCommandProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandProvider/PaymentRequestCommandProviderInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\CommandProvider;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool;

--- a/src/Sylius/Bundle/PaymentBundle/CommandProvider/ServiceProviderAwareCommandProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/CommandProvider/ServiceProviderAwareCommandProviderInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PaymentBundle\CommandProvider;
 
-/** @experimental */
 interface ServiceProviderAwareCommandProviderInterface extends PaymentRequestCommandProviderInterface
 {
     public function getCommandProvider(string $index): ?PaymentRequestCommandProviderInterface;

--- a/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentRequestRepository.php
+++ b/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentRequestRepository.php
@@ -25,8 +25,6 @@ use Symfony\Bridge\Doctrine\Types\UuidType;
  * @template T of PaymentRequestInterface
  *
  * @implements PaymentRequestRepositoryInterface<T>
- *
- * @experimental
  */
 class PaymentRequestRepository extends EntityRepository implements PaymentRequestRepositoryInterface
 {

--- a/src/Sylius/Bundle/PaymentBundle/EventListener/PaymentMethodChangeEventListener.php
+++ b/src/Sylius/Bundle/PaymentBundle/EventListener/PaymentMethodChangeEventListener.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Sylius\Component\Payment\Canceller\PaymentRequestCancellerInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
 
-/** @experimental */
 final class PaymentMethodChangeEventListener
 {
     public function __construct(private PaymentRequestCancellerInterface $paymentRequestCanceller)

--- a/src/Sylius/Bundle/PaymentBundle/Normalizer/SymfonyRequestNormalizer.php
+++ b/src/Sylius/Bundle/PaymentBundle/Normalizer/SymfonyRequestNormalizer.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Normalizer;
 
 use Symfony\Component\HttpFoundation\Request;
 
-/** @experimental */
 final class SymfonyRequestNormalizer implements SymfonyRequestNormalizerInterface
 {
     public function normalize(Request $request): array

--- a/src/Sylius/Bundle/PaymentBundle/Normalizer/SymfonyRequestNormalizerInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Normalizer/SymfonyRequestNormalizerInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Normalizer;
 
 use Symfony\Component\HttpFoundation\Request;
 
-/** @experimental */
 interface SymfonyRequestNormalizerInterface
 {
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Processor/NotifyPayloadProcessor.php
+++ b/src/Sylius/Bundle/PaymentBundle/Processor/NotifyPayloadProcessor.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\Normalizer\SymfonyRequestNormalizerInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-/** @experimental */
 final class NotifyPayloadProcessor implements NotifyPayloadProcessorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/PaymentBundle/Processor/NotifyPayloadProcessorInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Processor/NotifyPayloadProcessorInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Processor;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-/** @experimental */
 interface NotifyPayloadProcessorInterface
 {
     public function process(PaymentRequestInterface $paymentRequest, Request $request): void;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/AbstractServiceProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/AbstractServiceProvider.php
@@ -19,7 +19,6 @@ use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @experimental */
 abstract class AbstractServiceProvider implements ServiceProviderAwareProviderInterface
 {
     /** @var ServiceProviderInterface<HttpResponseProviderInterface> */

--- a/src/Sylius/Bundle/PaymentBundle/Provider/ActionsHttpResponseProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/ActionsHttpResponseProvider.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @experimental */
 final class ActionsHttpResponseProvider extends AbstractServiceProvider
 {
     /** @param ServiceProviderInterface<HttpResponseProviderInterface> $locator */

--- a/src/Sylius/Bundle/PaymentBundle/Provider/CompositeNotifyPaymentProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/CompositeNotifyPaymentProvider.php
@@ -18,7 +18,6 @@ use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Webmozart\Assert\Assert;
 
-/** @experimental */
 final class CompositeNotifyPaymentProvider implements NotifyPaymentProviderInterface
 {
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Provider/DefaultActionProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/DefaultActionProvider.php
@@ -18,7 +18,6 @@ use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\Repository\PaymentMethodRepositoryInterface;
 
-/** @experimental */
 final readonly class DefaultActionProvider implements DefaultActionProviderInterface
 {
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Provider/DefaultActionProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/DefaultActionProviderInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface DefaultActionProviderInterface
 {
     public function getAction(PaymentRequestInterface $paymentRequest): string;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/DefaultPayloadProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/DefaultPayloadProvider.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class DefaultPayloadProvider implements DefaultPayloadProviderInterface
 {
     public function getPayload(PaymentRequestInterface $paymentRequest): mixed

--- a/src/Sylius/Bundle/PaymentBundle/Provider/DefaultPayloadProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/DefaultPayloadProviderInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface DefaultPayloadProviderInterface
 {
     public function getPayload(PaymentRequestInterface $paymentRequest): mixed;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/GatewayFactoryHttpResponseProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/GatewayFactoryHttpResponseProvider.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @experimental */
 final class GatewayFactoryHttpResponseProvider extends AbstractServiceProvider
 {
     /** @param ServiceProviderInterface<HttpResponseProviderInterface> $locator */

--- a/src/Sylius/Bundle/PaymentBundle/Provider/GatewayFactoryNameProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/GatewayFactoryNameProvider.php
@@ -17,7 +17,6 @@ use Sylius\Component\Payment\Model\GatewayConfigInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class GatewayFactoryNameProvider implements GatewayFactoryNameProviderInterface
 {
     public function provide(PaymentMethodInterface $paymentMethod): string

--- a/src/Sylius/Bundle/PaymentBundle/Provider/GatewayFactoryNameProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/GatewayFactoryNameProviderInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface GatewayFactoryNameProviderInterface
 {
     public function provide(PaymentMethodInterface $paymentMethod): string;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/HttpResponseProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/HttpResponseProviderInterface.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 interface HttpResponseProviderInterface
 {
     public function supports(

--- a/src/Sylius/Bundle/PaymentBundle/Provider/NotifyPaymentProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/NotifyPaymentProviderInterface.php
@@ -17,7 +17,6 @@ use Sylius\Component\Payment\Model\PaymentInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-/** @experimental */
 interface NotifyPaymentProviderInterface
 {
     public function getPayment(Request $request, PaymentMethodInterface $paymentMethod): PaymentInterface;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/NotifyResponseProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/NotifyResponseProvider.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 final class NotifyResponseProvider implements NotifyResponseProviderInterface
 {
     public function provide(PaymentRequestInterface $paymentRequest): Response

--- a/src/Sylius/Bundle/PaymentBundle/Provider/NotifyResponseProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/NotifyResponseProviderInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @experimental */
 interface NotifyResponseProviderInterface
 {
     public function provide(PaymentRequestInterface $paymentRequest): Response;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/PaymentRequestProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/PaymentRequestProvider.php
@@ -18,7 +18,6 @@ use Sylius\Component\Payment\Exception\PaymentRequestNotFoundException;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 
-/** @experimental */
 final class PaymentRequestProvider implements PaymentRequestProviderInterface
 {
     /** @param PaymentRequestRepositoryInterface<PaymentRequestInterface> $paymentRequestRepository */

--- a/src/Sylius/Bundle/PaymentBundle/Provider/PaymentRequestProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/PaymentRequestProviderInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PaymentBundle\Provider;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface PaymentRequestProviderInterface
 {
     public function provide(PaymentRequestHashAwareInterface $command): PaymentRequestInterface;

--- a/src/Sylius/Bundle/PaymentBundle/Provider/ServiceProviderAwareProviderInterface.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/ServiceProviderAwareProviderInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PaymentBundle\Provider;
 
-/** @experimental */
 interface ServiceProviderAwareProviderInterface extends HttpResponseProviderInterface
 {
     public function getHttpResponseProvider(string $index): ?HttpResponseProviderInterface;

--- a/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumAfterPayResponseProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumAfterPayResponseProvider.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
-/** @experimental */
 final class PayumAfterPayResponseProvider implements AfterPayResponseProviderInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumPayResponseProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumPayResponseProvider.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
-/** @experimental */
 final class PayumPayResponseProvider implements PayResponseProviderInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Action/SyliusGetHttpRequestAction.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Action/SyliusGetHttpRequestAction.php
@@ -18,7 +18,6 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\GetHttpRequest;
 use Sylius\Bundle\PayumBundle\PaymentRequest\Context\PaymentRequestContextInterface;
 
-/** @experimental */
 final class SyliusGetHttpRequestAction implements ActionInterface
 {
     public function __construct(private PaymentRequestContextInterface $payumApiContext)

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Action/SyliusRenderTemplateAction.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Action/SyliusRenderTemplateAction.php
@@ -18,7 +18,6 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\RenderTemplate;
 use Sylius\Bundle\PayumBundle\PaymentRequest\Context\PaymentRequestContextInterface;
 
-/** @experimental */
 final class SyliusRenderTemplateAction implements ActionInterface
 {
     public function __construct(private PaymentRequestContextInterface $payumApiContext)

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/AuthorizePaymentRequest.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/AuthorizePaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Command;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareInterface;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareTrait;
 
-/** @experimental */
 class AuthorizePaymentRequest implements PaymentRequestHashAwareInterface
 {
     use PaymentRequestHashAwareTrait;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/CapturePaymentRequest.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/CapturePaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Command;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareInterface;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareTrait;
 
-/** @experimental */
 class CapturePaymentRequest implements PaymentRequestHashAwareInterface
 {
     use PaymentRequestHashAwareTrait;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/NotifyPaymentRequest.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/NotifyPaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Command;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareInterface;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareTrait;
 
-/** @experimental */
 class NotifyPaymentRequest implements PaymentRequestHashAwareInterface
 {
     use PaymentRequestHashAwareTrait;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/StatusPaymentRequest.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Command/StatusPaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Command;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareInterface;
 use Sylius\Bundle\PaymentBundle\Command\PaymentRequestHashAwareTrait;
 
-/** @experimental */
 class StatusPaymentRequest implements PaymentRequestHashAwareInterface
 {
     use PaymentRequestHashAwareTrait;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandHandler/ModelPaymentRequestHandler.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandHandler/ModelPaymentRequestHandler.php
@@ -22,7 +22,6 @@ use Sylius\Bundle\PayumBundle\PaymentRequest\Resolver\DoctrineProxyObjectResolve
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-/** @experimental */
 #[AsMessageHandler]
 final class ModelPaymentRequestHandler
 {

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandHandler/TokenPaymentRequestHandler.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandHandler/TokenPaymentRequestHandler.php
@@ -23,7 +23,6 @@ use Sylius\Bundle\PayumBundle\PaymentRequest\Processor\RequestProcessorInterface
 use Sylius\Bundle\PayumBundle\PaymentRequest\Resolver\DoctrineProxyObjectResolverInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-/** @experimental */
 #[AsMessageHandler]
 final class TokenPaymentRequestHandler
 {

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/AuthorizeCommandProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/AuthorizeCommandProvider.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInt
 use Sylius\Bundle\PayumBundle\PaymentRequest\Command\AuthorizePaymentRequest;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class AuthorizeCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/CaptureCommandProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/CaptureCommandProvider.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInt
 use Sylius\Bundle\PayumBundle\PaymentRequest\Command\CapturePaymentRequest;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class CaptureCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/NotifyCommandProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/NotifyCommandProvider.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInt
 use Sylius\Bundle\PayumBundle\PaymentRequest\Command\NotifyPaymentRequest;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class NotifyCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/StatusCommandProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/CommandProvider/StatusCommandProvider.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInt
 use Sylius\Bundle\PayumBundle\PaymentRequest\Command\StatusPaymentRequest;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class StatusCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContext.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContext.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Context;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class PaymentRequestContext implements PaymentRequestContextInterface
 {
     private ?PaymentRequestInterface $paymentRequest = null;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContextInterface.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContextInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Context;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface PaymentRequestContextInterface
 {
     public function isEnabled(): bool;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Factory/PayumTokenFactory.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Factory/PayumTokenFactory.php
@@ -20,7 +20,6 @@ use Sylius\Component\Payment\Exception\InvalidPaymentRequestPayloadException;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Webmozart\Assert\Assert;
 
-/** @experimental */
 final class PayumTokenFactory implements PayumTokenFactoryInterface
 {
     public function __construct(private Payum $payum)

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Factory/PayumTokenFactoryInterface.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Factory/PayumTokenFactoryInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Factory;
 use Payum\Core\Security\TokenInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface PayumTokenFactoryInterface
 {
     public function createNew(PaymentRequestInterface $paymentRequest): TokenInterface;

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/AfterTokenRequestProcessor.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/AfterTokenRequestProcessor.php
@@ -19,7 +19,6 @@ use Sylius\Component\Payment\Factory\PaymentRequestFactoryInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 
-/** @experimental */
 final class AfterTokenRequestProcessor implements AfterTokenRequestProcessorInterface
 {
     /**

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/AfterTokenRequestProcessorInterface.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/AfterTokenRequestProcessorInterface.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Processor;
 use Payum\Core\Security\TokenInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface AfterTokenRequestProcessorInterface
 {
     public function process(

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/RequestProcessor.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/RequestProcessor.php
@@ -20,7 +20,6 @@ use Sylius\Bundle\PayumBundle\PaymentRequest\Context\PaymentRequestContextInterf
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\PaymentRequestTransitions;
 
-/** @experimental */
 final readonly class RequestProcessor implements RequestProcessorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/RequestProcessorInterface.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Processor/RequestProcessorInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Processor;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface RequestProcessorInterface
 {
     public function process(

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Resolver/DoctrineProxyObjectResolver.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Resolver/DoctrineProxyObjectResolver.php
@@ -18,7 +18,6 @@ use Doctrine\Persistence\Proxy;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 final class DoctrineProxyObjectResolver implements DoctrineProxyObjectResolverInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Resolver/DoctrineProxyObjectResolverInterface.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Resolver/DoctrineProxyObjectResolverInterface.php
@@ -15,7 +15,6 @@ namespace Sylius\Bundle\PayumBundle\PaymentRequest\Resolver;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
-/** @experimental */
 interface DoctrineProxyObjectResolverInterface
 {
     public function resolve(PaymentRequestInterface $paymentRequest): void;

--- a/src/Sylius/Component/Payment/Canceller/PaymentRequestCancellerInterface.php
+++ b/src/Sylius/Component/Payment/Canceller/PaymentRequestCancellerInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Payment\Canceller;
 
-/** @experimental */
 interface PaymentRequestCancellerInterface
 {
     public function cancelPaymentRequests(mixed $paymentId, string $paymentMethodCode): void;

--- a/src/Sylius/Component/Payment/Factory/PaymentRequestFactory.php
+++ b/src/Sylius/Component/Payment/Factory/PaymentRequestFactory.php
@@ -20,8 +20,6 @@ use Sylius\Component\Resource\Exception\UnsupportedMethodException;
 
 /**
  * @implements PaymentRequestFactoryInterface<PaymentRequestInterface>
- *
- * @experimental
  */
 final class PaymentRequestFactory implements PaymentRequestFactoryInterface
 {

--- a/src/Sylius/Component/Payment/Factory/PaymentRequestFactoryInterface.php
+++ b/src/Sylius/Component/Payment/Factory/PaymentRequestFactoryInterface.php
@@ -22,8 +22,6 @@ use Sylius\Resource\Factory\FactoryInterface;
  * @template T of PaymentRequestInterface
  *
  * @extends FactoryInterface<T>
- *
- * @experimental
  */
 interface PaymentRequestFactoryInterface extends FactoryInterface
 {

--- a/src/Sylius/Component/Payment/Model/PaymentRequest.php
+++ b/src/Sylius/Component/Payment/Model/PaymentRequest.php
@@ -16,7 +16,6 @@ namespace Sylius\Component\Payment\Model;
 use Sylius\Component\Resource\Model\TimestampableTrait;
 use Symfony\Component\Uid\Uuid;
 
-/** @experimental */
 class PaymentRequest implements PaymentRequestInterface
 {
     use TimestampableTrait;

--- a/src/Sylius/Component/Payment/Model/PaymentRequestInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentRequestInterface.php
@@ -18,7 +18,6 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 use Symfony\Component\Uid\Uuid;
 
-/** @experimental */
 interface PaymentRequestInterface extends TimestampableInterface, ResourceInterface, EncryptionAwareInterface
 {
     public const STATE_CANCELLED = 'cancelled';

--- a/src/Sylius/Component/Payment/PaymentRequestTransitions.php
+++ b/src/Sylius/Component/Payment/PaymentRequestTransitions.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Payment;
 
-/** @experimental */
 interface PaymentRequestTransitions
 {
     public const GRAPH = 'sylius_payment_request';

--- a/src/Sylius/Component/Payment/Repository/PaymentRequestRepositoryInterface.php
+++ b/src/Sylius/Component/Payment/Repository/PaymentRequestRepositoryInterface.php
@@ -23,8 +23,6 @@ use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
  * @template T of PaymentRequestInterface
  *
  * @extends RepositoryInterface<T>
- *
- * @experimental
  */
 interface PaymentRequestRepositoryInterface extends RepositoryInterface
 {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #16237
| License         | MIT

The **Payment Request** feature is no longer **experimental**.

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Payment Request functionality is now officially supported rather than experimental.
  * Related payment flows, APIs, and integration components are covered by the Sylius Backward Compatibility policy.
  * Release documentation has been updated to reflect the status change.

* **Compatibility**
  * Existing Payment Request behavior, interfaces, and method signatures remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->