### PR TITLE
feat(product): #issue-13467 - add position field to ProductOptionValues

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/create.yaml
@@ -49,6 +49,9 @@ sylius_twig_hooks:
             code:
                 template: '@SyliusAdmin/product_option/form/sections/values/value/code.html.twig'
                 priority: 200
+            position:
+                template: '@SyliusAdmin/product_option/form/sections/values/value/position.html.twig'
+                priority: 150
             translations:
                 template: '@SyliusAdmin/product_option/form/sections/values/value/translations.html.twig'
                 priority: 100

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/update.yaml
@@ -51,6 +51,9 @@ sylius_twig_hooks:
             code:
                 template: '@SyliusAdmin/product_option/form/sections/values/value/code.html.twig'
                 priority: 200
+            position:
+                template: '@SyliusAdmin/product_option/form/sections/values/value/position.html.twig'
+                priority: 150
             translations:
                 template: '@SyliusAdmin/product_option/form/sections/values/value/translations.html.twig'
                 priority: 100

--- a/src/Sylius/Bundle/AdminBundle/templates/product_option/form/sections/values/value/position.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_option/form/sections/values/value/position.html.twig
@@ -1,0 +1,3 @@
+<div class="col-12">
+    {{ form_row(hookable_metadata.context.value_form.position, sylius_test_form_attribute('position')) }}
+</div>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionValue.xml
@@ -59,6 +59,9 @@
                         </value>
                     </values>
                 </normalizationContext>
+                <filters>
+                    <filter>sylius_api.order_filter.admin.product_option_value</filter>
+                </filters>
             </operation>
         </operations>
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
@@ -34,6 +34,14 @@
             <group>sylius:shop:product_option_value:index</group>
             <group>sylius:shop:product_option_value:show</group>
         </attribute>
+        <attribute name="position">
+            <group>sylius:admin:product_option_value:index</group>
+            <group>sylius:admin:product_option_value:show</group>
+            <group>sylius:admin:product_option:index</group>
+            <group>sylius:admin:product_option:show</group>
+            <group>sylius:admin:product_option:create</group>
+            <group>sylius:admin:product_option:update</group>
+        </attribute>
         <attribute name="translations">
             <group>sylius:admin:product_option_value:show</group>
             <group>sylius:admin:product_option:create</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/admin/filters.php
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/admin/filters.php
@@ -355,6 +355,13 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius_api.order_filter.admin.product_option_value')
+        ->parent('api_platform.doctrine.orm.order_filter')
+        ->args([['position' => '']])
+        ->tag('api_platform.filter')
+    ;
+
+    $services
         ->set('sylius_api.search_filter.admin.locale')
         ->parent('api_platform.doctrine.orm.search_filter')
         ->args([['code' => 'partial']])

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -66,12 +66,13 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
             /** @var ProductOptionValueInterface $productOptionValue */
             $productOptionValue = $this->productOptionValueFactory->createNew();
             $productOptionValue->setCode($code);
+            $productOptionValue->setPosition($value['position']);
 
             foreach ($this->getLocales() as $localeCode) {
                 $productOptionValue->setCurrentLocale($localeCode);
                 $productOptionValue->setFallbackLocale($localeCode);
 
-                $productOptionValue->setValue($value);
+                $productOptionValue->setValue($value['value']);
             }
 
             $productOption->addValue($productOptionValue);
@@ -104,7 +105,7 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
 
                 $values = [];
                 for ($i = 1; $i <= 5; ++$i) {
-                    $values[sprintf('%s-option#%d', $options['code'], $i)] = sprintf('%s #i%d', $options['name'], $i);
+                    $values[sprintf('%s-option#%d', $options['code'], $i)] = ['value' => sprintf('%s #i%d', $options['name'], $i), 'position' => $i - 1];
                 }
 
                 if (!empty($options['translations'])) {

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductOptionFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductOptionFixture.php
@@ -32,7 +32,12 @@ class ProductOptionFixture extends AbstractResourceFixture
                 ->arrayNode('values')
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('code')
-                    ->scalarPrototype()
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('value')->cannotBeEmpty()->end()
+                            ->integerNode('position')->defaultValue(0)->end()
+                        ->end()
+                    ->end()
                 ->end()
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20260623000000.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20260623000000.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractMigration;
+
+final class Version20260623000000 extends AbstractMigration
+{
+    private const TABLE_NAME = 'sylius_product_option_value';
+
+    public function getDescription(): string
+    {
+        return 'Add position column to sylius_product_option_value (MySQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable(self::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE_NAME);
+
+        if ($table->hasColumn('position')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE ' . self::TABLE_NAME . ' ADD position INT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable(self::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE_NAME);
+
+        if (!$table->hasColumn('position')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE ' . self::TABLE_NAME . ' DROP COLUMN position');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20260623000001.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20260623000001.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20260623000001 extends AbstractPostgreSQLMigration
+{
+    private const TABLE_NAME = 'sylius_product_option_value';
+
+    public function getDescription(): string
+    {
+        return 'Add position column to sylius_product_option_value (PostgreSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable(self::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE_NAME);
+
+        if ($table->hasColumn('position')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE ' . self::TABLE_NAME . ' ADD position INT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable(self::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE_NAME);
+
+        if (!$table->hasColumn('position')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE ' . self::TABLE_NAME . ' DROP COLUMN position');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/dress.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/dress.yaml
@@ -58,14 +58,34 @@ sylius_fixtures:
                             -   name: 'Dress size'
                                 code: 'dress_size'
                                 values:
-                                    dress_s: 'S'
-                                    dress_m: 'M'
-                                    dress_l: 'L'
-                                    dress_xl: 'XL'
-                                    dress_xxl: 'XXL'
+                                    dress_s:
+                                        value: 'S'
+                                        position: 0
+                                    dress_m:
+                                        value: 'M'
+                                        position: 1
+                                    dress_l:
+                                        value: 'L'
+                                        position: 2
+                                    dress_xl:
+                                        value: 'XL'
+                                        position: 3
+                                    dress_xxl:
+                                        value: 'XXL'
+                                        position: 4
 
                             -   name: 'Dress height'
                                 code: 'dress_height'
+                                values:
+                                    dress_height_petite:
+                                        value: 'Petite'
+                                        position: 0
+                                    dress_height_regular:
+                                        value: 'Regular'
+                                        position: 1
+                                    dress_height_tall:
+                                        value: 'Tall'
+                                        position: 2
                                 translations:
                                     en_US:
                                         values:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/jeans.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/jeans.yaml
@@ -73,11 +73,21 @@ sylius_fixtures:
                             -   name: 'Jeans size'
                                 code: 'jeans_size'
                                 values:
-                                    jeans_size_s: 'S'
-                                    jeans_size_m: 'M'
-                                    jeans_size_l: 'L'
-                                    jeans_size_xl: 'XL'
-                                    jeans_size_xxl: 'XXL'
+                                    jeans_size_s:
+                                        value: 'S'
+                                        position: 0
+                                    jeans_size_m:
+                                        value: 'M'
+                                        position: 1
+                                    jeans_size_l:
+                                        value: 'L'
+                                        position: 2
+                                    jeans_size_xl:
+                                        value: 'XL'
+                                        position: 3
+                                    jeans_size_xxl:
+                                        value: 'XXL'
+                                        position: 4
 
                 jeans_product:
                     name: product

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/tshirt.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/tshirt.yaml
@@ -78,11 +78,21 @@ sylius_fixtures:
                             -   name: 'T-shirt size'
                                 code: 't_shirt_size'
                                 values:
-                                    t_shirt_size_s: 'S'
-                                    t_shirt_size_m: 'M'
-                                    t_shirt_size_l: 'L'
-                                    t_shirt_size_xl: 'XL'
-                                    t_shirt_size_xxl: 'XXL'
+                                    t_shirt_size_s:
+                                        value: 'S'
+                                        position: 0
+                                    t_shirt_size_m:
+                                        value: 'M'
+                                        position: 1
+                                    t_shirt_size_l:
+                                        value: 'L'
+                                        position: 2
+                                    t_shirt_size_xl:
+                                        value: 'XL'
+                                        position: 3
+                                    t_shirt_size_xxl:
+                                        value: 'XXL'
+                                        position: 4
                                 translations:
                                     en_US: 
                                         name: 'T-shirt size'

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueType.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ProductBundle\Form\Type;
 use Sylius\Bundle\ResourceBundle\Form\EventSubscriber\AddCodeFormSubscriber;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceTranslationsType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class ProductOptionValueType extends AbstractResourceType
@@ -26,6 +27,10 @@ final class ProductOptionValueType extends AbstractResourceType
             ->add('translations', ResourceTranslationsType::class, [
                 'entry_type' => ProductOptionValueTranslationType::class,
                 'label' => 'sylius.form.option.name',
+            ])
+            ->add('position', IntegerType::class, [
+                'label' => 'sylius.form.option_value.position',
+                'required' => false,
             ])
             ->addEventSubscriber(new AddCodeFormSubscriber())
         ;

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOptionValue.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOptionValue.orm.xml
@@ -20,6 +20,8 @@
 
         <field name="code" column="code" type="string" unique="true" />
 
+        <field name="position" type="integer" />
+
         <many-to-one target-entity="Sylius\Component\Product\Model\ProductOptionInterface" field="option" inversed-by="values">
             <join-columns>
                 <join-column name="option_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.en.yml
@@ -29,3 +29,4 @@ sylius:
         option_value:
             add_value: Add value
             value: Value
+            position: Position

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.en_GB.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.en_GB.yml
@@ -26,3 +26,4 @@ sylius:
         option_value:
             add_value: Add value
             value: Value
+            position: Position

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.fr.yml
@@ -29,3 +29,4 @@ sylius:
         option_value:
             add_value: Ajouter une valeur
             value: Valeur
+            position: Emplacement

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.fr_BE.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.fr_BE.yml
@@ -29,3 +29,4 @@ sylius:
         option_value:
             add_value: Ajouter une valeur
             value: Valeur
+            position: Emplacement

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.fr_CA.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.fr_CA.yml
@@ -29,3 +29,4 @@ sylius:
         option_value:
             add_value: Ajouter une valeur
             value: Valeur
+            position: Emplacement

--- a/src/Sylius/Component/Product/Model/ProductOptionValue.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionValue.php
@@ -32,6 +32,9 @@ class ProductOptionValue implements ProductOptionValueInterface, \Stringable
     /** @var ProductOptionInterface|null */
     protected $option;
 
+    /** @var int|null */
+    protected $position;
+
     public function __construct()
     {
         $this->initializeTranslationCollection();
@@ -65,6 +68,16 @@ class ProductOptionValue implements ProductOptionValueInterface, \Stringable
     public function setOption(?ProductOptionInterface $option): void
     {
         $this->option = $option;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(?int $position): void
+    {
+        $this->position = $position;
     }
 
     public function getValue(): ?string

--- a/src/Sylius/Component/Product/Model/ProductOptionValueInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionValueInterface.php
@@ -32,6 +32,10 @@ interface ProductOptionValueInterface extends ResourceInterface, CodeAwareInterf
 
     public function getName(): ?string;
 
+    public function getPosition(): ?int;
+
+    public function setPosition(?int $position): void;
+
     /**
      * @return ProductOptionValueTranslationInterface
      */


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13467 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Hello, i have created the new position field for ProductOptionValues.

So we can get it
<img width="619" height="136" alt="image" src="https://github.com/user-attachments/assets/a1b65ade-3fa0-40cb-8856-659070f31d5b" />

I **did not** update this file  `Sylius/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOption.orm.xml` that allows to change the order on the front 

<img width="843" height="198" alt="image" src="https://github.com/user-attachments/assets/437c4fe4-d774-4561-a8c7-8b11a9d276fc" />