### PR TITLE
[Fix] [2.2] [AdminBundle] [UX] Compute shipment tracking placeholder width dynamically

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shipment/component/ship.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipment/component/ship.html.twig
@@ -5,12 +5,14 @@
 {% set path = path|default('sylius_admin_shipment_ship') %}
 {% set path_parameters = path_parameters|default({id: resource.id}) %}
 
+{% set tracking_placeholder = 'sylius.ui.tracking_code'|trans ~ '...' %}
+
 {% if sylius_sm_can(resource, 'sylius_shipment', 'ship') %}
     <div {{ attributes }}>
         {{ form_start(form, {'action': path(path, path_parameters), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
         <input type="hidden" name="_method" value="PUT">
         <div class="input-group flex-nowrap">
-            {{ form_widget(form.tracking, sylius_test_form_attribute('shipment-tracking')|sylius_merge_recursive({'attr': {'placeholder': 'sylius.ui.tracking_code'|trans ~ '...', 'style': 'min-width: 130px;'}})) }}
+            {{ form_widget(form.tracking, sylius_test_form_attribute('shipment-tracking')|sylius_merge_recursive({'attr': {'placeholder': tracking_placeholder, 'style': 'min-width: max(130px, ' ~ tracking_placeholder|length ~ 'ch)'}})) }}
             <button type="submit" class="btn" {{ sylius_test_html_attribute('shipment-ship-button') }}>
                 {{ ux_icon('tabler:truck') }}
                 {{ 'sylius.ui.ship'|trans }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #19103 
| License         | MIT

**Description**

This PR fixes the issue described in #19103.

With this PR, the `min-width` of the tracking code input field will be now dynamically calculated based on the length of the translated string.

## Demo
### Englisch
#### Shipments Grid
<img width="1878" height="104" alt="image" src="https://github.com/user-attachments/assets/d966d81a-d031-4c67-bb65-20d1478e7e79" />


#### Order Details
<img width="1412" height="158" alt="image" src="https://github.com/user-attachments/assets/730aa1d2-7704-4490-bb0a-7b69a2d94bf3" />

### German
#### Shipments Grid
<img width="1888" height="102" alt="image" src="https://github.com/user-attachments/assets/36ea5cfe-630d-4b66-af28-7686ec0f5001" />

#### Order Details
<img width="1409" height="162" alt="image" src="https://github.com/user-attachments/assets/a5beb552-f2c1-407d-9c1d-89c4d4856dd4" />

