### PR TITLE
Fix infinite loader on Safari back navigation after add to cart

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/entrypoint.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/entrypoint.js
@@ -11,6 +11,7 @@ import './styles/main.scss';
 
 import './scripts/bootstrap';
 import './scripts/spotlight';
+import './scripts/live-component-bfcache';
 
 const imagesContext = require.context('./images', true, /\.(jpg|jpeg|png|svg|gif|webp)$/);
 imagesContext.keys().forEach(imagesContext);

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/scripts/live-component-bfcache.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/scripts/live-component-bfcache.js
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * Safari (macOS/iOS) keeps pages in its back/forward cache (bfcache). When a
+ * Live Component action ends with a redirect (e.g. "add to cart"), the browser
+ * navigates away while the component's loading overlay is still visible. On a
+ * back navigation Safari restores the frozen page as-is, so the overlay stays
+ * stuck forever and the aborted request surfaces as "TypeError: Load failed".
+ * Reloading the restored page reinitializes the Live Component in a clean,
+ * idle state.
+ *
+ * See https://github.com/Sylius/Sylius/issues/18547
+ */
+window.addEventListener('pageshow', (event) => {
+    if (!event.persisted) {
+        return;
+    }
+
+    const isLoaderStuck = Array.from(document.querySelectorAll('[data-loading]'))
+        .some((element) => window.getComputedStyle(element).display !== 'none');
+
+    if (isLoaderStuck) {
+        window.location.reload();
+    }
+});

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/scripts/live-component-bfcache.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/scripts/live-component-bfcache.js
@@ -8,15 +8,8 @@
  */
 
 /*
- * Safari (macOS/iOS) keeps pages in its back/forward cache (bfcache). When a
- * Live Component action ends with a redirect (e.g. "add to cart"), the browser
- * navigates away while the component's loading overlay is still visible. On a
- * back navigation Safari restores the frozen page as-is, so the overlay stays
- * stuck forever and the aborted request surfaces as "TypeError: Load failed".
- * Reloading the restored page reinitializes the Live Component in a clean,
- * idle state.
- *
- * See https://github.com/Sylius/Sylius/issues/18547
+ * Safari bfcache restores the page mid-redirect, freezing the Live Component's loading overlay
+ * and surfacing the aborted request as "TypeError: Load failed".
  */
 window.addEventListener('pageshow', (event) => {
     if (!event.persisted) {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18547
| License         | MIT

On Safari (macOS/iOS) the product page is stored in the back/forward cache with the Live Component loading overlay still visible after an add-to-cart redirect. On back navigation the frozen page is restored with the spinner stuck. Reload the restored page when a stuck loader is detected.