### PR TITLE
Fix infinity loop on taxon edit form

### DIFF
--- a/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_via_api.feature
+++ b/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_via_api.feature
@@ -1,0 +1,45 @@
+@managing_taxons
+Feature: Preventing circular parent reference via API when updating a taxon
+    In order to maintain a valid taxon tree structure
+    As an API client
+    I want to be prevented from setting a taxon or its descendants as its parent via API
+
+    Background:
+        Given the store is available in "English (United States)"
+        And the store has "Category" taxonomy
+        And the "Category" taxon has children taxon "Clothing" and "Books"
+        And the "Clothing" taxon has children taxon "T-Shirts" and "Jeans"
+        And the "T-Shirts" taxon has children taxon "Men" and "Women"
+        And I am logged in as an administrator
+
+    @api
+    Scenario: Trying to set a child taxon as parent via API
+        When I want to modify the "Clothing" taxon
+        And I try to change its parent taxon to "T-Shirts"
+        And I try to save my changes
+        Then I should be notified that the parent relation is invalid
+        And this taxon should still belongs to "Category"
+
+    @api
+    Scenario: Trying to set a grandchild taxon as parent via API
+        When I want to modify the "Clothing" taxon
+        And I try to change its parent taxon to "Men"
+        And I try to save my changes
+        Then I should be notified that the parent relation is invalid
+        And this taxon should still belongs to "Category"
+
+    @api
+    Scenario: Successfully changing parent to a valid taxon via API
+        When I want to modify the "Clothing" taxon
+        And I change its parent taxon to "Books"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this taxon should belongs to "Books"
+
+    @api
+    Scenario: Successfully setting a sibling as parent via API
+        When I want to modify the "T-Shirts" taxon
+        And I change its parent taxon to "Jeans"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this taxon should belongs to "Jeans"

--- a/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_via_api.feature
+++ b/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_via_api.feature
@@ -1,7 +1,7 @@
 @managing_taxons
 Feature: Preventing circular parent reference via API when updating a taxon
     In order to maintain a valid taxon tree structure
-    As an API client
+    As an Administrator
     I want to be prevented from setting a taxon or its descendants as its parent via API
 
     Background:
@@ -12,34 +12,34 @@ Feature: Preventing circular parent reference via API when updating a taxon
         And the "T-Shirts" taxon has children taxon "Men" and "Women"
         And I am logged in as an administrator
 
-    @api
-    Scenario: Trying to set a child taxon as parent via API
+    @api @no-ui
+    Scenario: Trying to set a child taxon as parent
         When I want to modify the "Clothing" taxon
         And I try to change its parent taxon to "T-Shirts"
         And I try to save my changes
         Then I should be notified that the parent relation is invalid
-        And this taxon should still belongs to "Category"
+        And this taxon should still belong to "Category"
 
-    @api
-    Scenario: Trying to set a grandchild taxon as parent via API
+    @api @no-ui
+    Scenario: Trying to set a grandchild taxon as parent
         When I want to modify the "Clothing" taxon
         And I try to change its parent taxon to "Men"
         And I try to save my changes
         Then I should be notified that the parent relation is invalid
-        And this taxon should still belongs to "Category"
+        And this taxon should still belong to "Category"
 
-    @api
-    Scenario: Successfully changing parent to a valid taxon via API
+    @api @no-ui
+    Scenario: Successfully changing parent to a valid taxon
         When I want to modify the "Clothing" taxon
         And I change its parent taxon to "Books"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And this taxon should belongs to "Books"
+        And this taxon should belong to "Books"
 
-    @api
-    Scenario: Successfully setting a sibling as parent via API
+    @api @no-ui
+    Scenario: Successfully setting a sibling as parent
         When I want to modify the "T-Shirts" taxon
         And I change its parent taxon to "Jeans"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And this taxon should belongs to "Jeans"
+        And this taxon should belong to "Jeans"

--- a/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_when_editing_taxon.feature
+++ b/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_when_editing_taxon.feature
@@ -12,43 +12,43 @@ Feature: Preventing circular parent reference when editing a taxon
         And the "T-Shirts" taxon has children taxon "Men" and "Women"
         And I am logged in as an administrator
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: A taxon cannot be set as its own parent
         When I want to modify the "Clothing" taxon
         And I try to search for "Clothing" in the parent taxon autocomplete
         Then I should not see "Clothing" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: A child taxon cannot be set as parent of its ancestor
         When I want to modify the "Clothing" taxon
         And I try to search for "T-Shirts" in the parent taxon autocomplete
         Then I should not see "T-Shirts" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: A grandchild taxon cannot be set as parent of its ancestor
         When I want to modify the "Clothing" taxon
         And I try to search for "Men" in the parent taxon autocomplete
         Then I should not see "Men" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: All descendants are excluded from parent selection
         When I want to modify the "Clothing" taxon
         And I try to search for "Jeans" in the parent taxon autocomplete
         Then I should not see "Jeans" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: Sibling taxons can be selected as parent
         When I want to modify the "Clothing" taxon
         And I try to search for "Books" in the parent taxon autocomplete
         Then I should see "Books" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: Taxons from different branches can be selected as parent
         When I want to modify the "Clothing" taxon
         And I try to search for "Category" in the parent taxon autocomplete
         Then I should see "Category" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: A leaf taxon excludes only itself from parent selection
         When I want to modify the "Men" taxon
         And I try to search for "Men" in the parent taxon autocomplete
@@ -58,10 +58,10 @@ Feature: Preventing circular parent reference when editing a taxon
         And I try to search for "T-Shirts" in the parent taxon autocomplete
         And I should see "T-Shirts" in the parent taxon autocomplete results
 
-    @ui @mink:chromedriver
+    @no-api @ui @mink:chromedriver
     Scenario: Successfully changing parent to a valid taxon (not itself or descendant)
         When I want to modify the "Clothing" taxon
         And I change its parent taxon to "Books"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And this taxon should belongs to "Books"
+        And this taxon should belong to "Books"

--- a/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_when_editing_taxon.feature
+++ b/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_when_editing_taxon.feature
@@ -1,0 +1,67 @@
+@managing_taxons
+Feature: Preventing circular parent reference when editing a taxon
+    In order to maintain a valid taxon tree structure
+    As an Administrator
+    I want to be prevented from setting a taxon or its descendants as its parent
+
+    Background:
+        Given the store is available in "English (United States)"
+        And the store has "Category" taxonomy
+        And the "Category" taxon has children taxon "Clothing" and "Books"
+        And the "Clothing" taxon has children taxon "T-Shirts" and "Jeans"
+        And the "T-Shirts" taxon has children taxon "Men" and "Women"
+        And I am logged in as an administrator
+
+    @ui @mink:chromedriver
+    Scenario: A taxon cannot be set as its own parent
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Clothing" in the parent taxon autocomplete
+        Then I should not see "Clothing" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: A child taxon cannot be set as parent of its ancestor
+        When I want to modify the "Clothing" taxon
+        And I try to search for "T-Shirts" in the parent taxon autocomplete
+        Then I should not see "T-Shirts" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: A grandchild taxon cannot be set as parent of its ancestor
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Men" in the parent taxon autocomplete
+        Then I should not see "Men" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: All descendants are excluded from parent selection
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Jeans" in the parent taxon autocomplete
+        Then I should not see "Jeans" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: Sibling taxons can be selected as parent
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Books" in the parent taxon autocomplete
+        Then I should see "Books" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: Taxons from different branches can be selected as parent
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Category" in the parent taxon autocomplete
+        Then I should see "Category" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: A leaf taxon excludes only itself from parent selection
+        When I want to modify the "Men" taxon
+        And I try to search for "Men" in the parent taxon autocomplete
+        Then I should not see "Men" in the parent taxon autocomplete results
+        And I try to search for "Women" in the parent taxon autocomplete
+        And I should see "Women" in the parent taxon autocomplete results
+        And I try to search for "T-Shirts" in the parent taxon autocomplete
+        And I should see "T-Shirts" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: Successfully changing parent to a valid taxon (not itself or descendant)
+        When I want to modify the "Clothing" taxon
+        And I change its parent taxon to "Books"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this taxon should belongs to "Books"

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Admin\Helper\ValidationTrait;
@@ -37,34 +39,26 @@ final readonly class ManagingTaxonsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to see all taxons in store
-     */
+    #[When('I want to see all taxons in store')]
     public function iWantToSeeAllTaxonsInStore(): void
     {
         $this->client->index(Resources::TAXONS);
     }
 
-    /**
-     * @When I want to create a new taxon
-     */
+    #[When('I want to create a new taxon')]
     public function iWantToCreateNewTaxon(): void
     {
         $this->client->buildCreateRequest(Resources::TAXONS);
     }
 
-    /**
-     * @When I want to create a new taxon for :parentTaxon
-     */
+    #[When('I want to create a new taxon for :parentTaxon')]
     public function iWantToCreateANewTaxonForParent(TaxonInterface $parentTaxon): void
     {
         $this->iWantToCreateNewTaxon();
         $this->iSetItsParentTaxonTo($parentTaxon);
     }
 
-    /**
-     * @When I want to modify the :taxon taxon
-     */
+    #[When('I want to modify the :taxon taxon')]
     public function iWantToModifyATaxon(TaxonInterface $taxon): void
     {
         $this->sharedStorage->set('taxon', $taxon);
@@ -72,10 +66,8 @@ final readonly class ManagingTaxonsContext implements Context
         $this->client->buildUpdateRequest(Resources::TAXONS, $taxon->getCode());
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         if ($code !== null) {
@@ -83,71 +75,56 @@ final readonly class ManagingTaxonsContext implements Context
         }
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I rename it to :name in :localeCode
-     * @When I do not specify its name
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I rename it to :name in :localeCode')]
+    #[When('I do not specify its name')]
     public function iNameItIn(?string $name = null, string $localeCode = 'en_US'): void
     {
         $this->updateTranslations($localeCode, 'name', $name);
     }
 
-    /**
-     * @When I set its slug to :slug in :localeCode
-     */
+    #[When('I set its slug to :slug in :localeCode')]
     public function iSetItsSlugTo(string $slug, string $localeCode): void
     {
         $this->updateTranslations($localeCode, 'slug', $slug);
     }
 
-    /**
-     * @When I generate its slug in :localeCode
-     */
+    #[When('I generate its slug in :localeCode')]
     public function iGenerateItsSlugIn(string $localeCode): void
     {
         $this->updateTranslations($localeCode, 'slug', '');
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     * @When I change its description to :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
+    #[When('I change its description to :description in :localeCode')]
     public function iDescribeItAsIn(string $description, string $localeCode): void
     {
         $this->updateTranslations($localeCode, 'description', $description);
     }
 
-    /**
-     * @When I set its parent taxon to :parentTaxon
-     * @When I change its parent taxon to :parentTaxon
-     */
+    #[When('I set its parent taxon to :parentTaxon')]
+    #[When('I change its parent taxon to :parentTaxon')]
+    #[When('I try to change its parent taxon to :parentTaxon')]
     public function iSetItsParentTaxonTo(TaxonInterface $parentTaxon): void
     {
         $this->client->addRequestData('parent', $this->iriConverter->getIriFromResourceInSection($parentTaxon, 'admin'));
     }
 
-    /**
-     * @When /^I (enable|disable) it$/
-     */
+    #[When('/^I (enable|disable) it$/')]
     public function iEnableIt(string $toggleAction): void
     {
         $this->client->addRequestData('enabled', $toggleAction === 'enable');
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I remove taxon named :name
-     * @When I delete taxon named :name
-     * @When I try to delete taxon named :name
-     */
+    #[When('I remove taxon named :name')]
+    #[When('I delete taxon named :name')]
+    #[When('I try to delete taxon named :name')]
     public function iRemoveTaxonNamed(string $name): void
     {
         $code = StringInflector::nameToLowercaseCode($name);
@@ -155,9 +132,7 @@ final readonly class ManagingTaxonsContext implements Context
         $this->client->delete(Resources::TAXONS, $code);
     }
 
-    /**
-     * @When I move down :taxonName taxon
-     */
+    #[When('I move down :taxonName taxon')]
     public function iMoveDownTaxon(string $taxonName): void
     {
         $lastResponse = $this->client->getLastResponse();
@@ -172,9 +147,7 @@ final readonly class ManagingTaxonsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -183,9 +156,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the taxon named :name in the list
-     */
+    #[Then('I should see the taxon named :name in the list')]
     public function iShouldSeeTheTaxonNamedInTheList(string $name): void
     {
         $code = StringInflector::nameToLowercaseCode($name);
@@ -195,10 +166,8 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^taxon named "([^"]+)" should not be added$/
-     * @Then the taxon named :name should no longer exist in the registry
-     */
+    #[Then('/^taxon named "([^"]+)" should not be added$/')]
+    #[Then('the taxon named :name should no longer exist in the registry')]
     public function taxonNamedShouldNotBeAdded(string $name): void
     {
         $code = StringInflector::nameToLowercaseCode($name);
@@ -208,9 +177,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the ("[^"]+" taxon) should appear in the registry$/
-     */
+    #[Then('/^the ("[^"]+" taxon) should appear in the registry$/')]
     public function theTaxonShouldAppearInTheRegistry(TaxonInterface $taxon): void
     {
         Assert::true(
@@ -220,9 +187,7 @@ final readonly class ManagingTaxonsContext implements Context
         $this->sharedStorage->set('taxon', $taxon);
     }
 
-    /**
-     * @Then I should be notified that I cannot delete a menu taxon of any channel
-     */
+    #[Then('I should be notified that I cannot delete a menu taxon of any channel')]
     public function iShouldBeNotifiedThatICannotDeleteAMenuTaxonOfAnyChannel(): void
     {
         $lastResponse = $this->client->getLastResponse();
@@ -230,9 +195,7 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::false($this->responseChecker->isDeletionSuccessful($lastResponse));
     }
 
-    /**
-     * @Then /^(it) should not belong to any other taxon$/
-     */
+    #[Then('/^(it) should not belong to any other taxon$/')]
     public function itShouldNotBelongToAnyOtherTaxon(TaxonInterface $taxon): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -244,9 +207,8 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this taxon) should (belongs to "[^"]+")$/
-     */
+    #[Then('/^(this taxon) should (belongs to "[^"]+")$/')]
+    #[Then('/^(this taxon) should still (belongs to "[^"]+")$/')]
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon, TaxonInterface $parentTaxon): void
     {
         $this->iWantToSeeAllTaxonsInStore();
@@ -260,34 +222,26 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see :count taxons on the list
-     */
+    #[Then('I should see :count taxons on the list')]
     public function iShouldSeeTaxonsInTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then this taxon :field should be :value
-     * @Then this taxon should have :field :value in :localeCode
-     */
+    #[Then('this taxon :field should be :value')]
+    #[Then('this taxon should have :field :value in :localeCode')]
     public function thisTaxonFieldShouldBe(string $field, string $value, string $localeCode = 'en_US'): void
     {
         Assert::true($this->responseChecker->hasTranslation($this->client->getLastResponse(), $localeCode, $field, $value));
     }
 
-    /**
-     * @Then the :field of the :taxonName taxon should( still) be :value
-     */
+    #[Then('the :field of the :taxonName taxon should( still) be :value')]
     public function theFieldOfTheTaxonShouldStillBe(string $field, string $taxonName, string $value): void
     {
         $this->thisTaxonFieldShouldBe($field, $value);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -298,9 +252,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(it) should be (enabled|disabled)$/
-     */
+    #[Then('/^(it) should be (enabled|disabled)$/')]
     public function itShouldBeDisabled(TaxonInterface $taxon, string $enabled): void
     {
         Assert::true($this->responseChecker->hasValue(
@@ -310,9 +262,7 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that :field is required
-     */
+    #[Then('I should be notified that :field is required')]
     public function iShouldBeNotifiedThatFieldIsRequired(string $field): void
     {
         Assert::contains(
@@ -321,9 +271,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that taxon slug must be unique
-     */
+    #[Then('I should be notified that taxon slug must be unique')]
     public function iShouldBeNotifiedThatTaxonSlugMustBeUnique(): void
     {
         Assert::contains(
@@ -332,9 +280,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that taxon with this code already exists
-     */
+    #[Then('I should be notified that taxon with this code already exists')]
     public function iShouldBeNotifiedThatTaxonWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -343,9 +289,16 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one taxon with code :code
-     */
+    #[Then('I should be notified that the parent relation is invalid')]
+    public function iShouldBeNotifiedThatTheParentRelationIsInvalid(): void
+    {
+        Assert::contains(
+            $this->responseChecker->getError($this->client->getLastResponse()),
+            'parent: Parent must neither be the taxon itself nor any of its descendants',
+        );
+    }
+
+    #[Then('there should still be only one taxon with code :code')]
     public function thereShouldStillBeOnlyOneTaxonWithCode(string $code): void
     {
         Assert::count(
@@ -355,9 +308,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then the product :product should no longer have a main taxon
-     */
+    #[Then('the product :product should no longer have a main taxon')]
     public function theProductShouldNoLongerHaveAMainTaxon(ProductInterface $product): void
     {
         Assert::null($product->getMainTaxon());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
@@ -207,8 +207,8 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    #[Then('/^(this taxon) should (belongs to "[^"]+")$/')]
-    #[Then('/^(this taxon) should still (belongs to "[^"]+")$/')]
+    #[Then('/^(this taxon) should (belongs? to "[^"]+")$/')]
+    #[Then('/^(this taxon) should still (belongs? to "[^"]+")$/')]
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon, TaxonInterface $parentTaxon): void
     {
         $this->iWantToSeeAllTaxonsInStore();

--- a/src/Sylius/Behat/Context/Transform/TaxonContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxonContext.php
@@ -28,7 +28,7 @@ final class TaxonContext implements Context
 
     /**
      * @Transform /^classified as "([^"]+)"$/
-     * @Transform /^belongs to "([^"]+)"$/
+     * @Transform /^belongs? to "([^"]+)"$/
      * @Transform /^"([^"]+)" taxon$/
      * @Transform /^"([^"]+)" as a parent taxon$/
      * @Transform /^"([^"]+)" parent taxon$/

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
 use Behat\Step\When;
 use Sylius\Behat\Element\Admin\Product\TaxonomyFormElementInterface;
 use Sylius\Behat\Element\Admin\Taxon\FormElementInterface;
@@ -278,7 +279,7 @@ final readonly class ManagingTaxonsContext implements Context
      */
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon): void
     {
-        Assert::same($this->formElement->getParent(), $taxon->getName());
+        Assert::same($this->formElement->getParent(), $taxon->getFullname());
     }
 
     /**
@@ -518,5 +519,54 @@ final readonly class ManagingTaxonsContext implements Context
                 implode(', ', $autocompleteSearchResults),
             ),
         );
+    }
+
+    #[When('I try to search for :taxonName in the parent taxon autocomplete')]
+    public function iTryToSearchForInTheParentTaxonAutocomplete(string $taxonName): void
+    {
+        $this->sharedStorage->set('autocomplete_search_results', $this->formElement->searchInParentAutocomplete($taxonName));
+    }
+
+    #[Then('I should see :taxonName in the parent taxon autocomplete results')]
+    public function iShouldSeeInTheParentTaxonAutocompleteResults(string $taxonName): void
+    {
+        /** @var array<string, string> $results */
+        $results = $this->sharedStorage->get('autocomplete_search_results');
+
+        $found = false;
+        foreach ($results as $name) {
+            if (str_contains($name, $taxonName)) {
+                $found = true;
+
+                break;
+            }
+        }
+
+        Assert::true($found, sprintf('Expected to find "%s" in autocomplete results, but it was not found.', $taxonName));
+    }
+
+    #[Then('I should not see :taxonName in the parent taxon autocomplete results')]
+    public function iShouldNotSeeInTheParentTaxonAutocompleteResults(string $taxonName): void
+    {
+        /** @var array<string, string> $results */
+        $results = $this->sharedStorage->get('autocomplete_search_results');
+
+        $found = false;
+        foreach ($results as $name) {
+            if (str_contains($name, $taxonName)) {
+                $found = true;
+
+                break;
+            }
+        }
+
+        Assert::false($found, sprintf('Expected not to find "%s" in autocomplete results, but it was found.', $taxonName));
+    }
+
+    #[Then('I should be able to search for other taxons in the parent autocomplete')]
+    public function iShouldBeAbleToSearchForOtherTaxonsInTheParentAutocomplete(): void
+    {
+        $results = $this->formElement->searchInParentAutocomplete('');
+        Assert::notEmpty($results, 'Expected to find some taxons in the autocomplete, but none were found.');
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -275,7 +275,7 @@ final readonly class ManagingTaxonsContext implements Context
     }
 
     /**
-     * @Then /^this taxon should (belongs to "[^"]+")$/
+     * @Then /^this taxon should (belongs? to "[^"]+")$/
      */
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon): void
     {

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
@@ -28,6 +28,8 @@ class FormElement extends BaseFormElement implements FormElementInterface
     use ChecksCodeImmutability;
     use SpecifiesItsField;
 
+    private const TOM_SELECT_INITIALIZATION_TIMEOUT = 5000;
+
     public function __construct(
         Session $session,
         array|MinkParameters $minkParameters,
@@ -84,9 +86,11 @@ class FormElement extends BaseFormElement implements FormElementInterface
 
     public function chooseParent(TaxonInterface $taxon): void
     {
+        $parentElement = $this->waitForParentTomSelectInitialization();
+
         $this->autocompleteHelper->selectByName(
             $this->getDriver(),
-            $this->getElement('parent')->getXpath(),
+            $parentElement->getXpath(),
             $taxon->getName(),
         );
         $this->waitForFormUpdate();
@@ -94,8 +98,28 @@ class FormElement extends BaseFormElement implements FormElementInterface
 
     public function removeCurrentParent(): void
     {
-        $this->autocompleteHelper->clear($this->getDriver(), $this->getElement('parent')->getXpath());
+        $parentElement = $this->waitForParentTomSelectInitialization();
+
+        $this->autocompleteHelper->clear($this->getDriver(), $parentElement->getXpath());
         $this->waitForFormUpdate();
+    }
+
+    public function searchInParentAutocomplete(string $searchString): array
+    {
+        $parentElement = $this->waitForParentTomSelectInitialization();
+
+        $searchResults = $this->autocompleteHelper->search(
+            $this->getDriver(),
+            $parentElement->getXpath(),
+            $searchString,
+        );
+
+        return is_array($searchResults) ? $searchResults : [];
+    }
+
+    public function searchParentTaxon(string $searchTerm): array
+    {
+        return array_values($this->searchInParentAutocomplete($searchTerm));
     }
 
     public function getTranslationFieldValue(string $element, string $localeCode): string
@@ -155,16 +179,19 @@ class FormElement extends BaseFormElement implements FormElementInterface
         $translationAccordion->click();
     }
 
-    public function searchParentTaxon(string $searchTerm): array
+    private function waitForParentTomSelectInitialization(): NodeElement
     {
         DriverHelper::waitForPageToLoad($this->getSession());
 
-        $searchResults = $this->autocompleteHelper->search(
-            $this->getDriver(),
-            $this->getElement('parent')->getXpath(),
-            $searchTerm,
+        $initialized = $this->getSession()->wait(
+            self::TOM_SELECT_INITIALIZATION_TIMEOUT,
+            sprintf("document.querySelector('%s')?.tomselect !== undefined", $this->getDefinedElements()['parent']),
         );
 
-        return is_array($searchResults) ? array_values($searchResults) : [];
+        if (!$initialized) {
+            throw new \RuntimeException('Tom Select has not been initialized on the parent taxon field.');
+        }
+
+        return $this->getElement('parent');
     }
 }

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElementInterface.php
@@ -38,6 +38,11 @@ interface FormElementInterface extends BaseFormElementInterface
 
     public function removeCurrentParent(): void;
 
+    /**
+     * @return array<string, string>
+     */
+    public function searchInParentAutocomplete(string $searchString): array;
+
     public function getTranslationFieldValue(string $element, string $localeCode): string;
 
     public function enable(): void;

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
@@ -43,7 +43,7 @@ final class TaxonAutocompleteType extends AbstractType
 
         $resolver->setAllowedTypes('extra_options', 'array');
 
-        $resolver->setNormalizer('filter_query', function (Options $options, ?callable $filterQuery): ?callable {
+        $resolver->addNormalizer('filter_query', function (Options $options, ?callable $filterQuery): ?callable {
             /** @var array<string, mixed> $extraOptions */
             $extraOptions = $options['extra_options'];
             /** @var array<string> $excludedCodes */

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Form\Type;
 
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -37,6 +39,30 @@ final class TaxonAutocompleteType extends AbstractType
 
         $resolver->setDefault('choice_label', function (Options $options): string {
             return $options['extra_options']['choice_label'] ?? 'fullname';
+        });
+
+        $resolver->setAllowedTypes('extra_options', 'array');
+
+        $resolver->setNormalizer('filter_query', function (Options $options, ?callable $filterQuery): ?callable {
+            /** @var array<string, mixed> $extraOptions */
+            $extraOptions = $options['extra_options'];
+            /** @var array<string> $excludedCodes */
+            $excludedCodes = $extraOptions['excluded_taxon_codes'] ?? [];
+
+            if (empty($excludedCodes)) {
+                return $filterQuery;
+            }
+
+            return function (QueryBuilder $queryBuilder, string $query, EntityRepository $repository) use ($filterQuery, $excludedCodes): void {
+                if (null !== $filterQuery) {
+                    $filterQuery($queryBuilder, $query, $repository);
+                }
+
+                $queryBuilder
+                    ->andWhere('entity.code NOT IN (:excluded_codes)')
+                    ->setParameter('excluded_codes', $excludedCodes)
+                ;
+            };
         });
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AdminBundle\Form\Type;
 
 use Sylius\Bundle\CoreBundle\Form\Type\Taxon\TaxonImageType;
 use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonType as BaseTaxonType;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -24,6 +25,23 @@ final class TaxonType extends AbstractType
     /** @param array<string, mixed> $options */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var TaxonInterface|null $taxon */
+        $taxon = $builder->getData();
+        /** @var array<string> $excludedTaxonCodes */
+        $excludedTaxonCodes = [];
+
+        if (null !== $taxon) {
+            $taxonCode = $taxon->getCode();
+            if (null !== $taxonCode) {
+                $excludedTaxonCodes[] = $taxonCode;
+            }
+
+            $visitedTaxonIds = [spl_object_id($taxon) => true];
+            foreach ($taxon->getChildren() as $child) {
+                $this->addDescendantCodes($child, $excludedTaxonCodes, $visitedTaxonIds);
+            }
+        }
+
         $builder
             ->add('images', LiveCollectionType::class, [
                 'entry_type' => TaxonImageType::class,
@@ -41,6 +59,9 @@ final class TaxonType extends AbstractType
                 'label' => 'sylius.form.taxon.parent',
                 'multiple' => false,
                 'required' => false,
+                'extra_options' => [
+                    'excluded_taxon_codes' => $excludedTaxonCodes,
+                ],
             ])
         ;
     }
@@ -53,5 +74,30 @@ final class TaxonType extends AbstractType
     public function getParent(): string
     {
         return BaseTaxonType::class;
+    }
+
+    /**
+     * @param array<string> $excludedTaxonCodes
+     * @param array<int, true> $visitedTaxonIds
+     *
+     * @param-out array<string> $excludedTaxonCodes
+     */
+    private function addDescendantCodes(TaxonInterface $taxon, array &$excludedTaxonCodes, array &$visitedTaxonIds): void
+    {
+        $taxonId = spl_object_id($taxon);
+        if (isset($visitedTaxonIds[$taxonId])) {
+            return;
+        }
+
+        $visitedTaxonIds[$taxonId] = true;
+
+        $taxonCode = $taxon->getCode();
+        if (null !== $taxonCode) {
+            $excludedTaxonCodes[] = $taxonCode;
+        }
+
+        foreach ($taxon->getChildren() as $child) {
+            $this->addDescendantCodes($child, $excludedTaxonCodes, $visitedTaxonIds);
+        }
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | [11793](https://github.com/Sylius/Sylius/issues/11793)
| License         | MIT


PR #18470  I had to close because it was not actual.
Fix the infinite loop bug when filling in the 'Parent' field on the category form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BDD coverage for preventing circular/invalid parent taxon changes via the admin API and UI.
  * Improved parent taxon autocomplete and selector behavior by reliably excluding the edited taxon, its descendants, and preventing invalid re-parenting choices.

* **Bug Fixes**
  * Invalid parent update attempts now consistently return a “parent relation is invalid” notification and keep the original parent unchanged.
  * Valid parent updates persist and show a success confirmation.

* **Tests**
  * Added scenarios for API and admin UI parent-edit flows, including valid sibling/other-branch assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->