### PR TITLE
Simplifying the custom grid config

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGrid.php
+++ b/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGrid.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\Grid\Account;
 
 use Sylius\Bundle\GridBundle\Builder\Action\Action;
+use Sylius\Bundle\GridBundle\Builder\Action\ShowAction;
 use Sylius\Bundle\GridBundle\Builder\Field\DateTimeField;
 use Sylius\Bundle\GridBundle\Builder\Field\TwigField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
@@ -46,23 +47,22 @@ final class OrderGrid implements OrderGridInterface
                 TwigField::create('state', '@SyliusUi/grid/field/label.html.twig')
                     ->setLabel('sylius.ui.state')
                     ->setSortable(true)
-                    ->addOptions([
+                    ->withOptions([
                         'vars' => [
                             'labels' => '@SyliusShop/account/order/label/state',
                         ],
                     ]),
             )
             ->withItemActions(
-                Action::create('show', 'shop_show')
-                    ->setLabel('sylius.ui.show')
-                    ->setOptions([
-                        'link' => [
-                            'route' => 'sylius_shop_account_order_show',
-                            'parameters' => [
-                                'number' => 'resource.number',
-                            ],
+                ShowAction::create([
+                    'link' => [
+                        'route' => 'sylius_shop_account_order_show',
+                        'parameters' => [
+                            'number' => 'resource.number',
                         ],
-                    ]),
+                    ],
+                ])
+                    ->setTemplate('@SyliusShop/grid/action/show.html.twig'),
                 Action::create('pay', 'shop_pay')
                     ->setLabel('sylius.ui.pay')
                     ->setOptions([

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -19,11 +19,11 @@ webpack_encore:
 sylius_grid:
     templates:
         action:
-            shop_delete: "@SyliusShop/grid/action/delete.html.twig"
-            shop_list: "@SyliusShop/grid/action/list.html.twig"
+            shop_delete: "@SyliusShop/grid/action/delete.html.twig" # Unused ?
+            shop_list: "@SyliusShop/grid/action/list.html.twig" # Unused ?
             shop_pay: "@SyliusShop/account/order/grid/action/pay.html.twig"
-            shop_show: "@SyliusShop/grid/action/show.html.twig"
-            shop_update: "@SyliusShop/grid/action/update.html.twig"
+            shop_show: "@SyliusShop/grid/action/show.html.twig" # Deprecated
+            shop_update: "@SyliusShop/grid/action/update.html.twig" # Unused ?
         filter:
             shop_string: "@SyliusShop/grid/filter/string.html.twig"
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/grids/account/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/grids/account/order.yml
@@ -51,8 +51,8 @@ sylius_grid:
             actions:
                 item:
                     show:
-                        type: shop_show
-                        label: sylius.ui.show
+                        type: show
+                        template: "@SyliusShop/grid/action/show.html.twig"
                         options:
                             link:
                                 route: sylius_shop_account_order_show


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | technically yes
| Deprecations?   | yes
| Related tickets | refs #18555
| License         | MIT

## What's in this PR

Using the template property of the action instead of creating a whole new action type. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the account order listing’s “Show” action to use the standard order details behavior.
  * Ensured order details links continue to open the correct order using its order number.
  * Improved display of order state labels in the account order grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->