### PR TITLE
Extract add to cart logic into reusable CartItemAdder service

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -706,7 +706,7 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    ```php
    interface CartItemAdderInterface
    {
-       public function add(OrderInterface $cart, OrderItemInterface $cartItem): void;
+       public function add(AddToCartCommandInterface $addToCartCommand): void;
    }
    ```
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -699,3 +699,28 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    This allows you to decorate catalog display pricing independently from cart/order pricing
    (`sylius.order_processing.order_prices_recalculator`, `sylius.filter.promotion.price_range`),
    which remain on `ProductVariantPricesCalculatorInterface`.
+
+2. The add to cart logic has been extracted from `Sylius\Bundle\ShopBundle\Twig\Component\Product\AddToCartFormComponent`
+   into a new `Sylius\Bundle\OrderBundle\Adder\CartItemAdder` service (`sylius.adder.cart_item`):
+
+   ```php
+   interface CartItemAdderInterface
+   {
+       public function add(OrderInterface $cart, OrderItemInterface $cartItem): void;
+   }
+   ```
+
+   The service dispatches the `SyliusCartEvents::CART_ITEM_ADD` event (which performs the actual cart modification)
+   and persists the cart. Use it in custom add to cart components or controllers instead of duplicating this logic.
+
+   Not passing a `Sylius\Bundle\OrderBundle\Adder\CartItemAdderInterface` instance as the last constructor argument of
+   `AddToCartFormComponent` is deprecated since Sylius 2.3 and will be required in Sylius 3.0:
+
+   ```diff
+    public function __construct(
+        // ...
+        ProductRepositoryInterface $productRepository,
+        ProductVariantRepositoryInterface $productVariantRepository,
+   +    protected readonly ?CartItemAdderInterface $cartItemAdder = null,
+    ) {
+   ```

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -710,8 +710,9 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    }
    ```
 
-   The service dispatches the `SyliusCartEvents::CART_ITEM_ADD` event (which performs the actual cart modification)
-   and persists the cart. Use it in custom add to cart components or controllers instead of duplicating this logic.
+   The service dispatches the `SyliusCartEvents::CART_ITEM_ADD` event (which performs the actual cart modification),
+   persists and flushes the cart, and then dispatches `SyliusCartEvents::CART_ITEM_POST_ADD`. Use it in custom add to
+   cart components or controllers instead of duplicating this logic.
 
    Not passing a `Sylius\Bundle\OrderBundle\Adder\CartItemAdderInterface` instance as the last constructor argument of
    `AddToCartFormComponent` is deprecated since Sylius 2.3 and will be required in Sylius 3.0:

--- a/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdder.php
+++ b/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdder.php
@@ -33,5 +33,7 @@ final readonly class CartItemAdder implements CartItemAdderInterface
 
         $this->orderManager->persist($addToCartCommand->getCart());
         $this->orderManager->flush();
+
+        $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_POST_ADD);
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdder.php
+++ b/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdder.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\OrderBundle\Adder;
 
 use Doctrine\Persistence\ObjectManager;
-use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactoryInterface;
-use Sylius\Component\Order\Model\OrderInterface;
-use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Bundle\OrderBundle\Controller\AddToCartCommandInterface;
 use Sylius\Component\Order\SyliusCartEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -24,19 +22,16 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 final readonly class CartItemAdder implements CartItemAdderInterface
 {
     public function __construct(
-        private AddToCartCommandFactoryInterface $addToCartCommandFactory,
         private EventDispatcherInterface $eventDispatcher,
         private ObjectManager $orderManager,
     ) {
     }
 
-    public function add(OrderInterface $cart, OrderItemInterface $cartItem): void
+    public function add(AddToCartCommandInterface $addToCartCommand): void
     {
-        $addToCartCommand = $this->addToCartCommandFactory->createWithCartAndCartItem($cart, $cartItem);
-
         $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
 
-        $this->orderManager->persist($cart);
+        $this->orderManager->persist($addToCartCommand->getCart());
         $this->orderManager->flush();
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdder.php
+++ b/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdder.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Adder;
+
+use Doctrine\Persistence\ObjectManager;
+use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactoryInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\SyliusCartEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final readonly class CartItemAdder implements CartItemAdderInterface
+{
+    public function __construct(
+        private AddToCartCommandFactoryInterface $addToCartCommandFactory,
+        private EventDispatcherInterface $eventDispatcher,
+        private ObjectManager $orderManager,
+    ) {
+    }
+
+    public function add(OrderInterface $cart, OrderItemInterface $cartItem): void
+    {
+        $addToCartCommand = $this->addToCartCommandFactory->createWithCartAndCartItem($cart, $cartItem);
+
+        $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
+
+        $this->orderManager->persist($cart);
+        $this->orderManager->flush();
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdderInterface.php
+++ b/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Adder;
+
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
+
+interface CartItemAdderInterface
+{
+    public function add(OrderInterface $cart, OrderItemInterface $cartItem): void;
+}

--- a/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdderInterface.php
+++ b/src/Sylius/Bundle/OrderBundle/Adder/CartItemAdderInterface.php
@@ -13,10 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\Adder;
 
-use Sylius\Component\Order\Model\OrderInterface;
-use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Bundle\OrderBundle\Controller\AddToCartCommandInterface;
 
 interface CartItemAdderInterface
 {
-    public function add(OrderInterface $cart, OrderItemInterface $cartItem): void;
+    public function add(AddToCartCommandInterface $addToCartCommand): void;
 }

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Sylius\Bundle\OrderBundle\Adder\CartItemAdder;
+use Sylius\Bundle\OrderBundle\Adder\CartItemAdderInterface;
 use Sylius\Bundle\OrderBundle\Console\Command\RemoveExpiredCartsCommand;
 use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactory;
 use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactoryInterface;
@@ -118,6 +120,16 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('sylius.factory.add_to_cart_command', AddToCartCommandFactory::class);
     $services->alias(AddToCartCommandFactoryInterface::class, 'sylius.factory.add_to_cart_command');
+
+    $services
+        ->set('sylius.adder.cart_item', CartItemAdder::class)
+        ->args([
+            service('sylius.factory.add_to_cart_command'),
+            service('event_dispatcher'),
+            service('sylius.manager.order'),
+        ])
+    ;
+    $services->alias(CartItemAdderInterface::class, 'sylius.adder.cart_item');
 
     $services
         ->set('sylius.resetter.cart_changes', CartChangesResetter::class)

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.php
@@ -124,7 +124,6 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius.adder.cart_item', CartItemAdder::class)
         ->args([
-            service('sylius.factory.add_to_cart_command'),
             service('event_dispatcher'),
             service('sylius.manager.order'),
         ])

--- a/src/Sylius/Bundle/OrderBundle/tests/Adder/CartItemAdderTest.php
+++ b/src/Sylius/Bundle/OrderBundle/tests/Adder/CartItemAdderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\OrderBundle\Adder;
+
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\OrderBundle\Adder\CartItemAdder;
+use Sylius\Bundle\OrderBundle\Adder\CartItemAdderInterface;
+use Sylius\Bundle\OrderBundle\Controller\AddToCartCommandInterface;
+use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactoryInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\SyliusCartEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class CartItemAdderTest extends TestCase
+{
+    private AddToCartCommandFactoryInterface&MockObject $addToCartCommandFactory;
+
+    private EventDispatcherInterface&MockObject $eventDispatcher;
+
+    private MockObject&ObjectManager $orderManager;
+
+    private CartItemAdder $cartItemAdder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->addToCartCommandFactory = $this->createMock(AddToCartCommandFactoryInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->orderManager = $this->createMock(ObjectManager::class);
+        $this->cartItemAdder = new CartItemAdder(
+            $this->addToCartCommandFactory,
+            $this->eventDispatcher,
+            $this->orderManager,
+        );
+    }
+
+    public function testItImplementsCartItemAdderInterface(): void
+    {
+        self::assertInstanceOf(CartItemAdderInterface::class, $this->cartItemAdder);
+    }
+
+    public function testAddsCartItemToCartAndPersistsTheCart(): void
+    {
+        /** @var OrderInterface&MockObject $cart */
+        $cart = $this->createMock(OrderInterface::class);
+        /** @var OrderItemInterface&MockObject $cartItem */
+        $cartItem = $this->createMock(OrderItemInterface::class);
+        /** @var AddToCartCommandInterface&MockObject $addToCartCommand */
+        $addToCartCommand = $this->createMock(AddToCartCommandInterface::class);
+
+        $this->addToCartCommandFactory
+            ->expects(self::once())
+            ->method('createWithCartAndCartItem')
+            ->with($cart, $cartItem)
+            ->willReturn($addToCartCommand)
+        ;
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                self::callback(
+                    static fn (GenericEvent $event): bool => $event->getSubject() === $addToCartCommand,
+                ),
+                SyliusCartEvents::CART_ITEM_ADD,
+            )
+            ->willReturnArgument(0)
+        ;
+
+        $this->orderManager->expects(self::once())->method('persist')->with($cart);
+        $this->orderManager->expects(self::once())->method('flush');
+
+        $this->cartItemAdder->add($cart, $cartItem);
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/tests/Adder/CartItemAdderTest.php
+++ b/src/Sylius/Bundle/OrderBundle/tests/Adder/CartItemAdderTest.php
@@ -55,20 +55,27 @@ final class CartItemAdderTest extends TestCase
         $addToCartCommand = $this->createMock(AddToCartCommandInterface::class);
         $addToCartCommand->method('getCart')->willReturn($cart);
 
+        $dispatchedEventNames = [];
+
         $this->eventDispatcher
-            ->expects(self::once())
+            ->expects(self::exactly(2))
             ->method('dispatch')
-            ->with(
-                self::callback(
-                    static fn (GenericEvent $event): bool => $event->getSubject() === $addToCartCommand,
-                ),
-                SyliusCartEvents::CART_ITEM_ADD,
-            )
+            ->willReturnCallback(function (GenericEvent $event, string $eventName) use (&$dispatchedEventNames, $addToCartCommand) {
+                self::assertSame($addToCartCommand, $event->getSubject());
+                $dispatchedEventNames[] = $eventName;
+
+                return $event;
+            })
         ;
 
         $this->orderManager->expects(self::once())->method('persist')->with($cart);
         $this->orderManager->expects(self::once())->method('flush');
 
         $this->cartItemAdder->add($addToCartCommand);
+
+        self::assertSame(
+            [SyliusCartEvents::CART_ITEM_ADD, SyliusCartEvents::CART_ITEM_POST_ADD],
+            $dispatchedEventNames,
+        );
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/tests/Adder/CartItemAdderTest.php
+++ b/src/Sylius/Bundle/OrderBundle/tests/Adder/CartItemAdderTest.php
@@ -14,22 +14,20 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\OrderBundle\Adder;
 
 use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\OrderBundle\Adder\CartItemAdder;
 use Sylius\Bundle\OrderBundle\Adder\CartItemAdderInterface;
 use Sylius\Bundle\OrderBundle\Controller\AddToCartCommandInterface;
-use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactoryInterface;
 use Sylius\Component\Order\Model\OrderInterface;
-use Sylius\Component\Order\Model\OrderItemInterface;
 use Sylius\Component\Order\SyliusCartEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
+#[AllowMockObjectsWithoutExpectations]
 final class CartItemAdderTest extends TestCase
 {
-    private AddToCartCommandFactoryInterface&MockObject $addToCartCommandFactory;
-
     private EventDispatcherInterface&MockObject $eventDispatcher;
 
     private MockObject&ObjectManager $orderManager;
@@ -39,14 +37,9 @@ final class CartItemAdderTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->addToCartCommandFactory = $this->createMock(AddToCartCommandFactoryInterface::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->orderManager = $this->createMock(ObjectManager::class);
-        $this->cartItemAdder = new CartItemAdder(
-            $this->addToCartCommandFactory,
-            $this->eventDispatcher,
-            $this->orderManager,
-        );
+        $this->cartItemAdder = new CartItemAdder($this->eventDispatcher, $this->orderManager);
     }
 
     public function testItImplementsCartItemAdderInterface(): void
@@ -58,17 +51,9 @@ final class CartItemAdderTest extends TestCase
     {
         /** @var OrderInterface&MockObject $cart */
         $cart = $this->createMock(OrderInterface::class);
-        /** @var OrderItemInterface&MockObject $cartItem */
-        $cartItem = $this->createMock(OrderItemInterface::class);
         /** @var AddToCartCommandInterface&MockObject $addToCartCommand */
         $addToCartCommand = $this->createMock(AddToCartCommandInterface::class);
-
-        $this->addToCartCommandFactory
-            ->expects(self::once())
-            ->method('createWithCartAndCartItem')
-            ->with($cart, $cartItem)
-            ->willReturn($addToCartCommand)
-        ;
+        $addToCartCommand->method('getCart')->willReturn($cart);
 
         $this->eventDispatcher
             ->expects(self::once())
@@ -79,12 +64,11 @@ final class CartItemAdderTest extends TestCase
                 ),
                 SyliusCartEvents::CART_ITEM_ADD,
             )
-            ->willReturnArgument(0)
         ;
 
         $this->orderManager->expects(self::once())->method('persist')->with($cart);
         $this->orderManager->expects(self::once())->method('flush');
 
-        $this->cartItemAdder->add($cart, $cartItem);
+        $this->cartItemAdder->add($addToCartCommand);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/product.php
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/product.php
@@ -39,6 +39,7 @@ return static function (ContainerConfigurator $container) {
             AddToCartType::class,
             service('sylius.repository.product'),
             service('sylius.repository.product_variant'),
+            service('sylius.adder.cart_item'),
         ])
         ->call('setLiveResponder', [service('ux.live_component.live_responder')])
         ->tag('sylius.live_component.shop', ['key' => 'sylius_shop:product:add_to_cart_form'])

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
@@ -141,8 +141,8 @@ class AddToCartFormComponent
             $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
             $this->manager->persist($addToCartCommand->getCart());
             $this->manager->flush();
+            $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_POST_ADD);
         }
-        $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_POST_ADD);
 
         if ($addFlashMessage) {
             FlashBagProvider::getFlashBag($this->requestStack)->add('success', 'sylius.cart.add_item');

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
@@ -136,7 +136,7 @@ class AddToCartFormComponent
         $addToCartCommand = $this->getForm()->getData();
 
         if (null !== $this->cartItemAdder) {
-            $this->cartItemAdder->add($addToCartCommand->getCart(), $addToCartCommand->getCartItem());
+            $this->cartItemAdder->add($addToCartCommand);
         } else {
             $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
             $this->manager->persist($addToCartCommand->getCart());

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ShopBundle\Twig\Component\Product;
 
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\CoreBundle\Provider\FlashBagProvider;
+use Sylius\Bundle\OrderBundle\Adder\CartItemAdderInterface;
 use Sylius\Bundle\OrderBundle\Factory\AddToCartCommandFactoryInterface;
 use Sylius\Bundle\ShopBundle\Twig\Component\Product\Trait\ProductLivePropTrait;
 use Sylius\Bundle\ShopBundle\Twig\Component\Product\Trait\ProductVariantLivePropTrait;
@@ -84,9 +85,20 @@ class AddToCartFormComponent
         protected readonly string $formClass,
         ProductRepositoryInterface $productRepository,
         ProductVariantRepositoryInterface $productVariantRepository,
+        protected readonly ?CartItemAdderInterface $cartItemAdder = null,
     ) {
         $this->initializeProduct($productRepository);
         $this->initializeProductVariant($productVariantRepository);
+
+        if (null === $this->cartItemAdder) {
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '2.3',
+                'Not passing a "%s" to "%s" is deprecated and will be required in Sylius 3.0.',
+                CartItemAdderInterface::class,
+                self::class,
+            );
+        }
     }
 
     #[PostMount(priority: 100)]
@@ -123,9 +135,13 @@ class AddToCartFormComponent
         $this->submitForm();
         $addToCartCommand = $this->getForm()->getData();
 
-        $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
-        $this->manager->persist($addToCartCommand->getCart());
-        $this->manager->flush();
+        if (null !== $this->cartItemAdder) {
+            $this->cartItemAdder->add($addToCartCommand->getCart(), $addToCartCommand->getCartItem());
+        } else {
+            $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_ADD);
+            $this->manager->persist($addToCartCommand->getCart());
+            $this->manager->flush();
+        }
         $this->eventDispatcher->dispatch(new GenericEvent($addToCartCommand), SyliusCartEvents::CART_ITEM_POST_ADD);
 
         if ($addFlashMessage) {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets |
| License         | MIT

Currently the whole add to cart orchestration lives inline in the
`AddToCartFormComponent::addToCart()` live action: dispatching
`SyliusCartEvents::CART_ITEM_ADD` (which performs the actual cart modification
via `CartItemAddListener`) followed by persisting and flushing the cart.

Anyone writing a custom add to cart component (or overriding the default one)
has to copy this choreography and keep it in sync with Sylius on every upgrade.

This PR extracts it into a reusable `CartItemAdder` service in `OrderBundle`
(`sylius.adder.cart_item`):

```php
interface CartItemAdderInterface
{
    public function add(AddToCartCommandInterface $addToCartCommand): void;
}
```

- The service operates on the `AddToCartCommandInterface` the caller already
  holds (e.g. from the form), so the original command instance — including any
  customized implementation with extra state — is dispatched untouched, exactly
  as the inline code did.
- `AddToCartFormComponent` now delegates to the service and shrinks to its
  presentation concerns (form, flash, redirect). It is the first consumer of
  the new public entry point.
- Purely additive: the event flow, listener, and persistence behavior are
  unchanged. The service is injected as a nullable last constructor argument
  with a deprecation triggered when missing — not passing it will be required
  in Sylius 3.0 (UPGRADE note included, same pattern as
  `Checkout/Address/FormComponent`).
