### PR TITLE
[CI] Exclude PHP 8.3 with Symfony 8.1 (Symfony 8.1 requires PHP >= 8.4.1)

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -269,6 +269,12 @@
           "php": "8.5",
           "symfony": "~8.0.0"
         }
+      ],
+      "exclude": [
+        {
+          "php": "8.3",
+          "symfony": "~8.1.0"
+        }
       ]
     },
     "e2e-mariadb": {
@@ -312,6 +318,12 @@
           "state_machine_adapter": "symfony_workflow",
           "legacy_grid_config": false
         }
+      ],
+      "exclude": [
+        {
+          "php": "8.3",
+          "symfony": "~8.1.0"
+        }
       ]
     },
     "e2e-mysql": {
@@ -348,6 +360,12 @@
           "mysql": "8.4",
           "twig": "^3.3",
           "doctrine_bundle": "^3.0"
+        }
+      ],
+      "exclude": [
+        {
+          "php": "8.3",
+          "symfony": "~8.1.0"
         }
       ]
     },
@@ -508,6 +526,12 @@
           "postgres": "17.5",
           "doctrine_bundle": "^3.0"
         }
+      ],
+      "exclude": [
+        {
+          "php": "8.3",
+          "symfony": "~8.1.0"
+        }
       ]
     },
     "frontend": {
@@ -531,6 +555,12 @@
         {
           "php": "8.4",
           "symfony": "~8.0.0"
+        }
+      ],
+      "exclude": [
+        {
+          "php": "8.3",
+          "symfony": "~8.1.0"
         }
       ]
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
