### PR TITLE
Prevent LiveComponents from interfering with modal behavior

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/scripts/modal-portal.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/scripts/modal-portal.js
@@ -8,6 +8,10 @@
  */
 
 document.addEventListener('show.bs.modal', function (event) {
+    if (event.target.closest('[data-controller~="live"]')) {
+        return;
+    }
+
     if (event.target.parentElement !== document.body) {
         document.body.appendChild(event.target);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Fixes a conflict with submitting a form inside a modal using UX Live Components.
An error occurred when attempting to add a PayPal sandbox account