### PR TITLE
[CI] Fix PHP 8.3 builds and add PHP 8.3 coverage to the minimal build

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -50,6 +50,12 @@
     "e2e-mysql": {
       "include": [
         {
+          "php": "8.3",
+          "symfony": "~6.4.0",
+          "mysql": "8.4",
+          "twig": "^3.3"
+        },
+        {
           "php": "8.4",
           "symfony": "~6.4.0",
           "mysql": "8.4",

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -286,14 +286,6 @@
           "legacy_grid_config": true
         },
         {
-          "php": "8.3",
-          "symfony": "~8.1.0",
-          "mariadb": "11.4.12",
-          "doctrine_bundle": "^3.0",
-          "state_machine_adapter": "symfony_workflow",
-          "legacy_grid_config": false
-        },
-        {
           "php": "8.5",
           "symfony": "~7.4.0",
           "mariadb": "11.4.12",
@@ -395,6 +387,10 @@
         {
           "php": "8.3",
           "symfony": "~8.1.0"
+        },
+        {
+          "php": "8.3",
+          "doctrine_bundle": "^3.0"
         }
       ]
     },

--- a/config/packages/doctrine_native_lazy_objects.php
+++ b/config/packages/doctrine_native_lazy_objects.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require PHP 8.4+.
+    // On PHP < 8.4 (where only doctrine-bundle 2.x is installable) they must be disabled so the
+    // container can compile. On PHP 8.4+ the default is kept - and doctrine-bundle 3.x no longer
+    // allows the option to be set at all.
+    if (\PHP_VERSION_ID >= 80400) {
+        return;
+    }
+
+    $container->extension('doctrine', [
+        'orm' => [
+            'enable_native_lazy_objects' => false,
+        ],
+    ]);
+};

--- a/src/Sylius/Bundle/AddressingBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/AddressingBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -33,5 +34,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/AttributeBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/AttributeBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -30,5 +31,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/ChannelBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ChannelBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/ChannelBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ChannelBundle/test/app/config/config.yml
@@ -26,7 +26,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/src/Sylius/Bundle/CurrencyBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/CurrencyBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/CustomerBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/CustomerBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/CustomerBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/CustomerBundle/test/app/config/config.yml
@@ -26,7 +26,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/src/Sylius/Bundle/InventoryBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/InventoryBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -30,5 +31,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/InventoryBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/InventoryBundle/test/app/config/config.yml
@@ -26,7 +26,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/src/Sylius/Bundle/LocaleBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/LocaleBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/MoneyBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/MoneyBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/OrderBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -32,5 +33,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/OrderBundle/test/app/config/config.yml
@@ -26,7 +26,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/src/Sylius/Bundle/PaymentBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/PaymentBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -33,5 +34,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ProductBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -32,5 +33,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ProductBundle/test/app/config/config.yml
@@ -22,7 +22,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/src/Sylius/Bundle/PromotionBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/PromotionBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/PromotionBundle/test/app/config/config.yml
@@ -26,7 +26,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         auto_mapping: true
         mappings:
             App:

--- a/src/Sylius/Bundle/ReviewBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -34,5 +35,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/ReviewBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/config/config.yml
@@ -26,7 +26,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/src/Sylius/Bundle/ShippingBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ShippingBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/TaxationBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxationBundle/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -31,5 +32,13 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/tests/Functional/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/tests/Functional/app/AppKernel.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\TaxonomyBundle\SyliusTaxonomyBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -37,6 +38,14 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\PHP_VERSION_ID < 80400) {
+            // doctrine/doctrine-bundle 2.x enables native lazy objects by default, but they require
+            // PHP 8.4+. On PHP < 8.4 disable them so the container can compile.
+            $loader->load(static function (ContainerBuilder $container): void {
+                $container->loadFromExtension('doctrine', ['orm' => ['enable_native_lazy_objects' => false]]);
+            });
+        }
     }
 
     public function getCacheDir(): string

--- a/src/Sylius/Bundle/TaxonomyBundle/tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/TaxonomyBundle/tests/Functional/app/config/config.yml
@@ -30,7 +30,6 @@ doctrine:
         path: "%database_path%"
         charset: UTF8
     orm:
-        enable_native_lazy_objects: true
         entity_managers:
             default:
                 auto_mapping: true

--- a/tests/Functional/AbstractOrmTestCase.php
+++ b/tests/Functional/AbstractOrmTestCase.php
@@ -39,7 +39,11 @@ abstract class AbstractOrmTestCase extends TestCase
             )->getMetadataDriverImpl(),
         );
 
-        $config->enableNativeLazyObjects(true);
+        // Native lazy objects require PHP 8.4+; on lower versions Doctrine ORM falls back to
+        // lazy ghost objects, so the flag must only be enabled where the runtime supports it.
+        if (\PHP_VERSION_ID >= 80400) {
+            $config->enableNativeLazyObjects(true);
+        }
 
         return $config;
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Fixes the full build: https://github.com/Sylius/Sylius/actions/runs/29890231205

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
