### PR TITLE
[Enhancement] Normalize locale codes by replacing underscores with hyphens in Api Docs

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/OpenApi/Documentation/AcceptLanguageHeaderDocumentationModifier.php
+++ b/src/Sylius/Bundle/ApiBundle/OpenApi/Documentation/AcceptLanguageHeaderDocumentationModifier.php
@@ -36,7 +36,7 @@ final class AcceptLanguageHeaderDocumentationModifier implements DocumentationMo
             schema: [
                 'type' => 'string',
                 'enum' => array_map(
-                    fn (LocaleInterface $locale): string => $locale->getCode(),
+                    fn (LocaleInterface $locale): string => str_replace('_', '-', $locale->getCode()),
                     $this->localeRepository->findAll(),
                 ),
             ],


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | #15027
| License         | MIT

It contains a one-line fix in AcceptLanguageHeaderDocumentationModifier that normalizes locale codes in the OpenAPI documentation by replacing underscores with hyphens (e.g. en_US → en-US). The API accepts both formats, so  
  this doesn't fix broken behavior — it makes the documented Accept-Language enum values conform to the BCP 47 format actually used in HTTP headers.