### PR TITLE
[CoreBundle] Guard against null shipping method in order eligibility validator

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
@@ -43,8 +43,12 @@ final class OrderShippingMethodEligibilityValidator extends ConstraintValidator
         }
 
         foreach ($shipments as $shipment) {
-            /** @var ShippingMethodInterface $shippingMethod */
+            /** @var ?ShippingMethodInterface $shippingMethod */
             $shippingMethod = $shipment->getMethod();
+
+            if (null === $shippingMethod) {
+                continue;
+            }
 
             if (!$shippingMethod->isEnabled() || !$shippingMethod->getChannels()->contains($value->getChannel())) {
                 $this->context->addViolation(

--- a/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/OrderShippingMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Validator/Constraints/OrderShippingMethodEligibilityValidatorTest.php
@@ -55,6 +55,34 @@ final class OrderShippingMethodEligibilityValidatorTest extends TestCase
         $this->validator->validate('', $this->createMock(Constraint::class));
     }
 
+    public function testItDoesNothingWhenThereAreNoShipments(): void
+    {
+        $constraint = new OrderShippingMethodEligibility();
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getShipments')->willReturn(new ArrayCollection([]));
+
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate($order, $constraint);
+    }
+
+    public function testItSkipsShipmentsWithoutShippingMethod(): void
+    {
+        $constraint = new OrderShippingMethodEligibility();
+
+        $order = $this->createMock(OrderInterface::class);
+        $shipment = $this->createMock(ShipmentInterface::class);
+
+        $order->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
+        $shipment->method('getMethod')->willReturn(null);
+
+        $this->eligibilityChecker->expects($this->never())->method('isEligible');
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate($order, $constraint);
+    }
+
     public function testItAddsViolationForNotAvailableShippingMethods(): void
     {
         $constraint = new OrderShippingMethodEligibility();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

The shipment's method is guaranteed to be present by the NotBlank constraint defined in ShippingBundle Resources/config/validation/Shipment.xml, but the validator may run before that constraint is evaluated, so guard against a null method to avoid a type error.
