### PR TITLE
Add country and zone setup during installation process

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -236,6 +236,49 @@ The converter can help bootstrap the migration from YAML to PHP and reduce the a
 
 For a complete overview of the Grid component, see the [Grid documentation](https://stack.sylius.com/grid/index).
 
+## Installer
+
+1. The `sylius:install:setup` command now sets up a **country** and a **default zone** during installation.
+
+   Two new setup classes have been introduced:
+   - `Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetup` implementing `CountrySetupInterface`
+   - `Sylius\Bundle\CoreBundle\Installer\Setup\ZoneSetup` implementing `ZoneSetupInterface`
+
+   Both are registered as services and injected into `SetupCommand`. If you have decorated or replaced
+   `SetupCommand`, update your constructor to include the two new dependencies:
+
+   ```diff
+    public function __construct(
+        protected readonly EntityManagerInterface $entityManager,
+        protected readonly CommandDirectoryChecker $commandDirectoryChecker,
+        protected readonly CurrencySetupInterface $currencySetup,
+        protected readonly LocaleSetupInterface $localeSetup,
+        protected readonly ChannelSetupInterface $channelSetup,
+   +    protected readonly CountrySetupInterface $countrySetup,
+   +    protected readonly ZoneSetupInterface $zoneSetup,
+        protected readonly FactoryInterface $adminUserFactory,
+        protected readonly UserRepositoryInterface $adminUserRepository,
+        protected readonly ValidatorInterface $validator,
+    )
+   ```
+
+2. The `ChannelSetupInterface::setup()` method signature has been extended to receive the newly created
+   country, zone, and console I/O objects:
+
+   ```diff
+    public function setup(
+        LocaleInterface $locale,
+        CurrencyInterface $currency,
+   +    CountryInterface $country,
+   +    ZoneInterface $zone,
+   +    InputInterface $input,
+   +    OutputInterface $output,
+   +    QuestionHelper $questionHelper,
+    ): void;
+   ```
+
+   If you have a custom implementation of `ChannelSetupInterface`, update its `setup()` signature accordingly.
+
 ## Dependencies
 
 1. The `behat/transliterator` package has been **deprecated** and will be removed in Sylius 3.0.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -238,14 +238,17 @@ For a complete overview of the Grid component, see the [Grid documentation](http
 
 ## Installer
 
-1. The `sylius:install:setup` command now sets up a **country** and a **default zone** during installation.
+1. The `sylius:install:setup` command now sets up a **country** and a **default zone** during installation, and
+   optionally assigns the created zone as the default channel tax zone.
 
-   Two new setup classes have been introduced:
+   Three new setup classes have been introduced:
    - `Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetup` implementing `CountrySetupInterface`
    - `Sylius\Bundle\CoreBundle\Installer\Setup\ZoneSetup` implementing `ZoneSetupInterface`
+   - `Sylius\Bundle\CoreBundle\Installer\Setup\ChannelDefaultTaxZoneSetup` implementing `ChannelDefaultTaxZoneSetupInterface`
 
-   Both are registered as services and injected into `SetupCommand`. If you have decorated or replaced
-   `SetupCommand`, update your constructor to include the two new dependencies:
+   All three are registered as services and injected into `SetupCommand` as **optional** constructor arguments. If
+   you have decorated or replaced `SetupCommand`, not passing them is deprecated and will be prohibited in
+   Sylius 3.0:
 
    ```diff
     public function __construct(
@@ -254,26 +257,23 @@ For a complete overview of the Grid component, see the [Grid documentation](http
         protected readonly CurrencySetupInterface $currencySetup,
         protected readonly LocaleSetupInterface $localeSetup,
         protected readonly ChannelSetupInterface $channelSetup,
-   +    protected readonly CountrySetupInterface $countrySetup,
-   +    protected readonly ZoneSetupInterface $zoneSetup,
         protected readonly FactoryInterface $adminUserFactory,
         protected readonly UserRepositoryInterface $adminUserRepository,
         protected readonly ValidatorInterface $validator,
+   +    protected readonly ?CountrySetupInterface $countrySetup = null,
+   +    protected readonly ?ZoneSetupInterface $zoneSetup = null,
+   +    protected readonly ?ChannelDefaultTaxZoneSetupInterface $channelDefaultTaxZoneSetup = null,
     )
    ```
 
-2. The `ChannelSetupInterface::setup()` method signature has been extended to receive the newly created
-   country, zone, and console I/O objects:
+2. The `ChannelSetupInterface::setup()` method signature has been extended with an optional argument to receive the
+   newly created country:
 
    ```diff
     public function setup(
         LocaleInterface $locale,
         CurrencyInterface $currency,
-   +    CountryInterface $country,
-   +    ZoneInterface $zone,
-   +    InputInterface $input,
-   +    OutputInterface $output,
-   +    QuestionHelper $questionHelper,
+   +    ?CountryInterface $country = null,
     ): void;
    ```
 

--- a/src/Sylius/Behat/Context/Cli/InstallerContext.php
+++ b/src/Sylius/Behat/Context/Cli/InstallerContext.php
@@ -47,6 +47,7 @@ final class InstallerContext implements Context
         'currency' => 'USD',
         'locale' => 'en_US',
         'country' => 'US',
+        'zone' => 'no',
         'e-mail' => 'test@email.com',
         'username' => 'test',
         'firstName' => '',

--- a/src/Sylius/Behat/Context/Cli/InstallerContext.php
+++ b/src/Sylius/Behat/Context/Cli/InstallerContext.php
@@ -22,8 +22,10 @@ use Sylius\Bundle\CoreBundle\Console\Command\InstallSampleDataCommand;
 use Sylius\Bundle\CoreBundle\Console\Command\SetupCommand;
 use Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetupInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\LocaleSetupInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ZoneSetupInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -44,6 +46,7 @@ final class InstallerContext implements Context
     private array $inputChoices = [
         'currency' => 'USD',
         'locale' => 'en_US',
+        'country' => 'US',
         'e-mail' => 'test@email.com',
         'username' => 'test',
         'firstName' => '',
@@ -59,6 +62,8 @@ final class InstallerContext implements Context
         private readonly CurrencySetupInterface $currencySetup,
         private readonly LocaleSetupInterface $localeSetup,
         private readonly ChannelSetupInterface $channelSetup,
+        private readonly CountrySetupInterface $countrySetup,
+        private readonly ZoneSetupInterface $zoneSetup,
         private readonly FactoryInterface $adminUserFactory,
         private readonly UserRepositoryInterface $adminUserRepository,
         private readonly ValidatorInterface $validator,
@@ -76,6 +81,8 @@ final class InstallerContext implements Context
             $this->currencySetup,
             $this->localeSetup,
             $this->channelSetup,
+            $this->countrySetup,
+            $this->zoneSetup,
             $this->adminUserFactory,
             $this->adminUserRepository,
             $this->validator,

--- a/src/Sylius/Behat/Context/Cli/InstallerContext.php
+++ b/src/Sylius/Behat/Context/Cli/InstallerContext.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\CoreBundle\Console\Command\InstallSampleDataCommand;
 use Sylius\Bundle\CoreBundle\Console\Command\SetupCommand;
 use Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelDefaultTaxZoneSetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface;
@@ -65,6 +66,7 @@ final class InstallerContext implements Context
         private readonly ChannelSetupInterface $channelSetup,
         private readonly CountrySetupInterface $countrySetup,
         private readonly ZoneSetupInterface $zoneSetup,
+        private readonly ChannelDefaultTaxZoneSetupInterface $channelDefaultTaxZoneSetup,
         private readonly FactoryInterface $adminUserFactory,
         private readonly UserRepositoryInterface $adminUserRepository,
         private readonly ValidatorInterface $validator,
@@ -82,11 +84,12 @@ final class InstallerContext implements Context
             $this->currencySetup,
             $this->localeSetup,
             $this->channelSetup,
-            $this->countrySetup,
-            $this->zoneSetup,
             $this->adminUserFactory,
             $this->adminUserRepository,
             $this->validator,
+            $this->countrySetup,
+            $this->zoneSetup,
+            $this->channelDefaultTaxZoneSetup,
         ));
 
         $this->command = $this->application->find('sylius:install:setup');

--- a/src/Sylius/Behat/Resources/config/services/contexts/cli.php
+++ b/src/Sylius/Behat/Resources/config/services/contexts/cli.php
@@ -33,6 +33,7 @@ return static function (ContainerConfigurator $container) {
             service('sylius.setup.installer.channel'),
             service('sylius.setup.installer.country'),
             service('sylius.setup.installer.zone'),
+            service('sylius.setup.installer.channel_default_tax_zone'),
             service('sylius.factory.admin_user'),
             service('sylius.repository.admin_user'),
             service('validator'),

--- a/src/Sylius/Behat/Resources/config/services/contexts/cli.php
+++ b/src/Sylius/Behat/Resources/config/services/contexts/cli.php
@@ -31,6 +31,8 @@ return static function (ContainerConfigurator $container) {
             service('sylius.setup.installer.currency'),
             service('sylius.setup.installer.locale'),
             service('sylius.setup.installer.channel'),
+            service('sylius.setup.installer.country'),
+            service('sylius.setup.installer.zone'),
             service('sylius.factory.admin_user'),
             service('sylius.repository.admin_user'),
             service('validator'),

--- a/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
@@ -16,8 +16,10 @@ namespace Sylius\Bundle\CoreBundle\Console\Command;
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetupInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\LocaleSetupInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ZoneSetupInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;
@@ -49,6 +51,8 @@ final class SetupCommand extends AbstractInstallCommand
         protected readonly CurrencySetupInterface $currencySetup,
         protected readonly LocaleSetupInterface $localeSetup,
         protected readonly ChannelSetupInterface $channelSetup,
+        protected readonly CountrySetupInterface $countrySetup,
+        protected readonly ZoneSetupInterface $zoneSetup,
         protected readonly FactoryInterface $adminUserFactory,
         protected readonly UserRepositoryInterface $adminUserRepository,
         protected readonly ValidatorInterface $validator,
@@ -74,7 +78,9 @@ EOT
 
         $currency = $this->currencySetup->setup($input, $output, $questionHelper);
         $locale = $this->localeSetup->setup($input, $output, $questionHelper);
-        $this->channelSetup->setup($locale, $currency);
+        $country = $this->countrySetup->setup($input, $output, $questionHelper);
+        $zone = $this->zoneSetup->setup($country);
+        $this->channelSetup->setup($locale, $currency, $country, $zone, $input, $output, $questionHelper);
         $this->setupAdministratorUser($input, $output, $locale->getCode());
 
         return Command::SUCCESS;

--- a/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Console\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelDefaultTaxZoneSetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface;
@@ -51,13 +52,41 @@ final class SetupCommand extends AbstractInstallCommand
         protected readonly CurrencySetupInterface $currencySetup,
         protected readonly LocaleSetupInterface $localeSetup,
         protected readonly ChannelSetupInterface $channelSetup,
-        protected readonly CountrySetupInterface $countrySetup,
-        protected readonly ZoneSetupInterface $zoneSetup,
         protected readonly FactoryInterface $adminUserFactory,
         protected readonly UserRepositoryInterface $adminUserRepository,
         protected readonly ValidatorInterface $validator,
+        protected readonly ?CountrySetupInterface $countrySetup = null,
+        protected readonly ?ZoneSetupInterface $zoneSetup = null,
+        protected readonly ?ChannelDefaultTaxZoneSetupInterface $channelDefaultTaxZoneSetup = null,
     ) {
         parent::__construct($this->entityManager, $this->commandDirectoryChecker);
+
+        if (null === $this->countrySetup) {
+            trigger_deprecation(
+                'sylius/core',
+                '2.3',
+                'Not passing $countrySetup to "%s" constructor is deprecated and will be prohibited in Sylius 3.0.',
+                self::class,
+            );
+        }
+
+        if (null === $this->zoneSetup) {
+            trigger_deprecation(
+                'sylius/core',
+                '2.3',
+                'Not passing $zoneSetup to "%s" constructor is deprecated and will be prohibited in Sylius 3.0.',
+                self::class,
+            );
+        }
+
+        if (null === $this->channelDefaultTaxZoneSetup) {
+            trigger_deprecation(
+                'sylius/core',
+                '2.3',
+                'Not passing $channelDefaultTaxZoneSetup to "%s" constructor is deprecated and will be prohibited in Sylius 3.0.',
+                self::class,
+            );
+        }
     }
 
     protected function configure(): void
@@ -78,9 +107,16 @@ EOT
 
         $currency = $this->currencySetup->setup($input, $output, $questionHelper);
         $locale = $this->localeSetup->setup($input, $output, $questionHelper);
-        $country = $this->countrySetup->setup($input, $output, $questionHelper);
-        $zone = $this->zoneSetup->setup($country);
-        $this->channelSetup->setup($locale, $currency, $country, $zone, $input, $output, $questionHelper);
+
+        $country = null !== $this->countrySetup ? $this->countrySetup->setup($input, $output, $questionHelper) : null;
+        $zone = null !== $this->zoneSetup && null !== $country ? $this->zoneSetup->setup($country) : null;
+
+        $this->channelSetup->setup($locale, $currency, $country);
+
+        if (null !== $zone && null !== $this->channelDefaultTaxZoneSetup) {
+            $this->channelDefaultTaxZoneSetup->setup($zone, $input, $output, $questionHelper);
+        }
+
         $this->setupAdministratorUser($input, $output, $locale->getCode());
 
         return Command::SUCCESS;

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelDefaultTaxZoneSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelDefaultTaxZoneSetup.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Doctrine\Persistence\ObjectManager;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final readonly class ChannelDefaultTaxZoneSetup implements ChannelDefaultTaxZoneSetupInterface
+{
+    /**
+     * @param RepositoryInterface<ChannelInterface> $channelRepository
+     */
+    public function __construct(
+        private RepositoryInterface $channelRepository,
+        private ObjectManager $channelManager,
+    ) {
+    }
+
+    public function setup(
+        ZoneInterface $zone,
+        InputInterface $input,
+        OutputInterface $output,
+        QuestionHelper $questionHelper,
+    ): void {
+        /** @var ChannelInterface|null $channel */
+        $channel = $this->channelRepository->findOneBy([]);
+
+        if (null === $channel) {
+            return;
+        }
+
+        $question = new ConfirmationQuestion('Assign created zone as default tax zone? (yes/no) [no]: ', false);
+        if (!$questionHelper->ask($input, $output, $question)) {
+            return;
+        }
+
+        $channel->setDefaultTaxZone($zone);
+
+        $this->channelManager->flush();
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelDefaultTaxZoneSetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelDefaultTaxZoneSetupInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ChannelDefaultTaxZoneSetupInterface
+{
+    public function setup(
+        ZoneInterface $zone,
+        InputInterface $input,
+        OutputInterface $output,
+        QuestionHelper $questionHelper,
+    ): void;
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
@@ -15,16 +15,11 @@ namespace Sylius\Bundle\CoreBundle\Installer\Setup;
 
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Addressing\Model\CountryInterface;
-use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class ChannelSetup implements ChannelSetupInterface
 {
@@ -42,11 +37,7 @@ final class ChannelSetup implements ChannelSetupInterface
     public function setup(
         LocaleInterface $locale,
         CurrencyInterface $currency,
-        CountryInterface $country,
-        ZoneInterface $zone,
-        InputInterface $input,
-        OutputInterface $output,
-        QuestionHelper $questionHelper
+        ?CountryInterface $country = null,
     ): void {
         /** @var ChannelInterface|null $channel */
         $channel = $this->channelRepository->findOneBy([]);
@@ -65,11 +56,9 @@ final class ChannelSetup implements ChannelSetupInterface
         $channel->setBaseCurrency($currency);
         $channel->addLocale($locale);
         $channel->setDefaultLocale($locale);
-        $channel->addCountry($country);
 
-        $question = new ConfirmationQuestion('Assign created zone as default tax zone? (yes/no) [no]: ', false);
-        if ($questionHelper->ask($input, $output, $question)) {
-            $channel->setDefaultTaxZone($zone);
+        if (null !== $country) {
+            $channel->addCountry($country);
         }
 
         $this->channelManager->flush();

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
@@ -14,11 +14,17 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Installer\Setup;
 
 use Doctrine\Persistence\ObjectManager;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class ChannelSetup implements ChannelSetupInterface
 {
@@ -33,8 +39,15 @@ final class ChannelSetup implements ChannelSetupInterface
     ) {
     }
 
-    public function setup(LocaleInterface $locale, CurrencyInterface $currency): void
-    {
+    public function setup(
+        LocaleInterface $locale,
+        CurrencyInterface $currency,
+        CountryInterface $country,
+        ZoneInterface $zone,
+        InputInterface $input,
+        OutputInterface $output,
+        QuestionHelper $questionHelper
+    ): void {
         /** @var ChannelInterface|null $channel */
         $channel = $this->channelRepository->findOneBy([]);
 
@@ -52,6 +65,12 @@ final class ChannelSetup implements ChannelSetupInterface
         $channel->setBaseCurrency($currency);
         $channel->addLocale($locale);
         $channel->setDefaultLocale($locale);
+        $channel->addCountry($country);
+
+        $question = new ConfirmationQuestion('Assign created zone as default tax zone? (yes/no) [no]: ', false);
+        if ($questionHelper->ask($input, $output, $question)) {
+            $channel->setDefaultTaxZone($zone);
+        }
 
         $this->channelManager->flush();
     }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetupInterface.php
@@ -14,22 +14,14 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Installer\Setup;
 
 use Sylius\Component\Addressing\Model\CountryInterface;
-use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 interface ChannelSetupInterface
 {
     public function setup(
         LocaleInterface $locale,
         CurrencyInterface $currency,
-        CountryInterface $country,
-        ZoneInterface $zone,
-        InputInterface $input,
-        OutputInterface $output,
-        QuestionHelper $questionHelper
+        ?CountryInterface $country = null,
     ): void;
 }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CountrySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CountrySetup.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
+use Sylius\Resource\Factory\FactoryInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Intl\Countries;
+use Symfony\Component\Intl\Exception\MissingResourceException;
+
+final class CountrySetup implements CountrySetupInterface
+{
+    /**
+     * @param RepositoryInterface<CountryInterface> $countryRepository
+     * @param FactoryInterface<CountryInterface> $countryFactory
+     */
+    public function __construct(
+        private readonly RepositoryInterface $countryRepository,
+        private readonly FactoryInterface $countryFactory,
+        private string $country = 'US',
+    ) {
+        $this->country = trim($country);
+    }
+
+    public function setup(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): CountryInterface
+    {
+        $code = $this->getCountryCodeFromUser($input, $output, $questionHelper);
+
+        /** @var CountryInterface|null $existingCountry */
+        $existingCountry = $this->countryRepository->findOneBy(['code' => $code]);
+        if (null !== $existingCountry) {
+            return $existingCountry;
+        }
+
+        /** @var CountryInterface $country */
+        $country = $this->countryFactory->createNew();
+        $country->setCode($code);
+        $country->setEnabled(true);
+
+        $this->countryRepository->add($country);
+
+        return $country;
+    }
+
+    private function getCountryCodeFromUser(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): string
+    {
+        $code = $this->getNewCountryCode($input, $output, $questionHelper);
+        $name = $this->getCountryName($code);
+
+        while (null === $name) {
+            $output->writeln(
+                sprintf('<comment>Country with code <info>%s</info> could not be resolved.</comment>', $code),
+            );
+
+            $code = $this->getNewCountryCode($input, $output, $questionHelper);
+            $name = $this->getCountryName($code);
+        }
+
+        $output->writeln(sprintf('Adding <info>%s</info> country.', $name));
+
+        return $code;
+    }
+
+    private function getNewCountryCode(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): string
+    {
+        $question = new Question(sprintf('Country (press enter to use %s): ', $this->country), $this->country);
+
+        return strtoupper(trim($questionHelper->ask($input, $output, $question)));
+    }
+
+    private function getCountryName(string $code): ?string
+    {
+        try {
+            return Countries::getName($code);
+        } catch (MissingResourceException) {
+            return null;
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CountrySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CountrySetup.php
@@ -26,12 +26,12 @@ use Symfony\Component\Intl\Exception\MissingResourceException;
 final class CountrySetup implements CountrySetupInterface
 {
     /**
-     * @param RepositoryInterface<CountryInterface> $countryRepository
      * @param FactoryInterface<CountryInterface> $countryFactory
+     * @param RepositoryInterface<CountryInterface> $countryRepository
      */
     public function __construct(
-        private readonly RepositoryInterface $countryRepository,
         private readonly FactoryInterface $countryFactory,
+        private readonly RepositoryInterface $countryRepository,
         private string $country = 'US',
     ) {
         $this->country = trim($country);

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CountrySetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CountrySetupInterface.php
@@ -14,22 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Installer\Setup;
 
 use Sylius\Component\Addressing\Model\CountryInterface;
-use Sylius\Component\Addressing\Model\ZoneInterface;
-use Sylius\Component\Currency\Model\CurrencyInterface;
-use Sylius\Component\Locale\Model\LocaleInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-interface ChannelSetupInterface
+interface CountrySetupInterface
 {
-    public function setup(
-        LocaleInterface $locale,
-        CurrencyInterface $currency,
-        CountryInterface $country,
-        ZoneInterface $zone,
-        InputInterface $input,
-        OutputInterface $output,
-        QuestionHelper $questionHelper
-    ): void;
+    public function setup(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): CountryInterface;
 }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ZoneSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ZoneSetup.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Doctrine\Persistence\ObjectManager;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
+use Sylius\Resource\Factory\FactoryInterface;
+
+final readonly class ZoneSetup implements ZoneSetupInterface
+{
+    /**
+     * @param RepositoryInterface<ZoneInterface> $zoneRepository
+     * @param FactoryInterface<ZoneInterface> $zoneFactory
+     * @param FactoryInterface<ZoneMemberInterface> $zoneMemberFactory
+     */
+    public function __construct(
+        private RepositoryInterface $zoneRepository,
+        private FactoryInterface $zoneFactory,
+        private FactoryInterface $zoneMemberFactory,
+        private ObjectManager $zoneManager,
+    ) {
+    }
+
+    public function setup(CountryInterface $country): ZoneInterface
+    {
+        /** @var ZoneInterface|null $zone */
+        $zone = $this->zoneRepository->findOneBy([]);
+
+        if (null === $zone) {
+            /** @var ZoneInterface $zone */
+            $zone = $this->zoneFactory->createNew();
+            $zone->setCode('default');
+            $zone->setName('Default');
+            $zone->setType(ZoneInterface::TYPE_COUNTRY);
+
+            $this->zoneManager->persist($zone);
+        }
+
+        if (!$this->zoneHasMemberWithCode($zone, (string) $country->getCode())) {
+            /** @var ZoneMemberInterface $zoneMember */
+            $zoneMember = $this->zoneMemberFactory->createNew();
+            $zoneMember->setCode($country->getCode());
+
+            $zone->addMember($zoneMember);
+        }
+
+        $this->zoneManager->flush();
+
+        return $zone;
+    }
+
+    private function zoneHasMemberWithCode(ZoneInterface $zone, string $code): bool
+    {
+        foreach ($zone->getMembers() as $member) {
+            if ($member->getCode() === $code) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ZoneSetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ZoneSetupInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+
+interface ZoneSetupInterface
+{
+    public function setup(CountryInterface $country): ZoneInterface;
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/console_command.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/console_command.php
@@ -92,6 +92,8 @@ return static function (ContainerConfigurator $container) {
             service('sylius.setup.installer.currency'),
             service('sylius.setup.installer.locale'),
             service('sylius.setup.installer.channel'),
+            service('sylius.setup.installer.country'),
+            service('sylius.setup.installer.zone'),
             service('sylius.factory.admin_user'),
             service('sylius.repository.admin_user'),
             service('validator'),

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/console_command.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/console_command.php
@@ -92,11 +92,12 @@ return static function (ContainerConfigurator $container) {
             service('sylius.setup.installer.currency'),
             service('sylius.setup.installer.locale'),
             service('sylius.setup.installer.channel'),
-            service('sylius.setup.installer.country'),
-            service('sylius.setup.installer.zone'),
             service('sylius.factory.admin_user'),
             service('sylius.repository.admin_user'),
             service('validator'),
+            service('sylius.setup.installer.country'),
+            service('sylius.setup.installer.zone'),
+            service('sylius.setup.installer.channel_default_tax_zone'),
         ])
         ->tag('console.command')
     ;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.php
@@ -19,10 +19,14 @@ use Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProvider;
 use Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProviderInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetup;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetupInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetup;
+use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetup;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\LocaleSetup;
 use Sylius\Bundle\CoreBundle\Installer\Setup\LocaleSetupInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ZoneSetup;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ZoneSetupInterface;
 
 return static function (ContainerConfigurator $container) {
     $services = $container->services();
@@ -76,4 +80,24 @@ return static function (ContainerConfigurator $container) {
         ])
     ;
     $services->alias(ChannelSetupInterface::class, 'sylius.setup.installer.channel');
+
+    $services
+        ->set('sylius.setup.installer.country', CountrySetup::class)
+        ->args([
+            service('sylius.repository.country'),
+            service('sylius.factory.country'),
+        ])
+    ;
+    $services->alias(CountrySetupInterface::class, 'sylius.setup.installer.country');
+
+    $services
+        ->set('sylius.setup.installer.zone', ZoneSetup::class)
+        ->args([
+            service('sylius.repository.zone'),
+            service('sylius.factory.zone'),
+            service('sylius.factory.zone_member'),
+            service('sylius.manager.zone'),
+        ])
+    ;
+    $services->alias(ZoneSetupInterface::class, 'sylius.setup.installer.zone');
 };

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.php
@@ -17,6 +17,8 @@ use Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker;
 use Sylius\Bundle\CoreBundle\Installer\Checker\SyliusRequirementsChecker;
 use Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProvider;
 use Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProviderInterface;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelDefaultTaxZoneSetup;
+use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelDefaultTaxZoneSetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetup;
 use Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetupInterface;
 use Sylius\Bundle\CoreBundle\Installer\Setup\CountrySetup;
@@ -82,10 +84,19 @@ return static function (ContainerConfigurator $container) {
     $services->alias(ChannelSetupInterface::class, 'sylius.setup.installer.channel');
 
     $services
+        ->set('sylius.setup.installer.channel_default_tax_zone', ChannelDefaultTaxZoneSetup::class)
+        ->args([
+            service('sylius.repository.channel'),
+            service('sylius.manager.channel'),
+        ])
+    ;
+    $services->alias(ChannelDefaultTaxZoneSetupInterface::class, 'sylius.setup.installer.channel_default_tax_zone');
+
+    $services
         ->set('sylius.setup.installer.country', CountrySetup::class)
         ->args([
-            service('sylius.repository.country'),
             service('sylius.factory.country'),
+            service('sylius.repository.country'),
         ])
     ;
     $services->alias(CountrySetupInterface::class, 'sylius.setup.installer.country');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/10376
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now creates or reuses a country during setup (defaulting to **US**) and a default country zone, linking the zone to the country when needed.
  * Channel setup now associates the configured **country** and **zone**, and can optionally set the channel’s default tax zone via an interactive prompt.
  * Interactive installer/Behat flow includes default **country** and **zone** choices.
* **Documentation**
  * Updated upgrade notes to describe the new installer steps and the updated setup method requirements for custom implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->