### PR TITLE
[CoreBundle] [2.3] Fix PlatformHelper::isMysql() to also recognize MariaDB platforms

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/Platform/PlatformHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/Platform/PlatformHelper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Doctrine\Platform;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
 final class PlatformHelper
@@ -22,9 +22,10 @@ final class PlatformHelper
     {
     }
 
+    /** Matches both MySQL and MariaDB, as they share the same AbstractMySQLPlatform ancestor. */
     public static function isMysql(object $platform): bool
     {
-        return is_a($platform, MySQLPlatform::class, true);
+        return is_a($platform, AbstractMySQLPlatform::class, true);
     }
 
     public static function isPostgreSQL(object $platform): bool

--- a/src/Sylius/Bundle/CoreBundle/tests/Doctrine/Platform/PlatformHelperTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Doctrine/Platform/PlatformHelperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\CoreBundle\Doctrine\Platform;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Doctrine\Platform\PlatformHelper;
+
+final class PlatformHelperTest extends TestCase
+{
+    public function test_it_recognizes_mysql_platform(): void
+    {
+        self::assertTrue(PlatformHelper::isMysql(new MySQLPlatform()));
+    }
+
+    public function test_it_recognizes_mariadb_platform(): void
+    {
+        self::assertTrue(PlatformHelper::isMysql(new MariaDBPlatform()));
+    }
+
+    /** Versioned MariaDB platform classes were renamed between dbal 3.x and 4.x, so we test the ancestor match instead of a specific class name. */
+    public function test_it_recognizes_any_mysql_or_mariadb_platform_subclass(): void
+    {
+        $versionedPlatform = new class extends AbstractMySQLPlatform {
+        };
+
+        self::assertTrue(PlatformHelper::isMysql($versionedPlatform));
+    }
+
+    public function test_it_does_not_recognize_other_platforms_as_mysql(): void
+    {
+        self::assertFalse(PlatformHelper::isMysql(new PostgreSQLPlatform()));
+        self::assertFalse(PlatformHelper::isMysql(new SQLitePlatform()));
+    }
+
+    public function test_it_recognizes_postgresql_platform(): void
+    {
+        self::assertTrue(PlatformHelper::isPostgreSQL(new PostgreSQLPlatform()));
+        self::assertFalse(PlatformHelper::isPostgreSQL(new MySQLPlatform()));
+    }
+
+    public function test_it_recognizes_sqlite_platform(): void
+    {
+        self::assertTrue(PlatformHelper::isSqlite(new SQLitePlatform()));
+        self::assertFalse(PlatformHelper::isSqlite(new MySQLPlatform()));
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | _none_
| License         | MIT

`MariaDBPlatform` and `MySQLPlatform` are sibling classes that both extend `AbstractMySQLPlatform`, so `is_a()` against MySQLPlatform never matched MariaDB.

This broke the custom YEAR/MONTH/WEEK/DAY/HOUR DQL functions used by the admin dashboard statistics on MariaDB (e.g. MariaDB1010Platform), throwing "Platform ... is not supported!".

<img width="1228" height="288" alt="image" src="https://github.com/user-attachments/assets/68f55826-5e0f-4bc6-8cd7-d0b012272782" />
