### PR TITLE
[Composer] Conflict with api-platform/symfony 4.3.16

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -22,3 +22,13 @@ This document explains why certain conflicts were added to `composer.json` and r
   first missing constructor argument to be reported instead of all of them.
 
   References: https://github.com/api-platform/core/pull/7779
+
+- `api-platform/symfony:4.3.16`:
+
+  This version registers the `api_platform.openapi.name_converter` service as a child of
+  `serializer.name_converter.metadata_aware.abstract`, which does not exist on Symfony 6.4. Container compilation then
+  fails in `ResolveChildDefinitionsPass` with *Parent definition "serializer.name_converter.metadata_aware.abstract" does
+  not exist*, so the application cannot boot and every `bin/console` command and the whole test suite break.
+  The conflict is temporary and keeps the integration on 4.3.15 until a fixed `api-platform/symfony` release is tagged.
+
+  References: https://github.com/api-platform/core/pull/8386

--- a/composer.json
+++ b/composer.json
@@ -240,6 +240,7 @@
     },
     "conflict": {
         "api-platform/serializer": "4.2.17",
+        "api-platform/symfony": "4.3.16",
         "doctrine/orm": "2.20.7 || 3.5.3",
         "symfony/ux-live-component": "2.28.0 || 2.28.1"
     },

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -33,6 +33,9 @@
         "sylius/payum-bundle": "^2.0",
         "symfony/messenger": "^6.4 || ^7.4"
     },
+    "conflict": {
+        "api-platform/symfony": "4.3.16"
+    },
     "require-dev": {
         "ext-sqlite3": "*",
         "matthiasnoback/symfony-config-test": "^6.0",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/api-platform/core/pull/8386
| License         | MIT

Conflict with api-platform/symfony:4.3.16, it registers `api_platform.openapi.name_converter` under a non-existent Symfony 6.4 parent service, breaking container compilation. Temporary until a fixed release is tagged.

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
