### PR TITLE
[CI] Test mainly Symfony 8.1, keep minimal 8.0 coverage

### DIFF
--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -25,7 +25,7 @@ jobs:
                 include:
                     -
                         php: "8.4"
-                        symfony: "~8.0.0"
+                        symfony: "~8.1.0"
                         mysql: "8.4"
 
         env:

--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -45,7 +45,7 @@ jobs:
                 php:
                     - "8.4"
                 symfony:
-                    - "~8.0.0"
+                    - "~8.1.0"
                 package: ${{ fromJson(needs.get-packages.outputs.packages) }}
 
         env:

--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -112,8 +112,8 @@ jobs:
             -   name: Validate Yaml files
                 run: bin/console lint:yaml src --parse-tags
 
-            #-   name: Validate Package versions
-            #    run: vendor/bin/monorepo-builder validate
+            -   name: Validate Package versions
+                run: vendor/bin/monorepo-builder validate
 
             -   name: Run PHPArkitect
                 if: matrix.php != '8.5'

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -15,8 +15,12 @@
           "symfony": "~7.4.0"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "~8.0.0"
+        },
+        {
+          "php": "8.5",
+          "symfony": "~8.1.0"
         }
       ]
     },
@@ -37,8 +41,8 @@
           "legacy_grid_config": false
         },
         {
-          "php": "8.4",
-          "symfony": "~8.0.0",
+          "php": "8.5",
+          "symfony": "~8.1.0",
           "mariadb": "11.4.7",
           "doctrine_bundle": "^3.0",
           "state_machine_adapter": "symfony_workflow",
@@ -62,8 +66,15 @@
           "doctrine_bundle": "^3.0"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "~8.0.0",
+          "mysql": "8.4",
+          "twig": "^3.3",
+          "doctrine_bundle": "^3.0"
+        },
+        {
+          "php": "8.5",
+          "symfony": "~8.1.0",
           "mysql": "8.4",
           "twig": "^3.3",
           "doctrine_bundle": "^3.0"
@@ -144,35 +155,35 @@
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.0",
           "group": "Managing Products",
           "tags": "@mink:chromedriver&&@managing_products&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.0",
           "group": "Taxons, Shipping Methods, Countries, Zones",
           "tags": "@managing_taxons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_shipping_methods&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_countries&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_zones&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.0",
           "group": "Promotions, Catalog Promotions, Coupons",
           "tags": "@managing_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@applying_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_promotion_coupons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.0",
           "group": "Checkout, Cart, Address Book",
           "tags": "@checkout&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@shopping_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@cart_inventory&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@accessing_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@address_book&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.0",
           "group": "Remaining",
           "tags": "@mink:chromedriver&&~@managing_products&&~@managing_taxons&&~@managing_shipping_methods&&~@managing_countries&&~@managing_zones&&~@managing_promotions&&~@managing_catalog_promotions&&~@applying_catalog_promotions&&~@managing_promotion_coupons&&~@checkout&&~@shopping_cart&&~@cart_inventory&&~@accessing_cart&&~@address_book&&~@todo&&~@cli&&~@failing"
@@ -193,7 +204,7 @@
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.0"
         }
       ]
@@ -212,8 +223,8 @@
           "doctrine_bundle": "^3.0"
         },
         {
-          "php": "8.4",
-          "symfony": "~8.0.0",
+          "php": "8.5",
+          "symfony": "~8.1.0",
           "postgres": "17.5",
           "doctrine_bundle": "^3.0"
         }
@@ -236,7 +247,7 @@
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0"
+          "symfony": "~8.1.0"
         }
       ]
     }
@@ -251,7 +262,13 @@
       "symfony": [
         "~6.4.0",
         "~7.4.0",
-        "~8.0.0"
+        "~8.1.0"
+      ],
+      "include": [
+        {
+          "php": "8.5",
+          "symfony": "~8.0.0"
+        }
       ]
     },
     "e2e-mariadb": {
@@ -263,7 +280,7 @@
       "symfony": [
         "~6.4.0",
         "~7.4.0",
-        "~8.0.0"
+        "~8.1.0"
       ],
       "mariadb": [
         "11.4.7"
@@ -286,6 +303,14 @@
           "doctrine_bundle": "^2.0",
           "state_machine_adapter": "winzou_state_machine",
           "legacy_grid_config": true
+        },
+        {
+          "php": "8.4",
+          "symfony": "~8.0.0",
+          "mariadb": "11.4.7",
+          "doctrine_bundle": "^3.0",
+          "state_machine_adapter": "symfony_workflow",
+          "legacy_grid_config": false
         }
       ]
     },
@@ -297,7 +322,7 @@
       "symfony": [
         "~6.4.0",
         "~7.4.0",
-        "~8.0.0"
+        "~8.1.0"
       ],
       "mysql": [
         "8.4"
@@ -316,6 +341,13 @@
           "mysql": "8.0",
           "twig": "^3.3",
           "doctrine_bundle": "^2.0"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~8.0.0",
+          "mysql": "8.4",
+          "twig": "^3.3",
+          "doctrine_bundle": "^3.0"
         }
       ]
     },
@@ -393,35 +425,35 @@
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.4",
           "group": "Managing Products",
           "tags": "@mink:chromedriver&&@managing_products&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.4",
           "group": "Taxons, Shipping Methods, Countries, Zones",
           "tags": "@managing_taxons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_shipping_methods&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_countries&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_zones&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.4",
           "group": "Promotions, Catalog Promotions, Coupons",
           "tags": "@managing_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@applying_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_promotion_coupons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.4",
           "group": "Checkout, Cart, Address Book",
           "tags": "@checkout&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@shopping_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@cart_inventory&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@accessing_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@address_book&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.4",
           "group": "Remaining",
           "tags": "@mink:chromedriver&&~@managing_products&&~@managing_taxons&&~@managing_shipping_methods&&~@managing_countries&&~@managing_zones&&~@managing_promotions&&~@managing_catalog_promotions&&~@applying_catalog_promotions&&~@managing_promotion_coupons&&~@checkout&&~@shopping_cart&&~@cart_inventory&&~@accessing_cart&&~@address_book&&~@todo&&~@cli&&~@failing"
@@ -442,7 +474,7 @@
         },
         {
           "php": "8.4",
-          "symfony": "~8.0.0",
+          "symfony": "~8.1.0",
           "mysql": "8.4"
         }
       ]
@@ -456,7 +488,7 @@
       "symfony": [
         "~6.4.0",
         "~7.4.0",
-        "~8.0.0"
+        "~8.1.0"
       ],
       "postgres": [
         "15.13",
@@ -467,6 +499,12 @@
         {
           "php": "8.5",
           "symfony": "~7.4.0",
+          "postgres": "17.5",
+          "doctrine_bundle": "^3.0"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~8.0.0",
           "postgres": "17.5",
           "doctrine_bundle": "^3.0"
         }
@@ -487,7 +525,13 @@
       "symfony": [
         "~6.4.0",
         "~7.4.0",
-        "~8.0.0"
+        "~8.1.0"
+      ],
+      "include": [
+        {
+          "php": "8.4",
+          "symfony": "~8.0.0"
+        }
       ]
     }
   }

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -37,7 +37,7 @@
         "sylius/core-bundle": "^2.0",
         "sylius/payum-bundle": "^2.0",
         "sylius/ui-bundle": "^2.0",
-        "sylius/twig-hooks": "^0.9 || ^0.10",
+        "sylius/twig-hooks": "^0.9 || ^0.10 || ^0.11",
         "symfony/framework-bundle": "^6.4.1 || ^7.4 || ^8.0",
         "symfony/http-client": "^6.4 || ^7.4 || ^8.0",
         "symfony/stimulus-bundle": "^2.25",

--- a/src/Sylius/Bundle/AdminBundle/tests/Action/Account/RequestPasswordResetActionTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Action/Account/RequestPasswordResetActionTest.php
@@ -22,7 +22,6 @@ use Sylius\Bundle\CoreBundle\Command\Admin\Account\RequestResetPasswordEmail;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -74,8 +73,7 @@ final class RequestPasswordResetActionTest extends TestCase
     public function testSendsResetPasswordRequestToMessageBus(): void
     {
         $form = $this->createMock(FormInterface::class);
-        $request = $this->createMock(Request::class);
-        $attributesBag = $this->createMock(ParameterBag::class);
+        $request = new Request(attributes: ['_sylius' => ['redirect' => 'my_custom_route']]);
 
         $this->formFactory
             ->expects($this->once())
@@ -114,15 +112,6 @@ final class RequestPasswordResetActionTest extends TestCase
         ;
 
         $this->requestStack->expects($this->once())->method('getSession')->willReturn($this->session);
-
-        $attributesBag
-            ->expects($this->once())
-            ->method('get')
-            ->with('_sylius', [])
-            ->willReturn(['redirect' => 'my_custom_route'])
-        ;
-
-        $request->attributes = $attributesBag;
 
         $this->router
             ->expects($this->once())
@@ -140,8 +129,16 @@ final class RequestPasswordResetActionTest extends TestCase
     public function testItSendsResetPasswordRequestWhenSyliusRedirectParameterIsArray(): void
     {
         $form = $this->createMock(FormInterface::class);
-        $request = $this->createMock(Request::class);
-        $attributesBag = $this->createMock(ParameterBag::class);
+        $route = 'my_custom_route';
+        $params = ['my_parameter' => 'my_value'];
+        $request = new Request(attributes: [
+            '_sylius' => [
+                'redirect' => [
+                    'route' => $route,
+                    'params' => $params,
+                ],
+            ],
+        ]);
 
         $this->formFactory
             ->expects($this->once())
@@ -180,23 +177,6 @@ final class RequestPasswordResetActionTest extends TestCase
         ;
 
         $this->requestStack->expects($this->once())->method('getSession')->willReturn($this->session);
-
-        $route = 'my_custom_route';
-        $params = ['my_parameter' => 'my_value'];
-
-        $attributesBag
-            ->expects($this->once())
-            ->method('get')
-            ->with('_sylius', [])
-            ->willReturn([
-                'redirect' => [
-                    'route' => $route,
-                    'params' => $params,
-                ],
-            ])
-        ;
-
-        $request->attributes = $attributesBag;
 
         $this->router
             ->expects($this->once())
@@ -214,8 +194,7 @@ final class RequestPasswordResetActionTest extends TestCase
     public function testItRedirectsToDefaultRouteIfCustomOneIsNotDefined(): void
     {
         $form = $this->createMock(FormInterface::class);
-        $request = $this->createMock(Request::class);
-        $attributesBag = $this->createMock(ParameterBag::class);
+        $request = new Request();
 
         $this->formFactory
             ->expects($this->once())
@@ -254,15 +233,6 @@ final class RequestPasswordResetActionTest extends TestCase
         ;
 
         $this->requestStack->expects($this->once())->method('getSession')->willReturn($this->session);
-
-        $attributesBag
-            ->expects($this->once())
-            ->method('get')
-            ->with('_sylius', [])
-            ->willReturn([])
-        ;
-
-        $request->attributes = $attributesBag;
 
         $this->router
             ->expects($this->once())
@@ -281,7 +251,7 @@ final class RequestPasswordResetActionTest extends TestCase
     {
         $form = $this->createMock(FormInterface::class);
         $formView = $this->createMock(FormView::class);
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         $this->formFactory
             ->expects($this->once())

--- a/src/Sylius/Bundle/AdminBundle/tests/EventListener/AdminFilterSubscriberTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/EventListener/AdminFilterSubscriberTest.php
@@ -17,8 +17,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\AdminBundle\EventListener\AdminFilterSubscriber;
 use Sylius\Bundle\GridBundle\Storage\FilterStorageInterface;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -45,8 +43,7 @@ final class AdminFilterSubscriberTest extends TestCase
         $filterStorage = $this->createMock(FilterStorageInterface::class);
         $subscriber = new AdminFilterSubscriber($filterStorage);
 
-        $request = new Request(query: ['filter' => 'foo']);
-        $request->attributes = new ParameterBag([
+        $request = new Request(query: ['filter' => 'foo'], attributes: [
             '_route' => 'sylius_admin_product_index',
             '_sylius' => ['section' => 'admin'],
             '_controller' => 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction',
@@ -77,19 +74,12 @@ final class AdminFilterSubscriberTest extends TestCase
         $filterStorage = $this->createMock(FilterStorageInterface::class);
         $this->adminFilterSubscriber = new AdminFilterSubscriber($filterStorage);
 
-        $request = $this->createMock(Request::class);
-        $attributes = $this->createMock(ParameterBag::class);
-        $request->attributes = $attributes;
-
-        $request->method('getRequestFormat')->willReturn('json');
-        $request->query = new InputBag(['filter' => 'foo']);
-
-        $attributes->method('get')
-            ->willReturnMap([
-                ['_route', '', 'sylius_admin_product_index'],
-                ['_sylius', [], ['section' => 'admin']],
-                ['_controller', null, 'Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction'],
-            ]);
+        $request = new Request(query: ['filter' => 'foo'], attributes: [
+            '_route' => 'sylius_admin_product_index',
+            '_sylius' => ['section' => 'admin'],
+            '_controller' => 'Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction',
+        ]);
+        $request->setRequestFormat('json');
 
         $filterStorage->expects($this->never())->method('set');
 
@@ -103,21 +93,15 @@ final class AdminFilterSubscriberTest extends TestCase
     public function testDoesNotAddFilterIfNotAdminSection(): void
     {
         $event = $this->createMock(RequestEvent::class);
-        $request = $this->createMock(Request::class);
-        $attributes = $this->createMock(ParameterBag::class);
+
+        $request = new Request(query: ['filter' => 'foo'], attributes: [
+            '_route' => 'sylius_admin_product_index',
+            '_sylius' => ['section' => 'shop'],
+            '_controller' => 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction',
+        ]);
+        $request->setRequestFormat('html');
 
         $event->method('isMainRequest')->willReturn(true);
-        $request->method('getRequestFormat')->willReturn('html');
-
-        $attributes->method('get')->willReturnMap([
-            ['_route', '', 'sylius_admin_product_index'],
-            ['_sylius', [], ['section' => 'shop']],
-            ['_controller', null, 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction'],
-        ]);
-
-        $request->attributes = $attributes;
-        $request->query = new InputBag(['filter' => 'foo']);
-
         $event->method('getRequest')->willReturn($request);
 
         $this->filterStorage->expects($this->never())->method('set');
@@ -128,21 +112,15 @@ final class AdminFilterSubscriberTest extends TestCase
     public function testDoesNotAddFilterIfControllerIsNull(): void
     {
         $event = $this->createMock(RequestEvent::class);
-        $request = $this->createMock(Request::class);
-        $attributes = $this->createMock(ParameterBag::class);
+
+        $request = new Request(query: ['filter' => 'foo'], attributes: [
+            '_route' => 'sylius_admin_product_index',
+            '_sylius' => ['section' => 'admin'],
+            '_controller' => null,
+        ]);
+        $request->setRequestFormat('html');
 
         $event->method('isMainRequest')->willReturn(true);
-        $request->method('getRequestFormat')->willReturn('html');
-
-        $attributes->method('get')->willReturnMap([
-            ['_route', '', 'sylius_admin_product_index'],
-            ['_sylius', [], ['section' => 'admin']],
-            ['_controller', null, null],
-        ]);
-
-        $request->attributes = $attributes;
-        $request->query = new InputBag(['filter' => 'foo']);
-
         $event->method('getRequest')->willReturn($request);
 
         $this->filterStorage->expects($this->never())->method('set');
@@ -153,21 +131,15 @@ final class AdminFilterSubscriberTest extends TestCase
     public function testDoesNotAddFilterIfRouteIsMissing(): void
     {
         $event = $this->createMock(RequestEvent::class);
-        $request = $this->createMock(Request::class);
-        $attributes = $this->createMock(ParameterBag::class);
+
+        $request = new Request(query: ['filter' => 'foo'], attributes: [
+            '_route' => '',
+            '_sylius' => ['section' => 'admin'],
+            '_controller' => 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction',
+        ]);
+        $request->setRequestFormat('html');
 
         $event->method('isMainRequest')->willReturn(true);
-        $request->method('getRequestFormat')->willReturn('html');
-
-        $attributes->method('get')->willReturnMap([
-            ['_route', '', ''],
-            ['_sylius', [], ['section' => 'admin']],
-            ['_controller', null, 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction'],
-        ]);
-
-        $request->attributes = $attributes;
-        $request->query = new InputBag(['filter' => 'foo']);
-
         $event->method('getRequest')->willReturn($request);
 
         $this->filterStorage->expects($this->never())->method('set');
@@ -178,21 +150,15 @@ final class AdminFilterSubscriberTest extends TestCase
     public function testDoesNotAddFilterIfRouteIsNotIndex(): void
     {
         $event = $this->createMock(RequestEvent::class);
-        $request = $this->createMock(Request::class);
-        $attributes = $this->createMock(ParameterBag::class);
+
+        $request = new Request(query: ['filter' => 'foo'], attributes: [
+            '_route' => 'sylius_admin_product_update',
+            '_sylius' => ['section' => 'admin'],
+            '_controller' => 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction',
+        ]);
+        $request->setRequestFormat('html');
 
         $event->method('isMainRequest')->willReturn(true);
-        $request->method('getRequestFormat')->willReturn('html');
-
-        $attributes->method('get')->willReturnMap([
-            ['_route', '', 'sylius_admin_product_update'],
-            ['_sylius', [], ['section' => 'admin']],
-            ['_controller', null, 'Sylius\\Bundle\\AdminBundle\\Controller\\ProductController::indexAction'],
-        ]);
-
-        $request->attributes = $attributes;
-        $request->query = new InputBag(['filter' => 'foo']);
-
         $event->method('getRequest')->willReturn($request);
 
         $this->filterStorage->expects($this->never())->method('set');

--- a/src/Sylius/Bundle/AdminBundle/tests/EventListener/AdminSectionCacheControlSubscriberTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/EventListener/AdminSectionCacheControlSubscriberTest.php
@@ -21,7 +21,6 @@ use Sylius\Bundle\CoreBundle\SectionResolver\SectionInterface;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -52,32 +51,10 @@ final class AdminSectionCacheControlSubscriberTest extends TestCase
         $adminSection = $this->createMock(AdminSection::class);
         $this->sectionProvider->method('getSection')->willReturn($adminSection);
 
-        $responseHeaderBag = $this->getMockBuilder(ResponseHeaderBag::class)
-            ->onlyMethods(['addCacheControlDirective'])
-            ->getMock();
-
-        $expectedCalls = [
-            ['no-cache', true],
-            ['max-age', '0'],
-            ['must-revalidate', true],
-            ['no-store', true],
-        ];
-
-        $callIndex = 0;
-        $responseHeaderBag->expects($this->exactly(4))
-            ->method('addCacheControlDirective')
-            ->willReturnCallback(function ($directive, $value) use (&$callIndex, $expectedCalls) {
-                [$expectedDirective, $expectedValue] = $expectedCalls[$callIndex];
-                TestCase::assertSame($expectedDirective, $directive);
-                TestCase::assertSame($expectedValue, $value);
-                ++$callIndex;
-            });
-
-        $response = $this->createMock(Response::class);
-        $response->headers = $responseHeaderBag;
+        $response = new Response();
 
         $kernel = $this->createMock(HttpKernelInterface::class);
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         $event = new ResponseEvent(
             $kernel,
@@ -87,6 +64,11 @@ final class AdminSectionCacheControlSubscriberTest extends TestCase
         );
 
         $this->subscriber->setCacheControlDirectives($event);
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertSame('0', $response->headers->getCacheControlDirective('max-age'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
     }
 
     public function testDoesNothingIfSectionIsDifferentThanAdmin(): void
@@ -94,17 +76,10 @@ final class AdminSectionCacheControlSubscriberTest extends TestCase
         $section = $this->createMock(SectionInterface::class);
         $this->sectionProvider->method('getSection')->willReturn($section);
 
-        $responseHeaderBag = $this->getMockBuilder(ResponseHeaderBag::class)
-            ->onlyMethods(['addCacheControlDirective'])
-            ->getMock();
-
-        $responseHeaderBag->expects($this->never())->method('addCacheControlDirective');
-
-        $response = $this->createMock(Response::class);
-        $response->headers = $responseHeaderBag;
+        $response = new Response();
 
         $kernel = $this->createMock(HttpKernelInterface::class);
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         $event = new ResponseEvent(
             $kernel,
@@ -114,5 +89,8 @@ final class AdminSectionCacheControlSubscriberTest extends TestCase
         );
 
         $this->subscriber->setCacheControlDirectives($event);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('must-revalidate'));
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Context/TokenValueBasedCartContextTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Context/TokenValueBasedCartContextTest.php
@@ -20,7 +20,6 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Order\Context\CartNotFoundException;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -32,8 +31,6 @@ final class TokenValueBasedCartContextTest extends TestCase
 
     private TokenValueBasedCartContext $tokenValueBasedCartContext;
 
-    private MockObject&Request $request;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -44,7 +41,6 @@ final class TokenValueBasedCartContextTest extends TestCase
             $this->orderRepository,
             '/api/v2',
         );
-        $this->request = $this->createMock(Request::class);
     }
 
     public function testImplementsCartContextInterface(): void
@@ -57,13 +53,10 @@ final class TokenValueBasedCartContextTest extends TestCase
         /** @var OrderInterface&MockObject $cart */
         $cart = $this->createMock(OrderInterface::class);
 
-        $this->request->attributes = new ParameterBag(['tokenValue' => 'TOKEN_VALUE']);
+        $request = Request::create('/api/v2/orders/TOKEN_VALUE');
+        $request->attributes->set('tokenValue', 'TOKEN_VALUE');
 
-        $this->request->expects(self::once())
-            ->method('getRequestUri')
-            ->willReturn('/api/v2/orders/TOKEN_VALUE');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($this->request);
+        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
 
         $this->orderRepository->expects(self::once())
             ->method('findCartByTokenValue')
@@ -88,14 +81,11 @@ final class TokenValueBasedCartContextTest extends TestCase
 
     public function testThrowsAnExceptionIfTheRequestIsNotAnApiRequest(): void
     {
-        $this->request->attributes = new ParameterBag([]);
-        $this->request->expects(self::once())
-            ->method('getRequestUri')
-            ->willReturn('/orders');
+        $request = Request::create('/orders');
 
         $this->requestStack->expects(self::once())
             ->method('getMainRequest')
-            ->willReturn($this->request);
+            ->willReturn($request);
 
         self::expectException(CartNotFoundException::class);
 
@@ -106,14 +96,11 @@ final class TokenValueBasedCartContextTest extends TestCase
 
     public function testThrowsAnExceptionIfThereIsNoTokenValue(): void
     {
-        $this->request->attributes = new ParameterBag([]);
-        $this->request->expects(self::once())
-            ->method('getRequestUri')
-            ->willReturn('/api/v2/orders');
+        $request = Request::create('/api/v2/orders');
 
         $this->requestStack->expects(self::once())
             ->method('getMainRequest')
-            ->willReturn($this->request);
+            ->willReturn($request);
 
         self::expectException(CartNotFoundException::class);
 
@@ -124,14 +111,12 @@ final class TokenValueBasedCartContextTest extends TestCase
 
     public function testThrowsAnExceptionIfThereIsNoCartWithGivenTokenValue(): void
     {
-        $this->request->attributes = new ParameterBag(['tokenValue' => 'TOKEN_VALUE']);
-        $this->request->expects(self::once())
-            ->method('getRequestUri')
-            ->willReturn('/api/v2/orders/TOKEN_VALUE');
+        $request = Request::create('/api/v2/orders/TOKEN_VALUE');
+        $request->attributes->set('tokenValue', 'TOKEN_VALUE');
 
         $this->requestStack->expects(self::once())
             ->method('getMainRequest')
-            ->willReturn($this->request);
+            ->willReturn($request);
 
         $this->orderRepository->expects(self::once())
             ->method('findCartByTokenValue')

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/ImageNormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/ImageNormalizerTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ImageNormalizer;
 use Sylius\Component\Core\Model\ImageInterface;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
@@ -103,7 +102,7 @@ final class ImageNormalizerTest extends TestCase
 
     public function testResolvesPathBasedOnDefaultFilterWhenNoFilterInRequest(): void
     {
-        $requestMock = $this->createMock(Request::class);
+        $request = new Request(query: [ImageNormalizer::FILTER_QUERY_PARAMETER => '']);
         $imageMock = $this->createMock(ImageInterface::class);
 
         $this->normalizer->expects(self::once())
@@ -111,10 +110,9 @@ final class ImageNormalizerTest extends TestCase
             ->with($imageMock, null, ['sylius_image_normalizer_already_called' => true])
             ->willReturn(['path' => 'some_path']);
 
-        $requestMock->query = new InputBag([ImageNormalizer::FILTER_QUERY_PARAMETER => '']);
         $this->requestStack->expects(self::once())
             ->method('getCurrentRequest')
-            ->willReturn($requestMock);
+            ->willReturn($request);
 
         $this->cacheManager->expects(self::once())
             ->method('getBrowserPath')
@@ -126,7 +124,7 @@ final class ImageNormalizerTest extends TestCase
 
     public function testThrowsValidationExceptionForInvalidFilter(): void
     {
-        $requestMock = $this->createMock(Request::class);
+        $request = new Request(query: [ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid']);
         $imageMock = $this->createMock(ImageInterface::class);
 
         $this->normalizer->expects(self::once())
@@ -134,10 +132,9 @@ final class ImageNormalizerTest extends TestCase
             ->with($imageMock, null, ['sylius_image_normalizer_already_called' => true])
             ->willReturn(['path' => 'some_path']);
 
-        $requestMock->query = new InputBag([ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid']);
         $this->requestStack->expects(self::once())
             ->method('getCurrentRequest')
-            ->willReturn($requestMock);
+            ->willReturn($request);
 
         $this->cacheManager->expects(self::once())
             ->method('getBrowserPath')
@@ -150,7 +147,7 @@ final class ImageNormalizerTest extends TestCase
 
     public function testThrowsValidationExceptionWhenFilterNotResolvable(): void
     {
-        $requestMock = $this->createMock(Request::class);
+        $request = new Request(query: [ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid_filter']);
         $imageMock = $this->createMock(ImageInterface::class);
 
         $this->normalizer->expects(self::once())
@@ -158,10 +155,9 @@ final class ImageNormalizerTest extends TestCase
             ->with($imageMock, null, ['sylius_image_normalizer_already_called' => true])
             ->willReturn(['path' => 'some_path']);
 
-        $requestMock->query = new InputBag([ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid_filter']);
         $this->requestStack->expects(self::once())
             ->method('getCurrentRequest')
-            ->willReturn($requestMock);
+            ->willReturn($request);
 
         $this->cacheManager->expects(self::once())
             ->method('getBrowserPath')
@@ -189,7 +185,7 @@ final class ImageNormalizerTest extends TestCase
 
     public function testAppliesCustomFilter(): void
     {
-        $requestMock = $this->createMock(Request::class);
+        $request = new Request(query: [ImageNormalizer::FILTER_QUERY_PARAMETER => 'custom_filter']);
         $imageMock = $this->createMock(ImageInterface::class);
 
         $this->normalizer->expects(self::once())
@@ -197,10 +193,9 @@ final class ImageNormalizerTest extends TestCase
             ->with($imageMock, null, ['sylius_image_normalizer_already_called' => true])
             ->willReturn(['path' => 'some_path']);
 
-        $requestMock->query = new InputBag([ImageNormalizer::FILTER_QUERY_PARAMETER => 'custom_filter']);
         $this->requestStack->expects(self::once())
             ->method('getCurrentRequest')
-            ->willReturn($requestMock);
+            ->willReturn($request);
 
         $this->cacheManager->expects(self::once())
             ->method('getBrowserPath')

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/ShippingMethodNormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/ShippingMethodNormalizerTest.php
@@ -28,7 +28,6 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;
 use Sylius\Component\Registry\ServiceRegistryInterface;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -51,7 +50,7 @@ final class ShippingMethodNormalizerTest extends TestCase
 
     private MockObject&ShippingMethodInterface $shippingMethodMock;
 
-    private MockObject&Request $requestMock;
+    private Request $requestMock;
 
     private ChannelInterface&MockObject $channelMock;
 
@@ -78,7 +77,7 @@ final class ShippingMethodNormalizerTest extends TestCase
         );
         $this->shippingMethodNormalizer->setNormalizer($this->normalizer);
         $this->shippingMethodMock = $this->createMock(ShippingMethodInterface::class);
-        $this->requestMock = $this->createMock(Request::class);
+        $this->requestMock = new Request(attributes: ['tokenValue' => 'TOKEN', 'shipmentId' => '123']);
         $this->channelMock = $this->createMock(ChannelInterface::class);
         $this->cartMock = $this->createMock(OrderInterface::class);
         $this->shipmentMock = $this->createMock(ShipmentInterface::class);
@@ -232,7 +231,6 @@ final class ShippingMethodNormalizerTest extends TestCase
         $operation = new GetCollection(uriVariables: ['tokenValue' => [], 'shipmentId' => []]);
         $this->sectionProvider->expects(self::once())->method('getSection')->willReturn(new ShopApiSection());
         $this->requestStack->expects(self::once())->method('getCurrentRequest')->willReturn($this->requestMock);
-        $this->requestMock->attributes = new ParameterBag(['tokenValue' => 'TOKEN', 'shipmentId' => '123']);
         $this->orderRepository->expects(self::once())
             ->method('findCartByTokenValueAndChannel')
             ->with('TOKEN', $this->channelMock)
@@ -362,7 +360,6 @@ final class ShippingMethodNormalizerTest extends TestCase
         $operation = new GetCollection(uriVariables: ['tokenValue' => [], 'shipmentId' => []]);
         $this->sectionProvider->expects(self::once())->method('getSection')->willReturn(new ShopApiSection());
         $this->requestStack->expects(self::once())->method('getCurrentRequest')->willReturn($this->requestMock);
-        $this->requestMock->attributes = new ParameterBag(['tokenValue' => 'TOKEN', 'shipmentId' => '123']);
         $this->orderRepository->expects(self::once())
             ->method('findCartByTokenValueAndChannel')
             ->with('TOKEN', $this->channelMock)
@@ -388,7 +385,6 @@ final class ShippingMethodNormalizerTest extends TestCase
         $operation = new GetCollection(uriVariables: ['tokenValue' => [], 'shipmentId' => []]);
         $this->sectionProvider->expects(self::once())->method('getSection')->willReturn(new ShopApiSection());
         $this->requestStack->expects(self::once())->method('getCurrentRequest')->willReturn($this->requestMock);
-        $this->requestMock->attributes = new ParameterBag(['tokenValue' => 'TOKEN', 'shipmentId' => '123']);
         $this->orderRepository->expects(self::once())
             ->method('findCartByTokenValueAndChannel')
             ->with('TOKEN', $this->channelMock)
@@ -419,7 +415,6 @@ final class ShippingMethodNormalizerTest extends TestCase
         $operation = new GetCollection(uriVariables: ['tokenValue' => [], 'shipmentId' => []]);
         $this->sectionProvider->expects(self::once())->method('getSection')->willReturn(new ShopApiSection());
         $this->requestStack->expects(self::once())->method('getCurrentRequest')->willReturn($this->requestMock);
-        $this->requestMock->attributes = new ParameterBag(['tokenValue' => 'TOKEN', 'shipmentId' => '123']);
         $this->orderRepository->expects(self::once())
             ->method('findCartByTokenValueAndChannel')
             ->with('TOKEN', $this->channelMock)

--- a/src/Sylius/Bundle/ApiBundle/tests/StateProcessor/Admin/AvatarImage/PersistProcessorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/StateProcessor/Admin/AvatarImage/PersistProcessorTest.php
@@ -21,8 +21,7 @@ use Sylius\Bundle\ApiBundle\Creator\ImageCreatorInterface;
 use Sylius\Bundle\ApiBundle\StateProcessor\Admin\AvatarImage\PersistProcessor;
 use Sylius\Component\Core\Model\AvatarImageInterface;
 use Sylius\Component\Core\Repository\AvatarImageRepositoryInterface;
-use Symfony\Component\HttpFoundation\FileBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PersistProcessorTest extends TestCase
@@ -50,29 +49,16 @@ final class PersistProcessorTest extends TestCase
 
     public function testCreatesAndProcessesAnAvatarImage(): void
     {
-        /** @var Request|MockObject $requestMock */
-        $requestMock = $this->createMock(Request::class);
-        /** @var ParameterBag|MockObject $attributesMock */
-        $attributesMock = $this->createMock(ParameterBag::class);
-        /** @var FileBag|MockObject $filesMock */
-        $filesMock = $this->createMock(FileBag::class);
         /** @var AvatarImageInterface|MockObject $avatarImageMock */
         $avatarImageMock = $this->createMock(AvatarImageInterface::class);
 
         $operation = new Post();
 
-        $attributesMock->expects(self::once())
-            ->method('getString')
-            ->with('id')
-            ->willReturn('1');
+        $request = new Request(attributes: ['id' => '1']);
 
-        $requestMock->attributes = $attributesMock;
+        $file = new UploadedFile(__FILE__, basename(__FILE__), null, null, true);
 
-        $file = new \SplFileInfo(__FILE__);
-
-        $filesMock->expects(self::once())->method('get')->with('file')->willReturn($file);
-
-        $requestMock->files = $filesMock;
+        $request->files->set('file', $file);
 
         $this->avatarImageRepository->expects(self::never())->method('remove');
 
@@ -83,19 +69,13 @@ final class PersistProcessorTest extends TestCase
 
         $this->processor->expects(self::once())
             ->method('process')
-            ->with($avatarImageMock, $operation, [], ['request' => $requestMock]);
+            ->with($avatarImageMock, $operation, [], ['request' => $request]);
 
-        $this->persistProcessor->process(null, $operation, [], ['request' => $requestMock]);
+        $this->persistProcessor->process(null, $operation, [], ['request' => $request]);
     }
 
     public function testRemovesOldAvatarImageDuringProcessingANewOne(): void
     {
-        /** @var Request|MockObject $requestMock */
-        $requestMock = $this->createMock(Request::class);
-        /** @var ParameterBag|MockObject $attributesMock */
-        $attributesMock = $this->createMock(ParameterBag::class);
-        /** @var FileBag|MockObject $filesMock */
-        $filesMock = $this->createMock(FileBag::class);
         /** @var AvatarImageInterface|MockObject $oldAvatarImageMock */
         $oldAvatarImageMock = $this->createMock(AvatarImageInterface::class);
         /** @var AvatarImageInterface|MockObject $avatarImageMock */
@@ -103,18 +83,11 @@ final class PersistProcessorTest extends TestCase
 
         $operation = new Post();
 
-        $attributesMock->expects(self::once())
-            ->method('getString')
-            ->with('id')
-            ->willReturn('1');
+        $request = new Request(attributes: ['id' => '1']);
 
-        $requestMock->attributes = $attributesMock;
+        $file = new UploadedFile(__FILE__, basename(__FILE__), null, null, true);
 
-        $file = new \SplFileInfo(__FILE__);
-
-        $filesMock->expects(self::once())->method('get')->with('file')->willReturn($file);
-
-        $requestMock->files = $filesMock;
+        $request->files->set('file', $file);
 
         $this->avatarImageRepository->expects(self::once())->method('remove')->with($oldAvatarImageMock);
 
@@ -125,8 +98,8 @@ final class PersistProcessorTest extends TestCase
 
         $this->processor->expects(self::once())
             ->method('process')
-            ->with($avatarImageMock, $operation, [], ['request' => $requestMock]);
+            ->with($avatarImageMock, $operation, [], ['request' => $request]);
 
-        $this->persistProcessor->process($oldAvatarImageMock, $operation, [], ['request' => $requestMock]);
+        $this->persistProcessor->process($oldAvatarImageMock, $operation, [], ['request' => $request]);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/StateProcessor/Admin/ProductImage/PersistProcessorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/StateProcessor/Admin/ProductImage/PersistProcessorTest.php
@@ -22,9 +22,7 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ApiBundle\Creator\ImageCreatorInterface;
 use Sylius\Bundle\ApiBundle\StateProcessor\Admin\ProductImage\PersistProcessor;
 use Sylius\Component\Core\Model\ProductImageInterface;
-use Symfony\Component\HttpFoundation\FileBag;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -56,12 +54,6 @@ final class PersistProcessorTest extends TestCase
 
     public function testCreatesAndProcessesAProductImage(): void
     {
-        /** @var Request|MockObject $requestMock */
-        $requestMock = $this->createMock(Request::class);
-        /** @var ParameterBag|MockObject $attributesMock */
-        $attributesMock = $this->createMock(ParameterBag::class);
-        /** @var FileBag|MockObject $filesMock */
-        $filesMock = $this->createMock(FileBag::class);
         /** @var ProductImageInterface|MockObject $productImageMock */
         $productImageMock = $this->createMock(ProductImageInterface::class);
         /** @var ConstraintViolationListInterface|MockObject $constraintViolationListMock */
@@ -69,24 +61,14 @@ final class PersistProcessorTest extends TestCase
 
         $operation = new Post(validationContext: ['groups' => ['sylius']]);
 
-        $attributesMock->expects(self::once())->method('get')
-            ->with('code', '')
-            ->willReturn('code');
+        $request = new Request(
+            attributes: ['code' => 'code'],
+            request: ['type' => 'type', 'productVariants' => ['/api/v2/admin/product-variants/MUG']],
+        );
 
-        $requestMock->attributes = $attributesMock;
+        $file = new UploadedFile(__FILE__, basename(__FILE__), null, null, true);
 
-        $file = new \SplFileInfo(__FILE__);
-
-        $filesMock->expects(self::once())->method('get')->with('file')->willReturn($file);
-
-        $requestMock->files = $filesMock;
-
-        $requestParams = new InputBag([
-            'type' => 'type',
-            'productVariants' => ['/api/v2/admin/product-variants/MUG'],
-        ]);
-
-        $requestMock->request = $requestParams;
+        $request->files->set('file', $file);
 
         $this->productImageCreator->expects(self::once())
             ->method('create')
@@ -102,19 +84,13 @@ final class PersistProcessorTest extends TestCase
 
         $this->processor->expects(self::once())
             ->method('process')
-            ->with($productImageMock, $operation, [], ['request' => $requestMock]);
+            ->with($productImageMock, $operation, [], ['request' => $request]);
 
-        $this->persistProcessor->process(null, $operation, [], ['request' => $requestMock]);
+        $this->persistProcessor->process(null, $operation, [], ['request' => $request]);
     }
 
     public function testThrowsAValidationExceptionIfACreatedProductImageIsNotValid(): void
     {
-        /** @var Request|MockObject $requestMock */
-        $requestMock = $this->createMock(Request::class);
-        /** @var ParameterBag|MockObject $attributesMock */
-        $attributesMock = $this->createMock(ParameterBag::class);
-        /** @var FileBag|MockObject $filesMock */
-        $filesMock = $this->createMock(FileBag::class);
         /** @var ProductImageInterface|MockObject $productImageMock */
         $productImageMock = $this->createMock(ProductImageInterface::class);
         /** @var ConstraintViolationListInterface|MockObject $constraintViolationListMock */
@@ -124,25 +100,14 @@ final class PersistProcessorTest extends TestCase
 
         $operation = new Post(validationContext: ['groups' => ['sylius']]);
 
-        $attributesMock->expects(self::once())
-            ->method('get')
-            ->with('code', '')
-            ->willReturn('code');
+        $request = new Request(
+            attributes: ['code' => 'code'],
+            request: ['type' => 'type', 'productVariants' => ['/api/v2/admin/product-variants/MUG']],
+        );
 
-        $requestMock->attributes = $attributesMock;
+        $file = new UploadedFile(__FILE__, basename(__FILE__), null, null, true);
 
-        $file = new \SplFileInfo(__FILE__);
-
-        $filesMock->expects(self::once())->method('get')->with('file')->willReturn($file);
-
-        $requestMock->files = $filesMock;
-
-        $requestParams = new InputBag([
-            'type' => 'type',
-            'productVariants' => ['/api/v2/admin/product-variants/MUG'],
-        ]);
-
-        $requestMock->request = $requestParams;
+        $request->files->set('file', $file);
 
         $this->productImageCreator->expects(self::once())
             ->method('create')
@@ -168,11 +133,11 @@ final class PersistProcessorTest extends TestCase
 
         $this->processor->expects(self::never())
             ->method('process')
-            ->with($productImageMock, $operation, [], ['request' => $requestMock]);
+            ->with($productImageMock, $operation, [], ['request' => $request]);
 
         $this->expectException(ValidationException::class);
 
-        $this->persistProcessor->process($productImageMock, $operation, [], ['request' => $requestMock]);
+        $this->persistProcessor->process($productImageMock, $operation, [], ['request' => $request]);
     }
 
     public function testThrowsAnExceptionForDeleteOperation(): void

--- a/src/Sylius/Bundle/ApiBundle/tests/StateProcessor/Admin/TaxonImage/PersistProcessorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/StateProcessor/Admin/TaxonImage/PersistProcessorTest.php
@@ -21,9 +21,7 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ApiBundle\Creator\ImageCreatorInterface;
 use Sylius\Bundle\ApiBundle\StateProcessor\Admin\TaxonImage\PersistProcessor;
 use Sylius\Component\Core\Model\TaxonImageInterface;
-use Symfony\Component\HttpFoundation\FileBag;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PersistProcessorTest extends TestCase
@@ -49,31 +47,16 @@ final class PersistProcessorTest extends TestCase
 
     public function testCreatesAndProcessesATaxonImage(): void
     {
-        /** @var Request|MockObject $requestMock */
-        $requestMock = $this->createMock(Request::class);
-        /** @var ParameterBag|MockObject $attributesMock */
-        $attributesMock = $this->createMock(ParameterBag::class);
-        /** @var FileBag|MockObject $filesMock */
-        $filesMock = $this->createMock(FileBag::class);
         /** @var TaxonImageInterface|MockObject $taxonImageMock */
         $taxonImageMock = $this->createMock(TaxonImageInterface::class);
 
         $operation = new Post();
 
-        $attributesMock->expects(self::once())
-            ->method('get')
-            ->with('code', '')
-            ->willReturn('code');
+        $request = new Request(attributes: ['code' => 'code'], request: ['type' => 'type']);
 
-        $requestMock->attributes = $attributesMock;
+        $file = new UploadedFile(__FILE__, basename(__FILE__), null, null, true);
 
-        $file = new \SplFileInfo(__FILE__);
-
-        $filesMock->expects(self::once())->method('get')->with('file')->willReturn($file);
-
-        $requestMock->files = $filesMock;
-
-        $requestMock->request = new InputBag(['type' => 'type']);
+        $request->files->set('file', $file);
 
         $this->taxonImageCreator->expects(self::once())
             ->method('create')
@@ -82,9 +65,9 @@ final class PersistProcessorTest extends TestCase
 
         $this->processor->expects(self::once())
             ->method('process')
-            ->with($taxonImageMock, $operation, [], ['request' => $requestMock]);
+            ->with($taxonImageMock, $operation, [], ['request' => $request]);
 
-        $this->persistProcessor->process(null, $operation, [], ['request' => $requestMock]);
+        $this->persistProcessor->process(null, $operation, [], ['request' => $request]);
     }
 
     public function testThrowsAnExceptionForDeleteOperation(): void

--- a/src/Sylius/Bundle/ApiBundle/tests/StateProvider/Common/Adjustment/CollectionProviderTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/StateProvider/Common/Adjustment/CollectionProviderTest.php
@@ -21,7 +21,6 @@ use Sylius\Bundle\ApiBundle\StateProvider\Common\Adjustment\CollectionProvider;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItem;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 
 final class CollectionProviderTest extends TestCase
@@ -86,9 +85,7 @@ final class CollectionProviderTest extends TestCase
     {
         $operation = new GetCollection(class: AdjustmentInterface::class);
 
-        $request = $this->createMock(Request::class);
-
-        $request->query = new InputBag(['type' => 'type']);
+        $request = new Request(query: ['type' => 'type']);
 
         $orderItem = $this->createMock(OrderItem::class);
 

--- a/src/Sylius/Bundle/ApiBundle/tests/StateProvider/Shop/Order/OrderItem/Adjustment/CollectionProviderTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/StateProvider/Shop/Order/OrderItem/Adjustment/CollectionProviderTest.php
@@ -27,7 +27,6 @@ use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItem;
 use Sylius\Component\Core\Repository\OrderItemRepositoryInterface;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 
 final class CollectionProviderTest extends TestCase
@@ -111,15 +110,13 @@ final class CollectionProviderTest extends TestCase
     {
         $operation = new GetCollection(class: AdjustmentInterface::class);
 
-        $request = $this->createMock(Request::class);
+        $request = new Request(query: ['type' => 'type']);
 
         $orderItem = $this->createMock(OrderItem::class);
 
         $firstAdjustment = $this->createMock(AdjustmentInterface::class);
 
         $secondAdjustment = $this->createMock(AdjustmentInterface::class);
-
-        $request->query = new InputBag(['type' => 'type']);
 
         $adjustments = new ArrayCollection([$firstAdjustment, $secondAdjustment]);
 

--- a/src/Sylius/Bundle/ChannelBundle/tests/Context/FakeChannel/FakeChannelPersisterTest.php
+++ b/src/Sylius/Bundle/ChannelBundle/tests/Context/FakeChannel/FakeChannelPersisterTest.php
@@ -17,10 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ChannelBundle\Context\FakeChannel\FakeChannelCodeProviderInterface;
 use Sylius\Bundle\ChannelBundle\Context\FakeChannel\FakeChannelPersister;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -33,11 +31,9 @@ final class FakeChannelPersisterTest extends TestCase
 
     private HttpKernelInterface&MockObject $kernelMock;
 
-    private MockObject&Request $requestMock;
+    private Request $request;
 
-    private MockObject&Response $responseMock;
-
-    private MockObject&ResponseHeaderBag $responseHeaderBag;
+    private Response $response;
 
     protected function setUp(): void
     {
@@ -45,40 +41,39 @@ final class FakeChannelPersisterTest extends TestCase
         $this->fakeChannelCodeProvider = $this->createMock(FakeChannelCodeProviderInterface::class);
         $this->fakeChannelPersister = new FakeChannelPersister($this->fakeChannelCodeProvider);
         $this->kernelMock = $this->createMock(HttpKernelInterface::class);
-        $this->requestMock = $this->createMock(Request::class);
-        $this->responseMock = $this->createMock(Response::class);
-        $this->responseHeaderBag = $this->createMock(ResponseHeaderBag::class);
+        $this->request = new Request();
+        $this->response = new Response();
     }
 
     public function testAppliesOnlyToMasterRequests(): void
     {
         $this->fakeChannelCodeProvider->expects(self::never())->method('getCode');
 
-        $this->responseMock->headers = $this->responseHeaderBag;
-
-        $this->responseMock->headers->expects(self::never())->method('setCookie');
-
         $this->fakeChannelPersister->onKernelResponse(new ResponseEvent(
             $this->kernelMock,
-            $this->requestMock,
+            $this->request,
             HttpKernelInterface::SUB_REQUEST,
-            $this->responseMock,
+            $this->response,
         ));
+
+        self::assertCount(0, $this->response->headers->getCookies());
     }
 
     public function testAppliesOnlyForRequestWithFakeChannelCode(): void
     {
         $this->fakeChannelCodeProvider->expects(self::once())
             ->method('getCode')
-            ->with($this->requestMock)
+            ->with($this->request)
             ->willReturn(null);
 
         $this->fakeChannelPersister->onKernelResponse(new ResponseEvent(
             $this->kernelMock,
-            $this->requestMock,
+            $this->request,
             HttpKernelInterface::MAIN_REQUEST,
-            $this->responseMock,
+            $this->response,
         ));
+
+        self::assertCount(0, $this->response->headers->getCookies());
     }
 
     public function testPersistsFakeChannelCodesInACookie(): void
@@ -86,22 +81,20 @@ final class FakeChannelPersisterTest extends TestCase
         $this->fakeChannelCodeProvider
             ->expects(self::once())
             ->method('getCode')
-            ->with($this->requestMock)
+            ->with($this->request)
             ->willReturn('fake_channel_code');
-
-        $this->responseMock->headers = $this->responseHeaderBag;
-
-        $this->responseHeaderBag
-            ->expects(self::once())
-            ->method('setCookie')
-            ->with($this->callback(fn (Cookie $cookie) => $cookie->getName() === '_channel_code' &&
-                $cookie->getValue() === 'fake_channel_code'));
 
         $this->fakeChannelPersister->onKernelResponse(new ResponseEvent(
             $this->kernelMock,
-            $this->requestMock,
+            $this->request,
             HttpKernelInterface::MAIN_REQUEST,
-            $this->responseMock,
+            $this->response,
         ));
+
+        $cookies = $this->response->headers->getCookies();
+
+        self::assertCount(1, $cookies);
+        self::assertSame('_channel_code', $cookies[0]->getName());
+        self::assertSame('fake_channel_code', $cookies[0]->getValue());
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/Checkout/CheckoutRedirectListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Checkout/CheckoutRedirectListenerTest.php
@@ -20,7 +20,6 @@ use Sylius\Bundle\CoreBundle\Checkout\CheckoutRedirectListener;
 use Sylius\Bundle\CoreBundle\Checkout\CheckoutStateUrlGeneratorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Resource\Symfony\EventDispatcher\GenericEvent;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
@@ -47,7 +46,8 @@ final class CheckoutRedirectListenerTest extends TestCase
     public function testRedirectsToProperRouteBasedOnOrderCheckoutState(): void
     {
         $order = $this->createMock(OrderInterface::class);
-        $request = $this->createMock(Request::class);
+        $request = new Request();
+        $request->attributes->set('_sylius', []);
         $resourceControllerEvent = $this->createMock(GenericEvent::class);
 
         $this->requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
@@ -58,8 +58,6 @@ final class CheckoutRedirectListenerTest extends TestCase
             ->with($request)
             ->willReturn(true)
         ;
-
-        $request->attributes = new ParameterBag(['_sylius' => []]);
 
         $resourceControllerEvent->expects($this->once())->method('getSubject')->willReturn($order);
 
@@ -81,7 +79,7 @@ final class CheckoutRedirectListenerTest extends TestCase
 
     public function testDoesNothingIfCurrentRequestIsNotCheckoutRequest(): void
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
         $resourceControllerEvent = $this->createMock(GenericEvent::class);
 
         $this->requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
@@ -100,7 +98,8 @@ final class CheckoutRedirectListenerTest extends TestCase
 
     public function testDoesNothingIfCurrentRequestHasRedirectConfigured(): void
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
+        $request->attributes->set('_sylius', ['redirect' => 'redirect_route']);
         $resourceControllerEvent = $this->createMock(GenericEvent::class);
 
         $this->requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
@@ -111,8 +110,6 @@ final class CheckoutRedirectListenerTest extends TestCase
             ->with($request)
             ->willReturn(true)
         ;
-
-        $request->attributes = new ParameterBag(['_sylius' => ['redirect' => 'redirect_route']]);
 
         $resourceControllerEvent->expects($this->never())->method('getSubject');
 
@@ -121,7 +118,8 @@ final class CheckoutRedirectListenerTest extends TestCase
 
     public function testThrowsExceptionIfEventSubjectIsNotAnOrder(): void
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
+        $request->attributes->set('_sylius', []);
         $resourceControllerEvent = $this->createMock(GenericEvent::class);
 
         $this->requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
@@ -132,8 +130,6 @@ final class CheckoutRedirectListenerTest extends TestCase
             ->with($request)
             ->willReturn(true)
         ;
-
-        $request->attributes = new ParameterBag(['_sylius' => []]);
 
         $resourceControllerEvent
             ->expects($this->once())

--- a/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestBasedLocaleContextTest.php
+++ b/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestBasedLocaleContextTest.php
@@ -19,7 +19,6 @@ use Sylius\Bundle\LocaleBundle\Context\RequestBasedLocaleContext;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -33,16 +32,12 @@ final class RequestBasedLocaleContextTest extends TestCase
 
     private RequestBasedLocaleContext $requestBasedLocaleContext;
 
-    /** @var Request&MockObject */
-    private Request $request;
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->requestStack = $this->createMock(RequestStack::class);
         $this->localeProvider = $this->createMock(LocaleProviderInterface::class);
         $this->requestBasedLocaleContext = new RequestBasedLocaleContext($this->requestStack, $this->localeProvider);
-        $this->request = $this->createMock(Request::class);
     }
 
     public function testALocaleContext(): void
@@ -63,9 +58,7 @@ final class RequestBasedLocaleContextTest extends TestCase
     {
         $this->requestStack->expects(self::once())
             ->method('getMainRequest')
-            ->willReturn($this->request);
-
-        $this->request->attributes = new ParameterBag();
+            ->willReturn(new Request());
 
         self::expectException(LocaleNotFoundException::class);
 
@@ -76,9 +69,7 @@ final class RequestBasedLocaleContextTest extends TestCase
     {
         $this->requestStack->expects(self::once())
             ->method('getMainRequest')
-            ->willReturn($this->request);
-
-        $this->request->attributes = new ParameterBag(['_locale' => 'en_US']);
+            ->willReturn(new Request(attributes: ['_locale' => 'en_US']));
 
         $this->localeProvider->expects(self::once())
             ->method('getAvailableLocalesCodes')
@@ -93,9 +84,7 @@ final class RequestBasedLocaleContextTest extends TestCase
     {
         $this->requestStack->expects(self::once())
             ->method('getMainRequest')
-            ->willReturn($this->request);
-
-        $this->request->attributes = new ParameterBag(['_locale' => 'pl_PL']);
+            ->willReturn(new Request(attributes: ['_locale' => 'pl_PL']));
 
         $this->localeProvider->expects(self::once())
             ->method('getAvailableLocalesCodes')

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -30,7 +30,7 @@
         "php": "^8.2",
         "sylius/core-bundle": "^2.0",
         "sylius/payum-bundle": "^2.0",
-        "sylius/twig-hooks": "^0.9 || ^0.10",
+        "sylius/twig-hooks": "^0.9 || ^0.10 || ^0.11",
         "sylius/ui-bundle": "^2.0",
         "sylius/theme-bundle": "^2.4",
         "symfony/framework-bundle": "^6.4.1 || ^7.4 || ^8.0",

--- a/src/Sylius/Bundle/ShopBundle/tests/EventListener/NonChannelLocaleListenerTest.php
+++ b/src/Sylius/Bundle/ShopBundle/tests/EventListener/NonChannelLocaleListenerTest.php
@@ -19,7 +19,6 @@ use Sylius\Bundle\ShopBundle\EventListener\NonChannelLocaleListener;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -87,8 +86,7 @@ final class NonChannelLocaleListenerTest extends TestCase
 
     public function testItDoesNothingIfRequestBehindNoFirewall(): void
     {
-        $request = $this->createMock(Request::class);
-        $request->attributes = new ParameterBag(['_locale' => 'en']);
+        $request = new Request(attributes: ['_locale' => 'en']);
         $event = $this->createMock(RequestEvent::class);
 
         $event->expects($this->once())->method('isMainRequest')->willReturn(true);
@@ -102,8 +100,7 @@ final class NonChannelLocaleListenerTest extends TestCase
 
     public function testItDoesNothingIfFirewallNotInAllowedList(): void
     {
-        $request = $this->createMock(Request::class);
-        $request->attributes = new ParameterBag(['_locale' => 'en']);
+        $request = new Request(attributes: ['_locale' => 'en']);
         $event = $this->createMock(RequestEvent::class);
 
         $event->expects($this->once())->method('isMainRequest')->willReturn(true);
@@ -123,8 +120,8 @@ final class NonChannelLocaleListenerTest extends TestCase
 
     public function testItDoesNothingIfRequestLocaleIsInProvider(): void
     {
-        $request = $this->createMock(Request::class);
-        $request->attributes = new ParameterBag(['_locale' => 'en']);
+        $request = new Request(attributes: ['_locale' => 'en']);
+        $request->setLocale('en');
         $event = $this->createMock(RequestEvent::class);
 
         $event->expects($this->once())->method('isMainRequest')->willReturn(true);
@@ -137,8 +134,6 @@ final class NonChannelLocaleListenerTest extends TestCase
             ->with($request)
             ->willReturn($firewallConfig)
         ;
-
-        $request->expects($this->once())->method('getLocale')->willReturn('en');
 
         $this->localeProvider->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['en', 'ga_IE']);
 
@@ -147,8 +142,8 @@ final class NonChannelLocaleListenerTest extends TestCase
 
     public function testItRedirectsToDefaultLocaleIfRequestLocaleNotInProvider(): void
     {
-        $request = $this->createMock(Request::class);
-        $request->attributes = new ParameterBag(['_locale' => 'en']);
+        $request = new Request(attributes: ['_locale' => 'en']);
+        $request->setLocale('en');
         $event = $this->createMock(RequestEvent::class);
 
         $event->expects($this->once())->method('isMainRequest')->willReturn(true);
@@ -161,8 +156,6 @@ final class NonChannelLocaleListenerTest extends TestCase
             ->with($request)
             ->willReturn($firewallConfig)
         ;
-
-        $request->expects($this->once())->method('getLocale')->willReturn('en');
 
         $this->localeProvider->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['ga', 'ga_IE']);
         $this->localeProvider->expects($this->once())->method('getDefaultLocaleCode')->willReturn('ga');
@@ -185,14 +178,14 @@ final class NonChannelLocaleListenerTest extends TestCase
 
     public function testItDoesNothingIfRequestAttributesHasNoLocale(): void
     {
-        $request = $this->createMock(Request::class);
-        $request->attributes = new ParameterBag();
+        $request = new Request();
         $event = $this->createMock(RequestEvent::class);
 
         $event->expects($this->once())->method('isMainRequest')->willReturn(true);
         $event->expects($this->once())->method('getRequest')->willReturn($request);
 
-        $request->expects($this->never())->method('getLocale');
+        $this->firewallMap->expects($this->never())->method('getFirewallConfig');
+        $event->expects($this->never())->method('setResponse');
 
         $this->nonChannelLocaleListener->restrictRequestLocale($event);
     }

--- a/src/Sylius/Bundle/ShopBundle/tests/EventListener/ShopCustomerAccountSubSectionCacheControlSubscriberTest.php
+++ b/src/Sylius/Bundle/ShopBundle/tests/EventListener/ShopCustomerAccountSubSectionCacheControlSubscriberTest.php
@@ -21,7 +21,6 @@ use Sylius\Bundle\ShopBundle\EventListener\ShopCustomerAccountSubSectionCacheCon
 use Sylius\Bundle\ShopBundle\SectionResolver\ShopCustomerAccountSubSection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -52,67 +51,46 @@ final class ShopCustomerAccountSubSectionCacheControlSubscriberTest extends Test
     {
         /** @var HttpKernelInterface&MockObject $kernel */
         $kernel = $this->createMock(HttpKernelInterface::class);
-        /** @var Request&MockObject $request */
-        $request = $this->createMock(Request::class);
-        /** @var Response&MockObject $response */
-        $response = $this->createMock(Response::class);
-        /** @var ResponseHeaderBag&MockObject $responseHeaderBag */
-        $responseHeaderBag = $this->createMock(ResponseHeaderBag::class);
         /** @var ShopCustomerAccountSubSection&MockObject $customerAccountSubSection */
         $customerAccountSubSection = $this->createMock(ShopCustomerAccountSubSection::class);
 
+        $response = new Response();
+
         $this->sectionProvider->expects($this->once())->method('getSection')->willReturn($customerAccountSubSection);
-        $response->headers = $responseHeaderBag;
         $event = new ResponseEvent(
             $kernel,
-            $request,
+            new Request(),
             KernelInterface::MAIN_REQUEST,
             $response,
         );
 
-        $expectedCalls = [
-            ['no-cache', true],
-            ['max-age', '0'],
-            ['must-revalidate', true],
-            ['no-store', true],
-        ];
-
-        $callIndex = 0;
-        $responseHeaderBag->expects($this->exactly(4))
-            ->method('addCacheControlDirective')
-            ->willReturnCallback(function ($directive, $value) use (&$callIndex, $expectedCalls) {
-                [$expectedDirective, $expectedValue] = $expectedCalls[$callIndex];
-                $this->assertSame($expectedDirective, $directive);
-                $this->assertSame($expectedValue, $value);
-                ++$callIndex;
-            })
-        ;
-
         $this->shopCustomerAccountSubSectionCacheControlSubscriber->setCacheControlDirectives($event);
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertSame('0', $response->headers->getCacheControlDirective('max-age'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
     }
 
     public function testDoesNothingIfSectionIsDifferentThanCustomerAccount(): void
     {
         /** @var HttpKernelInterface&MockObject $kernel */
         $kernel = $this->createMock(HttpKernelInterface::class);
-        /** @var Request&MockObject $request */
-        $request = $this->createMock(Request::class);
-        /** @var Response&MockObject $response */
-        $response = $this->createMock(Response::class);
-        /** @var ResponseHeaderBag&MockObject $responseHeaderBag */
-        $responseHeaderBag = $this->createMock(ResponseHeaderBag::class);
         /** @var SectionInterface&MockObject $section */
         $section = $this->createMock(SectionInterface::class);
+
+        $response = new Response();
+
         $this->sectionProvider->expects($this->once())->method('getSection')->willReturn($section);
-        $response->headers = $responseHeaderBag;
         $event = new ResponseEvent(
             $kernel,
-            $request,
+            new Request(),
             KernelInterface::MAIN_REQUEST,
             $response,
         );
-        $responseHeaderBag->expects($this->never())->method('addCacheControlDirective');
 
         $this->shopCustomerAccountSubSectionCacheControlSubscriber->setCacheControlDirectives($event);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
     }
 }

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -34,7 +34,7 @@
         "knplabs/knp-menu-bundle": "^3.4",
         "laminas/laminas-stdlib": "^3.19",
         "sylius/grid-bundle": "^1.16",
-        "sylius/twig-extra": "^0.9 || ^0.10",
+        "sylius/twig-extra": "^0.9 || ^0.10 || ^0.11",
         "symfony/config": "^6.4 || ^7.4 || ^8.0",
         "symfony/expression-language": "^6.4 || ^7.4 || ^8.0",
         "symfony/framework-bundle": "^6.4.1 || ^7.4 || ^8.0",

--- a/src/Sylius/Bundle/UiBundle/tests/Controller/SecurityControllerTest.php
+++ b/src/Sylius/Bundle/UiBundle/tests/Controller/SecurityControllerTest.php
@@ -19,7 +19,6 @@ use Sylius\Bundle\UiBundle\Controller\SecurityController;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -40,7 +39,7 @@ final class SecurityControllerTest extends TestCase
 
     private MockObject&RouterInterface $router;
 
-    private MockObject&Request $request;
+    private Request $request;
 
     private SecurityController $securityController;
 
@@ -51,7 +50,7 @@ final class SecurityControllerTest extends TestCase
         $this->templatingEngine = $this->createMock(Environment::class);
         $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $this->router = $this->createMock(RouterInterface::class);
-        $this->request = $this->createMock(Request::class);
+        $this->request = new Request();
 
         $this->securityController = new SecurityController(
             $this->authenticationUtils,
@@ -64,9 +63,10 @@ final class SecurityControllerTest extends TestCase
 
     public function testRendersLoginForm(): void
     {
-        /** @var ParameterBag&MockObject $requestAttributes */
-        $requestAttributes = $this->createMock(ParameterBag::class);
-        $this->request->attributes = $requestAttributes;
+        $this->request->attributes->set('_sylius', [
+            'template' => 'CustomTemplateName',
+            'form' => 'custom_form_type',
+        ]);
         /** @var Form&MockObject $form */
         $form = $this->createMock(Form::class);
         /** @var FormView&MockObject $formView */
@@ -78,10 +78,6 @@ final class SecurityControllerTest extends TestCase
         $this->authenticationUtils->expects($this->once())->method('getLastAuthenticationError')->willReturn($authenticationException);
         $this->authenticationUtils->expects($this->once())->method('getLastUsername')->willReturn('john.doe');
 
-        $requestAttributes->expects($this->atLeastOnce())->method('get')->with('_sylius', [])->willReturn([
-            'template' => 'CustomTemplateName',
-            'form' => 'custom_form_type',
-        ]);
         $this->formFactory->expects($this->once())->method('createNamed')->with('', 'custom_form_type')->willReturn($form);
         $form->expects($this->once())->method('createView')->willReturn($formView);
         $this->templatingEngine->expects($this->once())->method('render')->with('CustomTemplateName', [
@@ -96,11 +92,8 @@ final class SecurityControllerTest extends TestCase
 
     public function testRedirectsWhenUserIsLoggedIn(): void
     {
-        /** @var ParameterBag&MockObject $requestAttributes */
-        $requestAttributes = $this->createMock(ParameterBag::class);
-        $this->request->attributes = $requestAttributes;
+        $this->request->attributes->set('_sylius', ['logged_in_route' => 'foo_bar']);
 
-        $requestAttributes->expects($this->once())->method('get')->with('_sylius', [])->willReturn(['logged_in_route' => 'foo_bar']);
         $this->authorizationChecker->expects($this->once())->method('isGranted')->with('IS_AUTHENTICATED_FULLY')->willReturn(true);
         $this->router->expects($this->once())->method('generate')->with('foo_bar')->willReturn('/login');
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for Symfony 8.1 across automated test and package validation scenarios.
  * Expanded compatibility with the latest Twig Hooks and Twig Extra releases.

* **Quality Assurance**
  * Re-enabled package version validation in static checks.
  * Improved test reliability by using realistic HTTP requests, responses, uploads, cookies, headers, and locale data in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->