### PR TITLE
[2.2][FIX] Behat live component wait

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,5 +1,18 @@
 # UPGRADE FROM `2.2.6` TO `2.2.7`
 
+## Behat
+
+1. The `waitForFormUpdate()` methods in the Behat page objects and elements now delegate to the new
+   `Sylius\Behat\Service\DriverHelper::waitForLiveComponentUpdate()` helper.
+   The previous implementation checked the `busy` attribute on the `form` element and relied on a fixed `sleep`,
+   but Symfony UX Live Components set `busy` on the component root (`[data-controller~="live"]`), not on the form,
+   so the wait was effectively a no-op. The helper now waits document-wide for `[busy]`/`[data-live-is-loading]`
+   markers to appear and then disappear, without any hardcoded sleep.
+   If you overrode `waitForFormUpdate()` in your own page objects, delegate to the helper as well.
+
+2. The `live_form` element and the `waitForFormUpdate()` override were removed from
+   `Sylius\Behat\Page\Admin\Order\UpdatePage`; it now inherits the shared implementation.
+
 ## Constructor Signature Changes
 
 1. The constructor of `Sylius\Bundle\ApiBundle\ApiPlatform\Routing\IriConverter` has been extended with an optional `ApiPlatform\Metadata\ResourceClassResolverInterface` argument.
@@ -126,16 +139,3 @@ SYLIUS_TELEMETRY_SALT=your-custom-salt
 1. The `TranslationLocaleProvider` now ensures that the default locale (configured as `locale` in `config/parameters.yaml`)
    is always placed at the beginning of the returned locales array.  
    Other locales remain in the same order as returned by the repository.
-
-## Behat
-
-1. The `waitForFormUpdate()` methods in the Behat page objects and elements now delegate to the new
-   `Sylius\Behat\Service\DriverHelper::waitForLiveComponentUpdate()` helper.
-   The previous implementation checked the `busy` attribute on the `form` element and relied on a fixed `sleep`,
-   but Symfony UX Live Components set `busy` on the component root (`[data-controller~="live"]`), not on the form,
-   so the wait was effectively a no-op. The helper now waits document-wide for `[busy]`/`[data-live-is-loading]`
-   markers to appear and then disappear, without any hardcoded sleep.
-   If you overrode `waitForFormUpdate()` in your own page objects, delegate to the helper as well.
-
-1. The `live_form` element and the `waitForFormUpdate()` override were removed from
-   `Sylius\Behat\Page\Admin\Order\UpdatePage`; it now inherits the shared implementation.

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -126,3 +126,16 @@ SYLIUS_TELEMETRY_SALT=your-custom-salt
 1. The `TranslationLocaleProvider` now ensures that the default locale (configured as `locale` in `config/parameters.yaml`)
    is always placed at the beginning of the returned locales array.  
    Other locales remain in the same order as returned by the repository.
+
+## Behat
+
+1. The `waitForFormUpdate()` methods in the Behat page objects and elements now delegate to the new
+   `Sylius\Behat\Service\DriverHelper::waitForLiveComponentUpdate()` helper.
+   The previous implementation checked the `busy` attribute on the `form` element and relied on a fixed `sleep`,
+   but Symfony UX Live Components set `busy` on the component root (`[data-controller~="live"]`), not on the form,
+   so the wait was effectively a no-op. The helper now waits document-wide for `[busy]`/`[data-live-is-loading]`
+   markers to appear and then disappear, without any hardcoded sleep.
+   If you overrode `waitForFormUpdate()` in your own page objects, delegate to the helper as well.
+
+1. The `live_form` element and the `waitForFormUpdate()` override were removed from
+   `Sylius\Behat\Page\Admin\Order\UpdatePage`; it now inherits the shared implementation.

--- a/src/Sylius/Behat/Element/Admin/Crud/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Crud/FormElement.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Element\Admin\Crud;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Element\SyliusElement;
+use Sylius\Behat\Service\DriverHelper;
 
 class FormElement extends SyliusElement implements FormElementInterface
 {
@@ -68,10 +69,7 @@ class FormElement extends SyliusElement implements FormElementInterface
 
     protected function waitForFormUpdate(): void
     {
-        $form = $this->getElement('form');
-
-        usleep(500000); // we need to sleep, as sometimes the check below is executed faster than the form sets the busy attribute
-        $form->waitFor(1500, fn () => !$form->hasAttribute('busy'));
+        DriverHelper::waitForLiveComponentUpdate($this->getSession());
     }
 
     /**

--- a/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
+++ b/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
@@ -119,10 +119,7 @@ class RegisterElement extends SyliusElement implements RegisterElementInterface
 
     protected function waitForFormUpdate(): void
     {
-        $form = $this->getElement('form');
-
-        usleep(500000); // we need to sleep, as sometimes the check below is executed faster than the form sets the busy attribute
-        $form->waitFor(1500, fn () => !$form->hasAttribute('busy'));
+        DriverHelper::waitForLiveComponentUpdate($this->getSession());
     }
 
     /**

--- a/src/Sylius/Behat/Element/SyliusElement.php
+++ b/src/Sylius/Behat/Element/SyliusElement.php
@@ -35,12 +35,14 @@ abstract class SyliusElement extends BaseElement
 
         // Wait for ALL LiveComponents to complete their operations
         // Returns immediately if condition is already met
-        // Max 10 seconds for: DOM ready, no loading indicators, no busy elements
+        // Max 10 seconds for: DOM ready, no loading indicators, no busy Live Component roots.
+        // The "busy" probe is scoped to the "live" Stimulus controller root (where ux-live-component
+        // sets it) so an unrelated "busy" attribute elsewhere in the DOM cannot stall the wait.
         $this->getSession()->wait(
             10000,
             "document.readyState === 'complete' && " .
             "document.querySelectorAll('[data-live-is-loading]').length === 0 && " .
-            "document.querySelectorAll('[busy]').length === 0",
+            "document.querySelectorAll('[data-controller~=\"live\"][busy]').length === 0",
         );
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -86,11 +86,7 @@ class CreatePage extends SyliusPage implements CreatePageInterface
 
     protected function waitForFormUpdate(): void
     {
-        $form = $this->getElement('form');
-        sleep(1); // we need to sleep, as sometimes the check below is executed faster than the form sets the busy attribute
-        $form->waitFor(1500, function () use ($form) {
-            return !$form->hasAttribute('busy');
-        });
+        DriverHelper::waitForLiveComponentUpdate($this->getSession());
     }
 
     protected function verifyStatusCode(): void

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -201,11 +201,7 @@ class IndexPage extends SyliusPage implements IndexPageInterface
 
     protected function waitForFormUpdate(): void
     {
-        $form = $this->getElement('filters_form');
-        usleep(500000); // we need to sleep, as sometimes the check below is executed faster than the form sets the busy attribute
-        $form->waitFor(1500, function () use ($form) {
-            return !$form->hasAttribute('busy');
-        });
+        DriverHelper::waitForLiveComponentUpdate($this->getSession());
     }
 
     protected function getDefinedElements(): array

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -97,11 +97,7 @@ class UpdatePage extends SyliusPage implements UpdatePageInterface
 
     protected function waitForFormUpdate(): void
     {
-        $form = $this->getElement('form');
-        sleep(1); // we need to sleep, as sometimes the check below is executed faster than the form sets the busy attribute
-        $form->waitFor(1500, function () use ($form) {
-            return !$form->hasAttribute('busy');
-        });
+        DriverHelper::waitForLiveComponentUpdate($this->getSession());
     }
 
     protected function verifyStatusCode(): void

--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
@@ -104,7 +104,6 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             'billing_province_name' => '#sylius_admin_order_billingAddress_provinceName',
             'billing_province_code' => '#sylius_admin_order_billingAddress_provinceCode',
             'billing_street' => '#sylius_admin_order_billingAddress_street',
-            'live_form' => '[data-live-name-value="sylius_admin:order:form"]',
             'shipping_city' => '#sylius_admin_order_shippingAddress_city',
             'shipping_country' => '#sylius_admin_order_shippingAddress_countryCode',
             'shipping_first_name' => '#sylius_admin_order_shippingAddress_firstName',
@@ -143,10 +142,5 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         }
 
         return $element;
-    }
-
-    protected function waitForFormUpdate(): void
-    {
-        $this->getElement('live_form')->waitFor('5', fn (NodeElement $element) => !$element->hasAttribute('busy'));
     }
 }

--- a/src/Sylius/Behat/Service/DriverHelper.php
+++ b/src/Sylius/Behat/Service/DriverHelper.php
@@ -67,15 +67,17 @@ abstract class DriverHelper
         }
 
         // Give the Live Component a brief, bounded chance to START the request.
-        // The "busy" attribute is set on the Live Component root element (not the form),
-        // so we probe both it and the "data-live-is-loading" markers document-wide.
-        $session->wait(1000, "document.querySelectorAll('[busy], [data-live-is-loading]').length > 0");
+        // The "busy" attribute is set by ux-live-component on the Live Component root element
+        // (the one carrying the "live" Stimulus controller), not on the form. We scope the "busy"
+        // probe to that root so that an unrelated "busy" attribute appearing elsewhere in the DOM
+        // cannot stall the wait; the "data-live-is-loading" marker is Live Component specific already.
+        $session->wait(1000, "document.querySelectorAll('[data-controller~=\"live\"][busy], [data-live-is-loading]').length > 0");
 
         // Wait until ALL Live Component requests have FINISHED.
         $session->wait(
             $timeout,
             "document.readyState === 'complete' && " .
-            "document.querySelectorAll('[busy], [data-live-is-loading]').length === 0",
+            "document.querySelectorAll('[data-controller~=\"live\"][busy], [data-live-is-loading]').length === 0",
         );
     }
 }

--- a/src/Sylius/Behat/Service/DriverHelper.php
+++ b/src/Sylius/Behat/Service/DriverHelper.php
@@ -59,4 +59,23 @@ abstract class DriverHelper
             $session->wait($timeout, "document.readyState === 'complete' && !document.querySelector('[data-live-is-loading]')");
         }
     }
+
+    public static function waitForLiveComponentUpdate(Session $session, int $timeout = 5000): void
+    {
+        if (self::isNotJavascript($session->getDriver())) {
+            return;
+        }
+
+        // Give the Live Component a brief, bounded chance to START the request.
+        // The "busy" attribute is set on the Live Component root element (not the form),
+        // so we probe both it and the "data-live-is-loading" markers document-wide.
+        $session->wait(1000, "document.querySelectorAll('[busy], [data-live-is-loading]').length > 0");
+
+        // Wait until ALL Live Component requests have FINISHED.
+        $session->wait(
+            $timeout,
+            "document.readyState === 'complete' && " .
+            "document.querySelectorAll('[busy], [data-live-is-loading]').length === 0",
+        );
+    }
 }

--- a/src/Sylius/Behat/tests/Service/DriverHelperTest.php
+++ b/src/Sylius/Behat/tests/Service/DriverHelperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Behat\Service;
+
+use Behat\Mink\Driver\DriverInterface;
+use Behat\Mink\Session;
+use DMore\ChromeDriver\ChromeDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylius\Behat\Service\DriverHelper;
+
+#[CoversClass(DriverHelper::class)]
+final class DriverHelperTest extends TestCase
+{
+    public function testItDoesNotWaitWhenDriverIsNotJavascript(): void
+    {
+        $driver = $this->createMock(DriverInterface::class);
+        $session = $this->createMock(Session::class);
+        $session->method('getDriver')->willReturn($driver);
+
+        $session->expects($this->never())->method('wait');
+
+        DriverHelper::waitForLiveComponentUpdate($session);
+    }
+
+    public function testItWaitsForTheLiveComponentRequestToStartAndFinishWhenDriverIsJavascript(): void
+    {
+        $driver = $this->createMock(ChromeDriver::class);
+        $session = $this->createMock(Session::class);
+        $session->method('getDriver')->willReturn($driver);
+
+        $calls = [];
+        $session->method('wait')->willReturnCallback(function (int $timeout, string $condition) use (&$calls): bool {
+            $calls[] = ['timeout' => $timeout, 'condition' => $condition];
+
+            return true;
+        });
+
+        DriverHelper::waitForLiveComponentUpdate($session, 5000);
+
+        $this->assertCount(2, $calls, 'It should wait for the request to start and then to finish.');
+
+        // 1) It probes for the "busy" marker on the Live Component root (and loading markers) document-wide,
+        //    NOT on the form element, and waits for the request to START.
+        $this->assertSame(1000, $calls[0]['timeout']);
+        $this->assertStringContainsString("querySelectorAll('[busy], [data-live-is-loading]')", $calls[0]['condition']);
+        $this->assertStringContainsString('.length > 0', $calls[0]['condition']);
+
+        // 2) It waits until ALL Live Component requests have FINISHED.
+        $this->assertSame(5000, $calls[1]['timeout']);
+        $this->assertStringContainsString("querySelectorAll('[busy], [data-live-is-loading]')", $calls[1]['condition']);
+        $this->assertStringContainsString('.length === 0', $calls[1]['condition']);
+        $this->assertStringContainsString("document.readyState === 'complete'", $calls[1]['condition']);
+    }
+}

--- a/src/Sylius/Behat/tests/Service/DriverHelperTest.php
+++ b/src/Sylius/Behat/tests/Service/DriverHelperTest.php
@@ -51,15 +51,15 @@ final class DriverHelperTest extends TestCase
 
         $this->assertCount(2, $calls, 'It should wait for the request to start and then to finish.');
 
-        // 1) It probes for the "busy" marker on the Live Component root (and loading markers) document-wide,
+        // 1) It probes for the "busy" marker scoped to the Live Component root (plus loading markers),
         //    NOT on the form element, and waits for the request to START.
         $this->assertSame(1000, $calls[0]['timeout']);
-        $this->assertStringContainsString("querySelectorAll('[busy], [data-live-is-loading]')", $calls[0]['condition']);
+        $this->assertStringContainsString('querySelectorAll(\'[data-controller~="live"][busy], [data-live-is-loading]\')', $calls[0]['condition']);
         $this->assertStringContainsString('.length > 0', $calls[0]['condition']);
 
         // 2) It waits until ALL Live Component requests have FINISHED.
         $this->assertSame(5000, $calls[1]['timeout']);
-        $this->assertStringContainsString("querySelectorAll('[busy], [data-live-is-loading]')", $calls[1]['condition']);
+        $this->assertStringContainsString('querySelectorAll(\'[data-controller~="live"][busy], [data-live-is-loading]\')', $calls[1]['condition']);
         $this->assertStringContainsString('.length === 0', $calls[1]['condition']);
         $this->assertStringContainsString("document.readyState === 'complete'", $calls[1]['condition']);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #19055 
| License         | MIT


The `waitForFormUpdate()` methods in the Behat page objects and elements now delegate to the new `Sylius\Behat\Service\DriverHelper::waitForLiveComponentUpdate()` helper. The previous implementation checked the `busy` attribute on the `form` element and relied on a fixed `sleep`, but Symfony UX Live Components set `busy` on the component root (`[data-controller~="live"]`), not on the form, so the wait was effectively a no-op. The helper now waits document-wide for `[busy]`/`[data-live-is-loading]` markers to appear and then disappear, without any hardcoded sleep. If you overrode `waitForFormUpdate()` in your own page objects, delegate to the helper as well.

The `live_form` element and the `waitForFormUpdate()` override were removed from `Sylius\Behat\Page\Admin\Order\UpdatePage`; it now inherits the shared implementation.
