### PR TITLE
Remove date time normalizer to use default Symfony RFC3339

### DIFF
--- a/UPGRADE-API-2.3.md
+++ b/UPGRADE-API-2.3.md
@@ -1,0 +1,63 @@
+# UPGRADE FROM `2.2` TO `2.3`
+
+## DateTime Serialization Format
+
+The `sylius_api.normalizer.date_time` service has been removed. Previously, Sylius registered a custom
+`DateTimeNormalizer` that overrode Symfony's built-in normalizer globally, forcing the `Y-m-d H:i:s` format
+on all `DateTime` fields across the entire API.
+
+All `DateTime` fields are now serialized using Symfony's default `DateTimeNormalizer`, which produces
+the RFC 3339 format (`Y-m-d\TH:i:sP`).
+
+**Before:**
+```json
+{
+    "startDate": "2022-01-01 00:00:00",
+    "endDate": "2022-01-02 00:00:00",
+    "birthday": "2023-10-24 11:00:00",
+    "expiresAt": "2020-01-01 12:00:00"
+}
+```
+
+**After:**
+```json
+{
+    "startDate": "2022-01-01T00:00:00+00:00",
+    "endDate": "2022-01-02T00:00:00+00:00",
+    "birthday": "2023-10-24T11:00:00+00:00",
+    "expiresAt": "2020-01-01T12:00:00+00:00"
+}
+```
+
+**Affected fields (non-exhaustive):** `startDate`, `endDate`, `startsAt`, `endsAt`, `expiresAt`, `birthday`,
+`createdAt`, `updatedAt`, `archivedAt` and any other `DateTime` field exposed via the API.
+
+**Migration guide:**
+
+If your API client depends on the old `Y-m-d H:i:s` format, update it to parse RFC 3339 dates instead.
+RFC 3339 is the standard format for REST APIs and is natively supported by all modern date libraries.
+
+If you need to restore the old format or apply a custom one globally, register your own `DateTimeNormalizer`
+with a higher priority than Symfony's default (`-910`):
+
+```php
+// config/services.php
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+
+$services
+    ->set('app.normalizer.date_time', DateTimeNormalizer::class)
+    ->args([['datetime_format' => 'Y-m-d H:i:s']])
+    ->tag('serializer.normalizer', ['priority' => 1])
+;
+```
+
+Alternatively, you may set the format for a specific field only by adding a serialization context
+to the attribute definition in your serialization XML:
+
+```xml
+<attribute name="startDate">
+    <context>
+        <entry name="datetime_format">Y-m-d</entry>
+    </context>
+</attribute>
+```

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -860,7 +860,11 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::true(
             $this->responseChecker->hasItemWithValues(
                 $response,
-                ['name' => $catalogPromotion->getName(), 'startDate' => $startDate . ':00', 'endDate' => $endDate . ':00'],
+                [
+                    'name' => $catalogPromotion->getName(),
+                    'startDate' => (new \DateTime($startDate))->format(\DateTimeInterface::RFC3339),
+                    'endDate' => (new \DateTime($endDate))->format(\DateTimeInterface::RFC3339),
+                ],
             ),
             sprintf(
                 'Cannot find catalog promotions with name "%s" operating between "%s" and "%s" in the list',
@@ -902,15 +906,15 @@ final readonly class ManagingCatalogPromotionsContext implements Context
                 $response,
                 [
                     'name' => $catalogPromotion->getName(),
-                    'startDate' => (new \DateTime('yesterday'))->format('Y-m-d H:i:s'),
-                    'endDate' => (new \DateTime('tomorrow'))->format('Y-m-d H:i:s'),
+                    'startDate' => (new \DateTime('yesterday'))->format(\DateTimeInterface::RFC3339),
+                    'endDate' => (new \DateTime('tomorrow'))->format(\DateTimeInterface::RFC3339),
                 ],
             ),
             sprintf(
                 'Cannot find catalog promotions with name "%s" operating between "%s" and "%s" in the list',
                 $catalogPromotion->getName(),
-                (new \DateTime('yesterday'))->format('Y-m-d H:i:s'),
-                (new \DateTime('tomorrow'))->format('Y-m-d H:i:s'),
+                (new \DateTime('yesterday'))->format(\DateTimeInterface::RFC3339),
+                (new \DateTime('tomorrow'))->format(\DateTimeInterface::RFC3339),
             ),
         );
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCustomersContext.php
@@ -351,7 +351,10 @@ final class ManagingCustomersContext implements Context
     #[Then('he should be registered since :registrationDate')]
     public function hisRegistrationDateShouldBe(string $registrationDate): void
     {
-        Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'createdAt', $registrationDate));
+        Assert::same(
+            (new \DateTime($this->responseChecker->getValue($this->client->getLastResponse(), 'createdAt')))->format(\DateTimeInterface::RFC3339),
+            (new \DateTime($registrationDate))->format(\DateTimeInterface::RFC3339),
+        );
     }
 
     #[Then('their email should be :email')]

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
@@ -755,7 +755,7 @@ final readonly class ManagingOrdersContext implements Context
 
         Assert::same(
             $this->responseChecker->getValue($response, 'shippedAt'),
-            (new \DateTime($dateTime))->format('Y-m-d H:i:s'),
+            (new \DateTime($dateTime))->format(\DateTimeInterface::RFC3339),
         );
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionCouponsContext.php
@@ -269,8 +269,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
     #[Then('this coupon should be valid until :date')]
     public function thisCouponShouldBeValidUntil(\DateTime $date): void
     {
-        $actualDate = \DateTime::createFromFormat(
-            'Y-m-d h:i:s',
+        $actualDate = new \DateTime(
             $this->responseChecker->getValue($this->client->getLastResponse(), 'expiresAt'),
         );
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
@@ -588,8 +588,8 @@ final readonly class ManagingPromotionsContext implements Context
                 $this->client->index(Resources::PROMOTIONS),
                 [
                     'name' => $promotion->getName(),
-                    'startsAt' => $startsDate->format('Y-m-d H:i:s'),
-                    'endsAt' => $endsDate->format('Y-m-d H:i:s'),
+                    'startsAt' => $startsDate->format(\DateTimeInterface::RFC3339),
+                    'endsAt' => $endsDate->format(\DateTimeInterface::RFC3339),
                 ],
             ),
         );

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.php
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.php
@@ -36,7 +36,6 @@ use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ProductOptionValueNormalizer;
 use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ProductVariantNormalizer;
 use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ShippingMethodNormalizer;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 return static function (ContainerConfigurator $container) {
     $services = $container->services();
@@ -171,12 +170,6 @@ return static function (ContainerConfigurator $container) {
         ->set('sylius_api.denormalizer.translatable', TranslatableDenormalizer::class)
         ->args([service('sylius.translation_locale_provider')])
         ->tag('serializer.normalizer', ['priority' => 64])
-    ;
-
-    $services
-        ->set('sylius_api.normalizer.date_time', DateTimeNormalizer::class)
-        ->args([['datetime_format' => 'Y-m-d H:i:s']])
-        ->tag('serializer.normalizer')
     ;
 
     $services

--- a/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_response.json
+++ b/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_response.json
@@ -5,8 +5,8 @@
     "id": "@integer@",
     "name": "T-Shirts discount",
     "code": "tshirts_discount",
-    "startDate": "2022-01-01 00:00:00",
-    "endDate": "2022-01-02 00:00:00",
+    "startDate": "@date@",
+    "endDate": "@date@",
     "priority": 100,
     "state": "@string@",
     "channels": [

--- a/tests/Api/Responses/admin/customer/post_customer_response.json
+++ b/tests/Api/Responses/admin/customer/post_customer_response.json
@@ -8,7 +8,7 @@
     "email": "api@example.com",
     "firstName": "John",
     "lastName": "Doe",
-    "birthday": "2023-10-24 11:00:00",
+    "birthday": "@date@",
     "gender": "m",
     "group": null,
     "phoneNumber": "+48123456789",

--- a/tests/Api/Responses/admin/customer/post_customer_with_user_response.json
+++ b/tests/Api/Responses/admin/customer/post_customer_with_user_response.json
@@ -13,7 +13,7 @@
     "email": "api@example.com",
     "firstName": "John",
     "lastName": "Doe",
-    "birthday": "2023-10-24 11:00:00",
+    "birthday": "@date@",
     "gender": "m",
     "group": "\/api\/v2\/admin\/customer-groups\/vip",
     "phoneNumber": "+48123456789",

--- a/tests/Api/Responses/admin/customer/update_customer_response.json
+++ b/tests/Api/Responses/admin/customer/update_customer_response.json
@@ -13,7 +13,7 @@
     "email": "api@example.com",
     "firstName": "John",
     "lastName": "Lim",
-    "birthday": "2023-09-24 11:00:00",
+    "birthday": "@date@",
     "gender": "f",
     "group": "\/api\/v2\/admin\/customer-groups\/premium",
     "phoneNumber": "+48987654321",

--- a/tests/Api/Responses/admin/promotion/post_promotion_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_response.json
@@ -14,8 +14,8 @@
     "usageLimit": 3,
     "used": 0,
     "archivedAt": null,
-    "startsAt": "2023-10-04 12:30:00",
-    "endsAt": "2023-11-04 12:30:00",
+    "startsAt": "@date@",
+    "endsAt": "@date@",
     "couponBased": true,
     "coupons": [],
     "rules": [

--- a/tests/Api/Responses/admin/promotion_coupon/generate_promotion_coupons_response.json
+++ b/tests/Api/Responses/admin/promotion_coupon/generate_promotion_coupons_response.json
@@ -9,7 +9,7 @@
         "usageLimit": 10,
         "used": 0,
         "promotion": "\/api\/v2\/admin\/promotions\/50_off",
-        "expiresAt": "2020-01-01 12:00:00",
+        "expiresAt": "@date@",
         "createdAt": "@date@",
         "updatedAt": "@date@"
     },
@@ -23,7 +23,7 @@
         "usageLimit": 10,
         "used": 0,
         "promotion": "\/api\/v2\/admin\/promotions\/50_off",
-        "expiresAt": "2020-01-01 12:00:00",
+        "expiresAt": "@date@",
         "createdAt": "@date@",
         "updatedAt": "@date@"
     },
@@ -37,7 +37,7 @@
         "usageLimit": 10,
         "used": 0,
         "promotion": "\/api\/v2\/admin\/promotions\/50_off",
-        "expiresAt": "2020-01-01 12:00:00",
+        "expiresAt": "@date@",
         "createdAt": "@date@",
         "updatedAt": "@date@"
     },
@@ -51,7 +51,7 @@
         "usageLimit": 10,
         "used": 0,
         "promotion": "\/api\/v2\/admin\/promotions\/50_off",
-        "expiresAt": "2020-01-01 12:00:00",
+        "expiresAt": "@date@",
         "createdAt": "@date@",
         "updatedAt": "@date@"
     }

--- a/tests/Api/Responses/admin/promotion_coupon/put_promotion_coupon_response.json
+++ b/tests/Api/Responses/admin/promotion_coupon/put_promotion_coupon_response.json
@@ -10,5 +10,5 @@
     "promotion": "\/api\/v2\/admin\/promotions\/dollar_off",
     "createdAt": "@date@",
     "updatedAt": "@date@",
-    "expiresAt": "2020-01-01 12:00:00"
+    "expiresAt": "@date@"
 }

--- a/tests/Api/Responses/shop/customer/put_customer_response.json
+++ b/tests/Api/Responses/shop/customer/put_customer_response.json
@@ -14,6 +14,6 @@
     "fullName": "John Wick",
     "phoneNumber": "666777888",
     "gender": "m",
-    "birthday": "2023-10-24 11:00:00",
+    "birthday": "@date@",
     "subscribedToNewsletter": true
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | https://github.com/Sylius/Sylius/issues/13911
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
