### PR TITLE
[Cart] Fix double-counted unit-level promotion in cart summary discount

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -49,26 +49,6 @@
    or `sylius.live_component.*` tag did not receive the `twig.component` tag.
    The priority has been lowered to `50` to ensure Symfony's autoconfiguration runs first.
 
-## Cart summary discount was double-counting the unit-level promotion
-
-The shop cart summary "Discount" row used `Order::getOrderPromotionTotal()`, which sums
-`ORDER_UNIT_PROMOTION_ADJUSTMENT`, `ORDER_ITEM_PROMOTION_ADJUSTMENT` and `ORDER_PROMOTION_ADJUSTMENT`.
-
-`ORDER_UNIT_PROMOTION_ADJUSTMENT` is already netted into each item's subtotal (`OrderItem::getSubtotal()`),
-which is what the "Items total" row above "Discount" displays. Showing it again in "Discount" subtracted
-it twice, so `Items total + Discount + shipping + tax` no longer added up to the actual order total, and
-the discount shown to the customer was larger than what was really applied.
-
-`discount.html.twig` now uses a new `Order::getOrderAndItemPromotionTotal()` method, which sums only
-`ORDER_ITEM_PROMOTION_ADJUSTMENT` and `ORDER_PROMOTION_ADJUSTMENT`, excluding the unit-level adjustment
-already reflected in "Items total".
-
-### Impact on custom code
-
-If you have custom templates, reports, or integrations that reproduce this calculation by calling
-`getOrderPromotionTotal()` next to `getItemsSubtotal()`/`getSubtotal()`, switch to
-`getOrderAndItemPromotionTotal()` to avoid the same double-counting.
-
 ## Order payment state recovery after authorized payment cancellation
 
 When an authorized `Payment` transitions to `cancelled` (e.g. the merchant voids the authorization

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -49,6 +49,26 @@
    or `sylius.live_component.*` tag did not receive the `twig.component` tag.
    The priority has been lowered to `50` to ensure Symfony's autoconfiguration runs first.
 
+## Cart summary discount was double-counting the unit-level promotion
+
+The shop cart summary "Discount" row used `Order::getOrderPromotionTotal()`, which sums
+`ORDER_UNIT_PROMOTION_ADJUSTMENT`, `ORDER_ITEM_PROMOTION_ADJUSTMENT` and `ORDER_PROMOTION_ADJUSTMENT`.
+
+`ORDER_UNIT_PROMOTION_ADJUSTMENT` is already netted into each item's subtotal (`OrderItem::getSubtotal()`),
+which is what the "Items total" row above "Discount" displays. Showing it again in "Discount" subtracted
+it twice, so `Items total + Discount + shipping + tax` no longer added up to the actual order total, and
+the discount shown to the customer was larger than what was really applied.
+
+`discount.html.twig` now uses a new `Order::getOrderAndItemPromotionTotal()` method, which sums only
+`ORDER_ITEM_PROMOTION_ADJUSTMENT` and `ORDER_PROMOTION_ADJUSTMENT`, excluding the unit-level adjustment
+already reflected in "Items total".
+
+### Impact on custom code
+
+If you have custom templates, reports, or integrations that reproduce this calculation by calling
+`getOrderPromotionTotal()` next to `getItemsSubtotal()`/`getSubtotal()`, switch to
+`getOrderAndItemPromotionTotal()` to avoid the same double-counting.
+
 ## Order payment state recovery after authorized payment cancellation
 
 When an authorized `Payment` transitions to `cancelled` (e.g. the merchant voids the authorization

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -444,6 +444,37 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    Payment Request layer in `Sylius\Bundle\ApiBundle`. These classes are now covered by the Sylius Backward
    Compatibility policy.
 
+## Order
+
+1. A new `getOrderAndItemPromotionTotal(): int` method has been added to
+   `Sylius\Component\Core\Model\OrderInterface` and implemented in `Sylius\Component\Core\Model\Order`.
+
+   ```php
+   public function getOrderAndItemPromotionTotal(): int;
+   ```
+
+   If you have custom classes implementing this interface without extending `Sylius\Component\Core\Model\Order`,
+   you must add this method.
+
+   `getOrderPromotionTotal()` sums `ORDER_UNIT_PROMOTION_ADJUSTMENT`, `ORDER_ITEM_PROMOTION_ADJUSTMENT` and
+   `ORDER_PROMOTION_ADJUSTMENT` together. The unit-level adjustment is already netted into each item's subtotal
+   (`OrderItem::getSubtotal()`), which is what the "Items total" row of the cart summary displays. Showing it again
+   in the "Discount" row subtracted it twice, so `Items total + Discount + shipping + tax` did not add up to the
+   actual order total and the discount shown to the customer was larger than the one really applied.
+
+   `getOrderAndItemPromotionTotal()` sums only `ORDER_ITEM_PROMOTION_ADJUSTMENT` and `ORDER_PROMOTION_ADJUSTMENT`,
+   so it can safely be displayed next to "Items total".
+
+2. The shop cart summary and checkout summary now use `getOrderAndItemPromotionTotal()` instead of
+   `getOrderPromotionTotal()`:
+
+   - `@SyliusShop/cart/index/content/form/sections/general/summary/discount.html.twig`
+   - `@SyliusShop/checkout/common/sidebar/summary/total/promotion_total.html.twig`
+
+   If you have custom templates, reports or integrations that display a promotion total next to
+   `getItemsSubtotal()`/`getSubtotal()`, switch them to `getOrderAndItemPromotionTotal()` to avoid the same
+   double-counting. `getOrderPromotionTotal()` is unchanged and still returns the promotion's full effect.
+
 ## Deprecations
 
 1. Passing a `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface` directly to the following catalog-facing classes is deprecated since Sylius 2.3.

--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -24,17 +24,6 @@
 If you decorate this service, make sure your decorator also implements
 `ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface` and proxies the `applyToItem` method.
 
-## New Order property
-
-1. The Order resource (admin and shop) now exposes a new `orderAndItemPromotionTotal` property, next to the
-   existing `orderPromotionTotal`.
-
-`orderPromotionTotal` sums the unit-level, item-level and order-level promotion adjustments together.
-The unit-level part is already reflected in `itemsSubtotal`/each item's `subtotal`, so combining
-`itemsSubtotal` with `orderPromotionTotal` double-counts that part. `orderAndItemPromotionTotal` sums
-only the item-level and order-level adjustments, so it can safely be added next to `itemsSubtotal`
-without double-counting.
-
 # UPGRADE FROM `2.1` TO `2.2`
 
 ## Modified routes

--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -24,6 +24,17 @@
 If you decorate this service, make sure your decorator also implements
 `ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface` and proxies the `applyToItem` method.
 
+## New Order property
+
+1. The Order resource (admin and shop) now exposes a new `orderAndItemPromotionTotal` property, next to the
+   existing `orderPromotionTotal`.
+
+`orderPromotionTotal` sums the unit-level, item-level and order-level promotion adjustments together.
+The unit-level part is already reflected in `itemsSubtotal`/each item's `subtotal`, so combining
+`itemsSubtotal` with `orderPromotionTotal` double-counts that part. `orderAndItemPromotionTotal` sums
+only the item-level and order-level adjustments, so it can safely be added next to `itemsSubtotal`
+without double-counting.
+
 # UPGRADE FROM `2.1` TO `2.2`
 
 ## Modified routes

--- a/UPGRADE-API-2.3.md
+++ b/UPGRADE-API-2.3.md
@@ -1,0 +1,15 @@
+# UPGRADE FROM `2.2` TO `2.3`
+
+## Order
+
+1. The Order resource (admin and shop) now exposes a new `orderAndItemPromotionTotal` property, next to the
+   existing `orderPromotionTotal`.
+
+   `orderPromotionTotal` sums the unit-level, item-level and order-level promotion adjustments together.
+   The unit-level part is already reflected in `itemsSubtotal`/each item's `subtotal`, so combining
+   `itemsSubtotal` with `orderPromotionTotal` double-counts that part. `orderAndItemPromotionTotal` sums
+   only the item-level and order-level adjustments, so it can safely be added next to `itemsSubtotal`
+   without double-counting.
+
+   The property is available in the `sylius:admin:order:index`, `sylius:admin:order:show`,
+   `sylius:shop:cart:show` and `sylius:shop:order:account:show` serialization groups.

--- a/features/shop/promotion/applying_promotion_coupon/not_invalidating_own_coupon_with_items_total_rule.feature
+++ b/features/shop/promotion/applying_promotion_coupon/not_invalidating_own_coupon_with_items_total_rule.feature
@@ -40,7 +40,7 @@ Feature: Not invalidating own coupon with items total rule
         And I use coupon with code "BUGME10"
         Then I should not be notified that the coupon is invalid
         And my cart total should be "$33.00"
-        And my discount should be "-$11.00"
+        And my total discount should be "-$11.00"
 
     @api @ui
     Scenario: Receiving the discount on the first application within the bug window

--- a/features/shop/promotion/complex_promotions.feature
+++ b/features/shop/promotion/complex_promotions.feature
@@ -56,7 +56,7 @@ Feature: Receiving a discount based on a configured promotion
         When I check the details of my cart
         Then theirs subtotal price should be decreased by "$140.00"
         And my cart total should be "$510.00"
-        And my discount should be "-$190.00"
+        And my discount should be "-$50.00"
 
     @api @ui
     Scenario: Receiving a discount on products from multiple taxons based on products from different taxons
@@ -76,5 +76,5 @@ Feature: Receiving a discount based on a configured promotion
         And I added product "Black Sabbath jacket" to the cart
         When I check the details of my cart
         Then product "Black Sabbath jacket" price should be discounted by "$10.00"
-        And my discount should be "-$30.00"
+        And my discount should be "-$20.00"
         And my cart total should be "$150.00"

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -854,9 +854,9 @@ final class CheckoutContext implements Context
         );
     }
 
-    #[Then('/^my discount should be ("[^"]+")$/')]
+    #[Then('/^my total discount should be ("[^"]+")$/')]
     #[Then('there should be no discount applied')]
-    public function myDiscountShouldBe(int $discount = 0): void
+    public function myTotalDiscountShouldBe(int $discount = 0): void
     {
         if ($this->sharedStorage->has('cart_token')) {
             $discountTotal = $this->responseChecker->getValue(
@@ -870,6 +870,23 @@ final class CheckoutContext implements Context
         }
 
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'orderPromotionTotal'), $discount);
+    }
+
+    #[Then('/^my discount should be ("[^"]+")$/')]
+    public function myDiscountShouldBe(int $discount): void
+    {
+        if ($this->sharedStorage->has('cart_token')) {
+            $discountTotal = $this->responseChecker->getValue(
+                $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token')),
+                'orderAndItemPromotionTotal',
+            );
+
+            Assert::same($discount, (int) $discountTotal);
+
+            return;
+        }
+
+        Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'orderAndItemPromotionTotal'), $discount);
     }
 
     #[Then('there should be no taxes charged')]

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
@@ -110,6 +110,13 @@
             <group>sylius:shop:order:account:show</group>
         </attribute>
 
+        <attribute name="orderAndItemPromotionTotal">
+            <group>sylius:admin:order:index</group>
+            <group>sylius:admin:order:show</group>
+            <group>sylius:shop:cart:show</group>
+            <group>sylius:shop:order:account:show</group>
+        </attribute>
+
         <attribute name="shippingPromotionTotal">
             <group>sylius:admin:order:index</group>
             <group>sylius:admin:order:show</group>

--- a/src/Sylius/Bundle/ShopBundle/templates/cart/index/content/form/sections/general/summary/discount.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/cart/index/content/form/sections/general/summary/discount.html.twig
@@ -1,13 +1,10 @@
 {% import "@SyliusShop/shared/macro/money.html.twig" as money %}
 
-{% set order_promotion_adjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
-{% set item_promotion_adjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT') %}
 {% set cart = hookable_metadata.context.cart %}
-{% set discount = cart.getAdjustmentsTotalRecursively(order_promotion_adjustment) + cart.getAdjustmentsTotalRecursively(item_promotion_adjustment) %}
 
-{% if discount %}
+{% if cart.orderAndItemPromotionTotal %}
     <div class="hstack gap-2 mb-2">
         <div>{{ 'sylius.ui.discount'|trans }}:</div>
-        <div class="ms-auto text-end" {{ sylius_test_html_attribute('cart-promotion-total') }}>{{ money.convertAndFormat(discount) }}</div>
+        <div class="ms-auto text-end" {{ sylius_test_html_attribute('cart-promotion-total') }}>{{ money.convertAndFormat(cart.orderAndItemPromotionTotal) }}</div>
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/cart/index/content/form/sections/general/summary/discount.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/cart/index/content/form/sections/general/summary/discount.html.twig
@@ -1,10 +1,13 @@
 {% import "@SyliusShop/shared/macro/money.html.twig" as money %}
 
+{% set order_promotion_adjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
+{% set item_promotion_adjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT') %}
 {% set cart = hookable_metadata.context.cart %}
+{% set discount = cart.getAdjustmentsTotalRecursively(order_promotion_adjustment) + cart.getAdjustmentsTotalRecursively(item_promotion_adjustment) %}
 
-{% if cart.orderPromotionTotal %}
+{% if discount %}
     <div class="hstack gap-2 mb-2">
         <div>{{ 'sylius.ui.discount'|trans }}:</div>
-        <div class="ms-auto text-end" {{ sylius_test_html_attribute('cart-promotion-total') }}>{{ money.convertAndFormat(cart.orderPromotionTotal) }}</div>
+        <div class="ms-auto text-end" {{ sylius_test_html_attribute('cart-promotion-total') }}>{{ money.convertAndFormat(discount) }}</div>
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/common/sidebar/summary/total/promotion_total.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/common/sidebar/summary/total/promotion_total.html.twig
@@ -4,5 +4,5 @@
 
 <tr>
     <td>{{ 'sylius.ui.discount'|trans }}:</td>
-    <td id="sylius-shop-checkout-summary-promotion-total" class="text-end">{{ money.convertAndFormat(order.orderPromotionTotal) }}</td>
+    <td id="sylius-shop-checkout-summary-promotion-total" class="text-end">{{ money.convertAndFormat(order.orderAndItemPromotionTotal) }}</td>
 </tr>

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -458,6 +458,14 @@ class Order extends BaseOrder implements OrderInterface
         ;
     }
 
+    public function getOrderAndItemPromotionTotal(): int
+    {
+        return
+            $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) +
+            $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)
+        ;
+    }
+
     public function getShippingPromotionTotal(): int
     {
         return $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT);

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -106,6 +106,8 @@ interface OrderInterface extends
 
     public function getOrderPromotionTotal(): int;
 
+    public function getOrderAndItemPromotionTotal(): int;
+
     public function getShippingPromotionTotal(): int;
 
     public function getItemsSubtotal(): int;

--- a/tests/Api/Responses/admin/order/get_all_orders.json
+++ b/tests/Api/Responses/admin/order/get_all_orders.json
@@ -58,6 +58,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         },
         {
@@ -114,6 +115,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/admin/order/get_order.json
+++ b/tests/Api/Responses/admin/order/get_order.json
@@ -88,5 +88,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/admin/order/get_orders_before_date.json
+++ b/tests/Api/Responses/admin/order/get_orders_before_date.json
@@ -92,6 +92,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 500,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/admin/order/get_orders_filtered_by_channel.json
+++ b/tests/Api/Responses/admin/order/get_orders_filtered_by_channel.json
@@ -58,6 +58,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/admin/order/get_orders_filtered_by_pln_and_usd_currency_codes.json
+++ b/tests/Api/Responses/admin/order/get_orders_filtered_by_pln_and_usd_currency_codes.json
@@ -58,6 +58,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         },
         {
@@ -114,6 +115,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         },
         {
@@ -170,6 +172,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         },
         {
@@ -226,6 +229,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/admin/order/get_orders_filtered_by_pln_currency_code.json
+++ b/tests/Api/Responses/admin/order/get_orders_filtered_by_pln_currency_code.json
@@ -58,6 +58,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         },
         {
@@ -114,6 +115,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/admin/order/get_orders_filtered_by_usd_currency_code.json
+++ b/tests/Api/Responses/admin/order/get_orders_filtered_by_usd_currency_code.json
@@ -58,6 +58,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         },
         {
@@ -114,6 +115,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/admin/order/get_orders_for_customer.json
+++ b/tests/Api/Responses/admin/order/get_orders_for_customer.json
@@ -58,6 +58,7 @@
             "taxIncludedTotal": 0,
             "shippingTotal": 0,
             "orderPromotionTotal": 0,
+            "orderAndItemPromotionTotal": 0,
             "shippingPromotionTotal": 0
         }
     ],

--- a/tests/Api/Responses/shop/checkout/cart/add_item.json
+++ b/tests/Api/Responses/shop/checkout/cart/add_item.json
@@ -57,5 +57,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/create_cart.json
+++ b/tests/Api/Responses/shop/checkout/cart/create_cart.json
@@ -28,5 +28,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/create_cart_as_guest.json
+++ b/tests/Api/Responses/shop/checkout/cart/create_cart_as_guest.json
@@ -28,5 +28,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/create_cart_as_shop_user.json
+++ b/tests/Api/Responses/shop/checkout/cart/create_cart_as_shop_user.json
@@ -32,5 +32,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/create_cart_with_locale.json
+++ b/tests/Api/Responses/shop/checkout/cart/create_cart_with_locale.json
@@ -28,5 +28,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/get_cart.json
+++ b/tests/Api/Responses/shop/checkout/cart/get_cart.json
@@ -57,5 +57,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/get_empty_cart.json
+++ b/tests/Api/Responses/shop/checkout/cart/get_empty_cart.json
@@ -28,5 +28,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/get_existing_cart_if_customer_has_cart.json
+++ b/tests/Api/Responses/shop/checkout/cart/get_existing_cart_if_customer_has_cart.json
@@ -47,5 +47,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_as_guest.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_as_guest.json
@@ -91,5 +91,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": -300,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_as_shop_user.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_as_shop_user.json
@@ -91,5 +91,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": -300,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_with_province_name_only.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_with_province_name_only.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/cart/update_item_quantity.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_item_quantity.json
@@ -57,5 +57,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/completion/order_with_free_non_shippable_items.json
+++ b/tests/Api/Responses/shop/checkout/completion/order_with_free_non_shippable_items.json
@@ -73,5 +73,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/completion/order_with_non_shippable_items.json
+++ b/tests/Api/Responses/shop/checkout/completion/order_with_non_shippable_items.json
@@ -80,5 +80,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 0,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/completion/order_with_shippable_and_non_shippable_items.json
+++ b/tests/Api/Responses/shop/checkout/completion/order_with_shippable_and_non_shippable_items.json
@@ -101,5 +101,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_guest.json
+++ b/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_guest.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_user.json
+++ b/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_user.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method.json
+++ b/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/order/change_payment_method_as_guest.json
+++ b/tests/Api/Responses/shop/order/change_payment_method_as_guest.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/order/change_payment_method_as_user.json
+++ b/tests/Api/Responses/shop/order/change_payment_method_as_user.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/order/get_order_by_guest.json
+++ b/tests/Api/Responses/shop/order/get_order_by_guest.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/order/get_order_by_user.json
+++ b/tests/Api/Responses/shop/order/get_order_by_user.json
@@ -87,5 +87,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }

--- a/tests/Api/Responses/shop/order/update_payment_method.json
+++ b/tests/Api/Responses/shop/order/update_payment_method.json
@@ -70,5 +70,6 @@
     "taxIncludedTotal": 0,
     "shippingTotal": 500,
     "orderPromotionTotal": 0,
+    "orderAndItemPromotionTotal": 0,
     "shippingPromotionTotal": 0
 }


### PR DESCRIPTION
## Description

The shop cart summary "Discount" row uses `Order::getOrderPromotionTotal()`, which sums three adjustment types together:

- `ORDER_UNIT_PROMOTION_ADJUSTMENT`
- `ORDER_ITEM_PROMOTION_ADJUSTMENT`
- `ORDER_PROMOTION_ADJUSTMENT`

`ORDER_UNIT_PROMOTION_ADJUSTMENT` is already netted into each item's subtotal via `OrderItem::getSubtotal()` (`unitPrice + unit's ORDER_UNIT_PROMOTION_ADJUSTMENT`), which is exactly what the "Items total" row directly above "Discount" displays.

By also including `ORDER_UNIT_PROMOTION_ADJUSTMENT` in the "Discount" row, the same amount is subtracted twice from the customer's point of view: once inside "Items total" (already-discounted item prices) and once again in "Discount". As a result:

- The visible breakdown (`Items total + Discount + shipping + tax`) no longer reconciles with the actual `Order total`.
- The "Discount" amount shown to the customer is larger than what was actually deducted from the order, which is misleading.

### Example

Cart with a per-unit coupon (`ORDER_UNIT_PROMOTION_ADJUSTMENT`) and an order-level promotion (`ORDER_PROMOTION_ADJUSTMENT`) applied:

- Items total already reflects the per-unit coupon (prices shown are post-coupon).
- "Discount" then subtracted the per-unit coupon amount a second time, on top of the order-level promotion, inflating the displayed discount and breaking the row-by-row math.

## Fix

`discount.html.twig` now computes the discount total from `ORDER_ITEM_PROMOTION_ADJUSTMENT` and `ORDER_PROMOTION_ADJUSTMENT` only, excluding `ORDER_UNIT_PROMOTION_ADJUSTMENT` since it's already accounted for in "Items total". This is a template-only change — no model/interface changes, so no BC concerns.

Before
<img width="1535" height="749" alt="image" src="https://github.com/user-attachments/assets/189f7ae8-e908-4a6b-acc3-690ae8a4bcb7" />
After
<img width="1535" height="749" alt="image" src="https://github.com/user-attachments/assets/09c6d379-642f-469a-9837-78b8f6c55560" />
