### PR TITLE
Add translatable message for checking disabled accounts

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -347,7 +347,17 @@ For a complete overview of the Grid component, see the [Grid documentation](http
 
 ## Deprecations
 
-1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.
+1. Not passing a `Symfony\Contracts\Translation\TranslatorInterface` to `Sylius\Component\User\Security\Checker\EnabledUserChecker` is deprecated since Sylius 2.3 and will be required in Sylius 3.0.
+
+   ```diff
+   -public function __construct()
+   +public function __construct(private readonly ?TranslatorInterface $translator = null)
+   ```
+
+   > **Deprecated:** When a translator is provided, the "account is disabled" message shown during authentication uses the new `sylius.user.account_disabled` translation key (`validators` domain).
+   > Without it, the checker falls back to the original `DisabledException('User account is disabled.')` behavior.
+
+2. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.
    Implement `Sylius\Component\Core\Calculator\CatalogPricesCalculatorInterface` instead, which extends `ProductVariantPricesCalculatorInterface` with no additional methods.
    It will be required in Sylius 3.0.
 

--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.php
@@ -139,6 +139,7 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.user_checker.enabled', EnabledUserChecker::class)
+        ->args([service('translator')])
         ->tag('security.user_checker.admin', ['priority' => 100])
         ->tag('security.user_checker.shop', ['priority' => 100])
         ->tag('security.user_checker.api_admin', ['priority' => 100])

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/validators.en.yml
@@ -1,6 +1,6 @@
 sylius:
     user:
-        account_disabled: User account is disabled.
+        account_disabled: Invalid credentials.
         email:
             not_blank: Please enter your email.
             invalid: This email is invalid.

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/validators.en.yml
@@ -1,5 +1,6 @@
 sylius:
     user:
+        account_disabled: User account is disabled.
         email:
             not_blank: Please enter your email.
             invalid: This email is invalid.

--- a/src/Sylius/Component/User/Security/Checker/EnabledUserChecker.php
+++ b/src/Sylius/Component/User/Security/Checker/EnabledUserChecker.php
@@ -15,12 +15,27 @@ namespace Sylius\Component\User\Security\Checker;
 
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class EnabledUserChecker implements UserCheckerInterface
+final readonly class EnabledUserChecker implements UserCheckerInterface
 {
+    public function __construct(private ?TranslatorInterface $translator = null)
+    {
+        if (null === $this->translator) {
+            trigger_deprecation(
+                'sylius/user',
+                '2.3',
+                'Not passing a "%s" to "%s" is deprecated and will be required in Sylius 3.0.',
+                TranslatorInterface::class,
+                self::class,
+            );
+        }
+    }
+
     public function checkPreAuth(SymfonyUserInterface $user): void
     {
         if (!$user instanceof UserInterface) {
@@ -28,7 +43,11 @@ final class EnabledUserChecker implements UserCheckerInterface
         }
 
         if (!$user->isEnabled()) {
-            $exception = new DisabledException('User account is disabled.');
+            $exception = null !== $this->translator
+                ? new CustomUserMessageAccountStatusException(
+                    $this->translator->trans('sylius.user.account_disabled', [], 'validators'),
+                )
+                : new DisabledException('User account is disabled.');
             $exception->setUser($user);
 
             throw $exception;

--- a/src/Sylius/Component/User/tests/Security/Checker/EnabledUserCheckerTest.php
+++ b/src/Sylius/Component/User/tests/Security/Checker/EnabledUserCheckerTest.php
@@ -18,7 +18,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Security\Checker\EnabledUserChecker;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class EnabledUserCheckerTest extends TestCase
@@ -49,5 +51,25 @@ final class EnabledUserCheckerTest extends TestCase
         $this->userMock->expects($this->once())->method('isEnabled')->willReturn(true);
 
         $this->userChecker->checkPreAuth($this->userMock);
+    }
+
+    public function testShouldThrowCustomUserMessageAccountStatusExceptionWithTranslatedMessageIfTranslatorIsGivenAndAccountIsDisabled(): void
+    {
+        /** @var TranslatorInterface&MockObject $translatorMock */
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock->expects($this->once())
+            ->method('trans')
+            ->with('sylius.user.account_disabled', [], 'validators')
+            ->willReturn('Translated disabled account message.')
+        ;
+
+        $userChecker = new EnabledUserChecker($translatorMock);
+
+        $this->userMock->expects($this->once())->method('isEnabled')->willReturn(false);
+
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+        $this->expectExceptionMessage('Translated disabled account message.');
+
+        $userChecker->checkPreAuth($this->userMock);
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | yes
| Related tickets | https://github.com/Sylius/Sylius/issues/15016
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an English validator message for disabled user accounts (“Invalid credentials.”).
  * Disabled user accounts now show a localized error message when translation support is available.

* **Bug Fixes**
  * Improved authentication handling for disabled accounts to provide a clearer, user-friendly message.

* **Documentation**
  * Documented a deprecation notice and upcoming requirement to provide translation support for the account status checker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->