### PR TITLE
Save removed promotion rules and actions to restore their configuration on re-add

### DIFF
--- a/features/admin/promotion/managing_promotions/restoring_removed_rules_and_actions.feature
+++ b/features/admin/promotion/managing_promotions/restoring_removed_rules_and_actions.feature
@@ -29,16 +29,14 @@ Feature: Restoring removed promotion rules and actions
         Given there is a promotion "Holiday sale" with priority 1
         And the promotion gives "$10.00" discount to every order with quantity at least 5
         When I want to modify a "Holiday sale" promotion
-        Then the rule quantity should be 5
-        And the action amount should be "10.00"
-        When I remove its last rule
+        And I remove its last rule
         And I remove its last action
         And I add a new rule
         And I add a new action
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And I want to modify a "Holiday sale" promotion
-        And the rule quantity should be 5
+        When I want to modify a "Holiday sale" promotion
+        Then the rule quantity should be 5
         And the action amount should be "10.00"
 
     @no-api @ui @mink:chromedriver

--- a/features/admin/promotion/managing_promotions/restoring_removed_rules_and_actions.feature
+++ b/features/admin/promotion/managing_promotions/restoring_removed_rules_and_actions.feature
@@ -1,0 +1,62 @@
+@managing_promotions
+Feature: Restoring removed promotion rules and actions
+    In order to not lose an already configured rule or action after removing it by mistake
+    As an Administrator
+    I want the previously entered configuration to be restored when I add back a rule or action of the same type
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And I am logged in as an administrator
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Restoring the configuration of a removed rule and action while creating a new promotion
+        When I want to create a new promotion
+        And I specify its code as "HOLIDAY_SALE"
+        And I name it "Holiday sale"
+        And I add a new rule with quantity 3
+        And I add the "Order fixed discount" action configured with amount of "$10.00" for "United States" channel
+        And I remove its last rule
+        And I remove its last action
+        And I add a new rule
+        And I add a new action
+        And I add it
+        Then the "Holiday sale" promotion should be successfully created
+        And the rule quantity should be 3
+        And the action amount should be "10.00"
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Restoring the configuration of a removed rule and action while editing an existing promotion
+        Given there is a promotion "Holiday sale" with priority 1
+        And the promotion gives "$10.00" discount to every order with quantity at least 5
+        When I want to modify a "Holiday sale" promotion
+        Then the rule quantity should be 5
+        And the action amount should be "10.00"
+        When I remove its last rule
+        And I remove its last action
+        And I add a new rule
+        And I add a new action
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And I want to modify a "Holiday sale" promotion
+        And the rule quantity should be 5
+        And the action amount should be "10.00"
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Restoring rules and actions of the same type in the last-in-first-out order
+        When I want to create a new promotion
+        And I specify its code as "LIFO_PROMOTION"
+        And I name it "LIFO promotion"
+        And I add a new rule with quantity 3
+        And I add a new rule with quantity 7
+        And I add the "Order fixed discount" action configured with amount of "$10.00" for "United States" channel
+        And I add the "Order fixed discount" action configured with amount of "$20.00" for "United States" channel
+        And I remove its last rule
+        And I remove its last rule
+        And I remove its last action
+        And I remove its last action
+        And I add a new rule
+        And I add a new action
+        And I add it
+        Then the "LIFO promotion" promotion should be successfully created
+        And the rule quantity should be 3
+        And the action amount should be "10.00"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -644,6 +644,13 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->addRule(CartQuantityRuleChecker::TYPE);
     }
 
+    #[When('I add a new rule with quantity :quantity')]
+    public function iAddANewRuleWithQuantity(int $quantity): void
+    {
+        $this->formElement->addRule(CartQuantityRuleChecker::TYPE);
+        $this->formElement->fillRuleOption('Count', (string) $quantity);
+    }
+
     #[When('I add a new action')]
     public function iAddANewAction(): void
     {
@@ -684,6 +691,18 @@ final class ManagingPromotionsContext implements Context
     public function itShouldHaveOfItemPercentageDiscount(string $amount, ChannelInterface $channel): void
     {
         Assert::same($this->updatePage->getItemPercentageDiscountActionValue($channel->getCode()), $amount);
+    }
+
+    #[Then('the rule quantity should be :quantity')]
+    public function theRuleQuantityShouldBe(int $quantity): void
+    {
+        Assert::same($this->formElement->getRuleCountValue(), (string) $quantity);
+    }
+
+    #[Then('the action amount should be :amount')]
+    public function theActionAmountShouldBe(string $amount): void
+    {
+        Assert::same($this->formElement->getActionAmountValue(), $amount);
     }
 
     #[Then('I should see the action configuration form')]

--- a/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
@@ -180,6 +180,16 @@ class FormElement extends BaseFormElement implements FormElementInterface
         $this->waitForFormUpdate();
     }
 
+    public function getRuleCountValue(): string
+    {
+        return $this->getElement('rule_count')->getValue();
+    }
+
+    public function getActionAmountValue(): string
+    {
+        return $this->getElement('action_amount')->getValue();
+    }
+
     public function checkIfRuleConfigurationFormIsVisible(): bool
     {
         return $this->hasElement('rule_count');

--- a/src/Sylius/Behat/Element/Admin/Promotion/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Promotion/FormElementInterface.php
@@ -53,6 +53,10 @@ interface FormElementInterface extends BaseFormElementInterface
 
     public function removeLastRule(): void;
 
+    public function getRuleCountValue(): string;
+
+    public function getActionAmountValue(): string;
+
     public function selectRuleOption(string $option, string $value, bool $multiple = false): void;
 
     public function fillRuleOption(string $option, string $value): void;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component.php
@@ -26,7 +26,6 @@ use Sylius\Bundle\AdminBundle\Form\Type\PaymentMethodType;
 use Sylius\Bundle\AdminBundle\Form\Type\ProductAssociationTypeType;
 use Sylius\Bundle\AdminBundle\Form\Type\ProductGenerateVariantsType;
 use Sylius\Bundle\AdminBundle\Form\Type\ProductReviewType;
-use Sylius\Bundle\AdminBundle\Form\Type\PromotionType;
 use Sylius\Bundle\AdminBundle\Form\Type\ShippingCategoryType;
 use Sylius\Bundle\AdminBundle\Form\Type\ShippingMethodType;
 use Sylius\Bundle\AdminBundle\Form\Type\TaxCategoryType;
@@ -181,17 +180,6 @@ return static function (ContainerConfigurator $container) {
             ProductReviewType::class,
         ])
         ->tag('sylius.live_component.admin', ['key' => 'sylius_admin:product_review:form'])
-    ;
-
-    $services
-        ->set('sylius_admin.twig.component.promotion.form', ResourceFormComponent::class)
-        ->args([
-            service('sylius.repository.promotion'),
-            service('form.factory'),
-            '%sylius.model.promotion.class%',
-            PromotionType::class,
-        ])
-        ->tag('sylius.live_component.admin', ['key' => 'sylius_admin:promotion:form'])
     ;
 
     $services

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component/promotion.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component/promotion.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Sylius\Bundle\AdminBundle\Form\Type\PromotionType;
+use Sylius\Bundle\AdminBundle\Twig\Component\Promotion\FormComponent;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services
+        ->set('sylius_admin.twig.component.promotion.form', FormComponent::class)
+        ->args([
+            service('sylius.repository.promotion'),
+            service('form.factory'),
+            '%sylius.model.promotion.class%',
+            PromotionType::class,
+        ])
+        ->tag('sylius.live_component.admin', ['key' => 'sylius_admin:promotion:form'])
+    ;
+};

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Promotion/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Promotion/FormComponent.php
@@ -26,6 +26,10 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 #[AsLiveComponent]
 class FormComponent
 {
+    private const RULES_PROPERTY_PATH = '[rules]';
+
+    private const ACTIONS_PROPERTY_PATH = '[actions]';
+
     use LiveCollectionTrait;
 
     /** @use ResourceFormComponentTrait<PromotionInterface> */
@@ -93,8 +97,8 @@ class FormComponent
     private function rememberDeletedItem(string $propertyPath, array $item): void
     {
         match ($propertyPath) {
-            '[rules]' => $this->deletedRules[$item['type']][] = $item,
-            '[actions]' => $this->deletedActions[$item['type']][] = $item,
+            self::RULES_PROPERTY_PATH => $this->deletedRules[$item['type']][] = $item,
+            self::ACTIONS_PROPERTY_PATH => $this->deletedActions[$item['type']][] = $item,
             default => null,
         };
     }
@@ -103,8 +107,8 @@ class FormComponent
     private function recallDeletedItem(string $propertyPath, string $type): ?array
     {
         return match ($propertyPath) {
-            '[rules]' => $this->popDeletedItem($this->deletedRules, $type),
-            '[actions]' => $this->popDeletedItem($this->deletedActions, $type),
+            self::RULES_PROPERTY_PATH => $this->popDeletedItem($this->deletedRules, $type),
+            self::ACTIONS_PROPERTY_PATH => $this->popDeletedItem($this->deletedActions, $type),
             default => null,
         };
     }

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Promotion/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Promotion/FormComponent.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Twig\Component\Promotion;
+
+use Sylius\Bundle\UiBundle\Twig\Component\LiveCollectionTrait;
+use Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponentTrait;
+use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
+use Sylius\Component\Core\Model\PromotionInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+
+#[AsLiveComponent]
+class FormComponent
+{
+    use LiveCollectionTrait;
+
+    /** @use ResourceFormComponentTrait<PromotionInterface> */
+    use ResourceFormComponentTrait {
+        initialize as public __construct;
+    }
+
+    use TemplatePropTrait;
+
+    /** @var array<string, list<array<string, mixed>>> */
+    #[LiveProp]
+    public array $deletedRules = [];
+
+    /** @var array<string, list<array<string, mixed>>> */
+    #[LiveProp]
+    public array $deletedActions = [];
+
+    #[LiveAction]
+    public function addCollectionItem(
+        PropertyAccessorInterface $propertyAccessor,
+        #[LiveArg]
+        string $name,
+        #[LiveArg]
+        ?string $type = null,
+    ): void {
+        $propertyPath = $this->fieldNameToPropertyPath($name, $this->formName);
+        $data = $propertyAccessor->getValue($this->formValues, $propertyPath);
+
+        if (!\is_array($data)) {
+            $propertyAccessor->setValue($this->formValues, $propertyPath, []);
+            $data = [];
+        }
+
+        $index = $this->provideNewCollectionItemIndex($data);
+        $item = null !== $type ? $this->recallDeletedItem($propertyPath, $type) : null;
+
+        $propertyAccessor->setValue(
+            $this->formValues,
+            sprintf('%s[%s]', $propertyPath, $index),
+            $item ?? (null === $type ? [] : ['type' => $type]),
+        );
+    }
+
+    #[LiveAction]
+    public function removeCollectionItem(
+        PropertyAccessorInterface $propertyAccessor,
+        #[LiveArg]
+        string $name,
+        #[LiveArg]
+        int|string $index,
+    ): void {
+        $propertyPath = $this->fieldNameToPropertyPath($name, $this->formName);
+        $data = $propertyAccessor->getValue($this->formValues, $propertyPath);
+
+        $removedItem = $data[$index] ?? null;
+        if (\is_array($removedItem) && isset($removedItem['type']) && \is_string($removedItem['type'])) {
+            $this->rememberDeletedItem($propertyPath, $removedItem);
+        }
+
+        unset($data[$index]);
+        $propertyAccessor->setValue($this->formValues, $propertyPath, $data);
+    }
+
+    /** @param array<string, mixed> $item */
+    private function rememberDeletedItem(string $propertyPath, array $item): void
+    {
+        match ($propertyPath) {
+            '[rules]' => $this->deletedRules[$item['type']][] = $item,
+            '[actions]' => $this->deletedActions[$item['type']][] = $item,
+            default => null,
+        };
+    }
+
+    /** @return array<string, mixed>|null */
+    private function recallDeletedItem(string $propertyPath, string $type): ?array
+    {
+        return match ($propertyPath) {
+            '[rules]' => $this->popDeletedItem($this->deletedRules, $type),
+            '[actions]' => $this->popDeletedItem($this->deletedActions, $type),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, list<array<string, mixed>>> $deletedItems
+     *
+     * @return array<string, mixed>|null
+     */
+    private function popDeletedItem(array &$deletedItems, string $type): ?array
+    {
+        if ([] === ($deletedItems[$type] ?? [])) {
+            return null;
+        }
+
+        $item = array_pop($deletedItems[$type]);
+
+        if ([] === $deletedItems[$type]) {
+            unset($deletedItems[$type]);
+        }
+
+        return $item;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Promotion/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Promotion/FormComponent.php
@@ -26,11 +26,11 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 #[AsLiveComponent]
 class FormComponent
 {
+    use LiveCollectionTrait;
+
     private const RULES_PROPERTY_PATH = '[rules]';
 
     private const ACTIONS_PROPERTY_PATH = '[actions]';
-
-    use LiveCollectionTrait;
 
     /** @use ResourceFormComponentTrait<PromotionInterface> */
     use ResourceFormComponentTrait {

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/form.html.twig
@@ -1,4 +1,4 @@
-{# Rendered with \Sylius\Bundle\AdminBundle\TwigComponent\Promotion\FormComponent #}
+{# Rendered with \Sylius\Bundle\AdminBundle\Twig\Component\Promotion\FormComponent #}
 
 {% form_theme form '@SyliusAdmin/promotion/form_theme.html.twig' %}
 

--- a/src/Sylius/Bundle/AdminBundle/tests/Twig/Component/Promotion/FormComponentTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Twig/Component/Promotion/FormComponentTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\AdminBundle\Twig\Component\Promotion;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Twig\Component\Promotion\FormComponent;
+use Sylius\Component\Core\Model\PromotionInterface;
+use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+final class FormComponentTest extends TestCase
+{
+    private const FORM_NAME = 'sylius_admin_promotion';
+
+    private MockObject&RepositoryInterface $repository;
+
+    private FormFactoryInterface&MockObject $formFactory;
+
+    private PropertyAccessorInterface $propertyAccessor;
+
+    private FormComponent $formComponent;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(RepositoryInterface::class);
+        $this->formFactory = $this->createMock(FormFactoryInterface::class);
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        $this->formComponent = new FormComponent(
+            $this->repository,
+            $this->formFactory,
+            PromotionInterface::class,
+            'promotion_form_type',
+        );
+        $this->formComponent->formName = self::FORM_NAME;
+    }
+
+    public function testItRestoresRuleConfigurationWhenTheSameTypeIsAddedAgainAfterRemoval(): void
+    {
+        $this->formComponent->formValues = [
+            'rules' => [
+                0 => ['type' => 'cart_quantity', 'configuration' => ['count' => 3]],
+            ],
+        ];
+
+        $this->formComponent->removeCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 0);
+
+        $this->assertSame([], $this->formComponent->formValues['rules']);
+        $this->assertSame(
+            [['type' => 'cart_quantity', 'configuration' => ['count' => 3]]],
+            $this->formComponent->deletedRules['cart_quantity'],
+        );
+
+        $this->formComponent->addCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 'cart_quantity');
+
+        $this->assertSame(
+            ['type' => 'cart_quantity', 'configuration' => ['count' => 3]],
+            $this->formComponent->formValues['rules'][0],
+        );
+        $this->assertArrayNotHasKey('cart_quantity', $this->formComponent->deletedRules);
+    }
+
+    public function testItRestoresActionConfigurationWhenTheSameTypeIsAddedAgainAfterRemoval(): void
+    {
+        $this->formComponent->formValues = [
+            'actions' => [
+                0 => ['type' => 'percentage_discount', 'configuration' => ['amount' => 0.1]],
+            ],
+        ];
+
+        $this->formComponent->removeCollectionItem($this->propertyAccessor, self::FORM_NAME . '[actions]', 0);
+        $this->formComponent->addCollectionItem($this->propertyAccessor, self::FORM_NAME . '[actions]', 'percentage_discount');
+
+        $this->assertSame(
+            ['type' => 'percentage_discount', 'configuration' => ['amount' => 0.1]],
+            $this->formComponent->formValues['actions'][0],
+        );
+        $this->assertArrayNotHasKey('percentage_discount', $this->formComponent->deletedActions);
+    }
+
+    public function testItAddsAnEmptyRuleWhenNoMatchingRemovedRuleExistsForTheGivenType(): void
+    {
+        $this->formComponent->formValues = ['rules' => []];
+
+        $this->formComponent->addCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 'cart_quantity');
+
+        $this->assertSame(['type' => 'cart_quantity'], $this->formComponent->formValues['rules'][0]);
+    }
+
+    public function testItDoesNotMixUpDeletedRulesAndDeletedActionsOfTheSameType(): void
+    {
+        $this->formComponent->formValues = [
+            'rules' => [0 => ['type' => 'cart_quantity', 'configuration' => ['count' => 3]]],
+            'actions' => [0 => ['type' => 'cart_quantity', 'configuration' => ['amount' => 0.1]]],
+        ];
+
+        $this->formComponent->removeCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 0);
+        $this->formComponent->removeCollectionItem($this->propertyAccessor, self::FORM_NAME . '[actions]', 0);
+
+        $this->formComponent->addCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 'cart_quantity');
+
+        $this->assertSame(
+            ['type' => 'cart_quantity', 'configuration' => ['count' => 3]],
+            $this->formComponent->formValues['rules'][0],
+        );
+        $this->assertSame(
+            [['type' => 'cart_quantity', 'configuration' => ['amount' => 0.1]]],
+            $this->formComponent->deletedActions['cart_quantity'],
+        );
+    }
+
+    public function testItRestoresEachRemovedRuleOfTheSameTypeInReverseOrderOfRemoval(): void
+    {
+        $this->formComponent->formValues = [
+            'rules' => [
+                0 => ['type' => 'cart_quantity', 'configuration' => ['count' => 3]],
+                1 => ['type' => 'cart_quantity', 'configuration' => ['count' => 5]],
+            ],
+        ];
+
+        $this->formComponent->removeCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 0);
+        $this->formComponent->removeCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 1);
+
+        $this->assertSame(
+            [
+                ['type' => 'cart_quantity', 'configuration' => ['count' => 3]],
+                ['type' => 'cart_quantity', 'configuration' => ['count' => 5]],
+            ],
+            $this->formComponent->deletedRules['cart_quantity'],
+        );
+
+        $this->formComponent->addCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 'cart_quantity');
+
+        $this->assertSame(
+            ['type' => 'cart_quantity', 'configuration' => ['count' => 5]],
+            $this->formComponent->formValues['rules'][0],
+        );
+        $this->assertSame(
+            [['type' => 'cart_quantity', 'configuration' => ['count' => 3]]],
+            $this->formComponent->deletedRules['cart_quantity'],
+        );
+
+        $this->formComponent->addCollectionItem($this->propertyAccessor, self::FORM_NAME . '[rules]', 'cart_quantity');
+
+        $this->assertSame(
+            ['type' => 'cart_quantity', 'configuration' => ['count' => 3]],
+            $this->formComponent->formValues['rules'][1],
+        );
+        $this->assertArrayNotHasKey('cart_quantity', $this->formComponent->deletedRules);
+    }
+}


### PR DESCRIPTION

| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/10413
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

  Previously, the promotion form used the generic `ResourceFormComponent`.                                                                                                                                
  Removing a rule or action from the collection and then adding a new item                                                                                                                                
  of the same type lost the original configuration — the item reappeared                                                                                                                                  
  empty instead of restoring what the user had entered before.                                                                                                                                            
                                                                                                                                                                                                          
  This PR introduces a dedicated `Sylius\Bundle\AdminBundle\Twig\Component\Promotion\FormComponent`                                                                                                       
  that remembers removed rule/action items by type (`$deletedRules`,                                                                                                                                      
  `$deletedActions`) and restores the configuration when an item of the same                                                                                                                              
  type is added back. Removed items of the same type are stored as a                                                                                                                                      
  per-type stack, so removing/re-adding several items of the same type                                                                                                                                    
  restores them in reverse (LIFO) order without collisions between rules                                                                                                                                  
  and actions sharing the same type key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotion forms in the admin now support adding and removing rule/action items more smoothly.
  * Previously removed items of the same type can be restored when re-added.

* **Bug Fixes**
  * Improved handling so deleted rules and actions are kept separate.
  * Re-adding items now restores them in the expected order and clears old removed-item state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->