### PR TITLE
[Context] Fixed context to work with frankenphp worker mode

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
@@ -20,6 +20,7 @@
         <service id="sylius.context.channel.cached" class="Sylius\Component\Channel\Context\CachedPerRequestChannelContext" decorates="sylius.context.channel" decoration-priority="256">
             <argument type="service" id="sylius.context.channel.cached.inner" />
             <argument type="service" id="request_stack" />
+            <tag name="kernel.reset" method="reset" />
         </service>
 
         <service id="sylius.context.shopper" class="Sylius\Component\Core\Context\ShopperContext" lazy="true">
@@ -34,6 +35,7 @@
             <argument type="service" id="sylius.context.cart.new_shop_based.inner" />
             <argument type="service" id="sylius.context.shopper" />
             <argument type="service" id="sylius.resolver.cart.created_by_guest_flag" />
+            <tag name="kernel.reset" method="reset" />
         </service>
         <service id="sylius.context.cart.customer_and_channel_based" class="Sylius\Bundle\CoreBundle\Context\CustomerAndChannelBasedCartContext">
             <argument type="service" id="sylius.context.customer" />

--- a/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -606,6 +606,34 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
         yield 'preview' => ['preview', true];
     }
 
+    #[Test]
+    public function it_registers_cached_channel_context_to_be_reset_between_requests(): void
+    {
+        $this->container->setParameter('kernel.environment', 'prod');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'sylius.context.channel.cached',
+            'kernel.reset',
+            ['method' => 'reset'],
+        );
+    }
+
+    #[Test]
+    public function it_registers_shop_based_cart_context_to_be_reset_between_requests(): void
+    {
+        $this->container->setParameter('kernel.environment', 'prod');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'sylius.context.cart.new_shop_based',
+            'kernel.reset',
+            ['method' => 'reset'],
+        );
+    }
+
     protected function getContainerExtensions(): array
     {
         return [new SyliusCoreExtension()];

--- a/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContext.php
+++ b/src/Sylius/Bundle/PayumBundle/PaymentRequest/Context/PaymentRequestContext.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PayumBundle\PaymentRequest\Context;
 
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /** @experimental */
-final class PaymentRequestContext implements PaymentRequestContextInterface
+final class PaymentRequestContext implements PaymentRequestContextInterface, ResetInterface
 {
     private ?PaymentRequestInterface $paymentRequest = null;
 
@@ -38,5 +39,10 @@ final class PaymentRequestContext implements PaymentRequestContextInterface
     public function disable(): void
     {
         $this->paymentRequest = null;
+    }
+
+    public function reset(): void
+    {
+        $this->disable();
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/payment_request/context.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/payment_request/context.xml
@@ -18,7 +18,9 @@
 >
 
     <services>
-        <service id="sylius_payum.context.payment_request" class="Sylius\Bundle\PayumBundle\PaymentRequest\Context\PaymentRequestContext" />
+        <service id="sylius_payum.context.payment_request" class="Sylius\Bundle\PayumBundle\PaymentRequest\Context\PaymentRequestContext">
+            <tag name="kernel.reset" method="reset" />
+        </service>
         <service id="Sylius\Bundle\PayumBundle\PaymentRequest\Context\PaymentRequestContextInterface" alias="sylius_payum.context.payment_request" />
     </services>
 </container>

--- a/src/Sylius/Bundle/PayumBundle/tests/DependencyInjection/PaymentRequestContextServiceTest.php
+++ b/src/Sylius/Bundle/PayumBundle/tests/DependencyInjection/PaymentRequestContextServiceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PayumBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+final class PaymentRequestContextServiceTest extends TestCase
+{
+    #[Test]
+    public function it_registers_payment_request_context_to_be_reset_between_requests(): void
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../../Resources/config/services/payment_request'),
+        );
+        $loader->load('context.xml');
+
+        $definition = $container->getDefinition('sylius_payum.context.payment_request');
+
+        self::assertSame(
+            [['method' => 'reset']],
+            $definition->getTag('kernel.reset'),
+            'The payment request context must be tagged with "kernel.reset" so it is reset between worker requests.',
+        );
+    }
+}

--- a/src/Sylius/Component/Channel/Context/CachedPerRequestChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/CachedPerRequestChannelContext.php
@@ -15,8 +15,9 @@ namespace Sylius\Component\Channel\Context;
 
 use Sylius\Component\Channel\Model\ChannelInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\ResetInterface;
 
-final class CachedPerRequestChannelContext implements ChannelContextInterface
+final class CachedPerRequestChannelContext implements ChannelContextInterface, ResetInterface
 {
     private \SplObjectStorage $requestToChannelMap;
 
@@ -50,5 +51,11 @@ final class CachedPerRequestChannelContext implements ChannelContextInterface
 
             throw $exception;
         }
+    }
+
+    public function reset(): void
+    {
+        $this->requestToChannelMap = new \SplObjectStorage();
+        $this->requestToExceptionMap = new \SplObjectStorage();
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | pull request https://github.com/Sylius/Sylius/pull/18959
| License         | MIT

When running Sylius on FrankenPHP worker mode, several context services keep
state in memory between requests. Because the PHP process is reused, entities
(e.g. the `Channel`) cached during a previous request still reference a closed
EntityManager. On the next request `flush()` sees them as new, unmanaged
entities and throws `ORMInvalidArgumentException` (typically when adding a
product to the cart).

This makes the affected services resettable between worker requests by tagging
them with `kernel.reset`:

- `CachedPerRequestChannelContext` — now implements `ResetInterface` and clears
its per-request maps.
- `PaymentRequestContext` — now implements `ResetInterface` and resets the
current payment request.
- `ShopBasedCartContext` — already implemented `ResettableCartContextInterface`,
but as a decorator it was never tagged `kernel.reset`, so its `reset()` was
never called. It is now tagged explicitly.

Implementing `ResetInterface` alone is not enough here: these bundle services
are not autoconfigured, so the `kernel.reset` tag has to be added explicitly in
the service definitions.

Thanks to @kgonella for spotting the `ShopBasedCartContext` case.

This PR targets 2.2 (the format change to PHP DI config happens in 2.3); the
up-merge to 2.3 translates the same tags to the PHP config.