### PR TITLE
  [Admin][Shop] Make CSRF token field name configurable

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -31,8 +31,8 @@ security:
                 use_forward: false
                 use_referer: true
                 enable_csrf: true
-                csrf_parameter: _csrf_admin_security_token
-                csrf_token_id: admin_authenticate
+                csrf_parameter: '%sylius_admin.security.csrf_parameter%'
+                csrf_token_id: '%sylius_admin.security.csrf_token_id%'
             remember_me:
                 secret: "%env(APP_SECRET)%"
                 path: "/%sylius_admin.path_name%"
@@ -88,8 +88,8 @@ security:
                 use_forward: false
                 use_referer: true
                 enable_csrf: true
-                csrf_parameter: _csrf_shop_security_token
-                csrf_token_id: shop_authenticate
+                csrf_parameter: '%sylius_shop.security.csrf_parameter%'
+                csrf_token_id: '%sylius_shop.security.csrf_token_id%'
             json_login:
                 check_path: sylius_shop_json_login_check
                 username_path: _username

--- a/src/Sylius/Bundle/AdminBundle/Action/RemoveAvatarAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/RemoveAvatarAction.php
@@ -29,6 +29,7 @@ final class RemoveAvatarAction
         private AvatarImageRepositoryInterface $avatarRepository,
         private RouterInterface $router,
         private ?CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly string $csrfParameter = '_csrf_token',
     ) {
     }
 
@@ -37,7 +38,7 @@ final class RemoveAvatarAction
         $userId = $request->attributes->get('id', '');
 
         if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
-            new CsrfToken($userId, (string) $request->query->get('_csrf_token', '')),
+            new CsrfToken($userId, (string) $request->query->get($this->csrfParameter, '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
         }

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
@@ -35,6 +35,7 @@ final readonly class ResendOrderConfirmationEmailAction
         private ?CsrfTokenManagerInterface $csrfTokenManager,
         private RequestStack $requestStack,
         private RouterInterface $router,
+        private string $csrfParameter = '_csrf_token',
     ) {
     }
 
@@ -43,7 +44,7 @@ final readonly class ResendOrderConfirmationEmailAction
         $orderId = $request->attributes->get('id', '');
 
         if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
-            new CsrfToken($orderId, (string) $request->query->get('_csrf_token', '')),
+            new CsrfToken($orderId, (string) $request->query->get($this->csrfParameter, '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
         }

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -33,6 +33,7 @@ final readonly class ResendShipmentConfirmationEmailAction
         private ResendShipmentConfirmationEmailDispatcherInterface $resendShipmentConfirmationDispatcher,
         private ?CsrfTokenManagerInterface $csrfTokenManager,
         private RequestStack $requestStack,
+        private string $csrfParameter = '_csrf_token',
     ) {
     }
 
@@ -41,7 +42,7 @@ final readonly class ResendShipmentConfirmationEmailAction
         $shipmentId = $request->attributes->get('id', '');
 
         if ($this->csrfTokenManager && !$this->csrfTokenManager->isTokenValid(
-            new CsrfToken($shipmentId, (string) $request->query->get('_csrf_token', '')),
+            new CsrfToken($shipmentId, (string) $request->query->get($this->csrfParameter, '')),
         )) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
         }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -8,6 +8,8 @@ parameters:
     env(SYLIUS_ADMIN_ROUTING_PATH_NAME): admin
     sylius_admin.path_name: '%env(resolve:SYLIUS_ADMIN_ROUTING_PATH_NAME)%'
     sylius.security.admin_regex: "^/%sylius_admin.path_name%"
+    sylius_admin.security.csrf_parameter: '_csrf_admin_security_token'
+    sylius_admin.security.csrf_token_id: 'admin_authenticate'
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -44,6 +44,7 @@
             <argument type='service' id="sylius.repository.avatar_image" />
             <argument type="service" id="router" />
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
+            <argument>%sylius.resource.csrf_parameter%</argument>
         </service>
 
         <service id="sylius_admin.controller.resend_order_confirmation_email" class="Sylius\Bundle\AdminBundle\Action\ResendOrderConfirmationEmailAction">
@@ -52,6 +53,7 @@
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
             <argument type="service" id="request_stack" />
             <argument type="service" id="router" />
+            <argument>%sylius.resource.csrf_parameter%</argument>
         </service>
 
         <service id="sylius_admin.controller.resend_shipment_confirmation_email" class="Sylius\Bundle\AdminBundle\Action\ResendShipmentConfirmationEmailAction">
@@ -59,6 +61,7 @@
             <argument type="service" id="sylius.command_dispatcher.resend_shipment_confirmation_email" />
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
             <argument type="service" id="request_stack" />
+            <argument>%sylius.resource.csrf_parameter%</argument>
         </service>
 
         <service id="sylius_admin.controller.account.render_request_password_reset_page" class="Sylius\Bundle\AdminBundle\Action\Account\RenderRequestPasswordResetPageAction">

--- a/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
@@ -18,7 +18,7 @@
         {{ form_widget(hookable_metadata.context.form.avatar) }}
         {% if admin_user.id is not null and admin_user.avatar is not null and admin_user.avatar.path is not empty %}
             <button
-                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(admin_user.id) : null}) }}"
+                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(admin_user.id) : null}) }}"
                 type="submit"
                 class="btn btn-danger"
                 {{ sylius_test_html_attribute('delete-avatar-button') }}

--- a/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
@@ -5,7 +5,7 @@
     <form action="{{ path('sylius_admin_shop_user_delete', {'id': user.id, 'customerId': customer.id}) }}" method="POST">
         <input type="hidden" name="_method" value="DELETE" />
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(user.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(user.id) }}" />
         {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('customer-actions-delete') }}>
             {{ ux_icon('tabler:trash-x', {'class': 'icon dropdown-item-icon'}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/cancel.html.twig
@@ -6,7 +6,7 @@
     <form action="{{ path('sylius_admin_order_cancel', {'id': order.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(order.id) }}" />
         {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('cancel-order') }}>
             {{ ux_icon('tabler:circle-check', {'class': 'icon dropdown-item-icon'}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/cancel.html.twig
@@ -4,7 +4,7 @@
     <form action="{{ path('sylius_admin_order_cancel', {'id': order.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(order.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(order.id) }}" />
         {% endif %}
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('cancel-order') }}>
             {{ ux_icon('tabler:circle-check', {'class': 'icon dropdown-item-icon'}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/resend_confirmation_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/list/resend_confirmation_email.html.twig
@@ -1,7 +1,7 @@
 {% set order = hookable_metadata.context.resource %}
 
 {% if order.state in sylius_order_states_that_allows_to_resend_order_confirmation_email %}
-    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
+    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
     <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('resend-order-confirmation-email') }}>
         {{ ux_icon('tabler:send', {'class': 'icon dropdown-item-icon flex-shrink-0'}) }}
         <div class="pe-6">{{ 'sylius.ui.resend_the_order_confirmation_email'|trans }}</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/resend_confirmation_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/header/title_block/actions/resend_confirmation_email.html.twig
@@ -3,7 +3,7 @@
 {% set order = hookable_metadata.context.resource %}
 
 {% if order.state in sylius_order_states_that_allows_to_resend_order_confirmation_email %}
-    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, '_csrf_token': sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
+    {% set path = path('sylius_admin_order_resend_confirmation_email', {'id': order.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(order.id) : null}) %}
     <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('resend-order-confirmation-email') }}>
         {{ ux_icon('tabler:send', {'class': 'icon dropdown-item-icon flex-shrink-0'}) }}
         <div class="pe-6">{{ 'sylius.ui.resend_the_order_confirmation_email'|trans }}</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/complete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/complete.html.twig
@@ -5,7 +5,7 @@
     <form action="{{ path('sylius_admin_order_payment_complete', {'orderId': order.id, 'id': payment.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(payment.id) }}" />
         {% endif %}
         <button type="submit" class="btn" {{ sylius_test_html_attribute('complete-payment', payment.id) }}>
             {{ ux_icon('tabler:check') }} {{ 'sylius.ui.complete'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/refund.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/payments/item/actions/refund.html.twig
@@ -5,7 +5,7 @@
     <form action="{{ path('sylius_admin_order_payment_refund', {'orderId': order.id, 'id': payment.id}) }}" method="POST" novalidate>
         <input type="hidden" name="_method" value="PUT">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(payment.id) }}" />
         {% endif %}
         <button type="submit" class="btn" {{ sylius_test_html_attribute('refund-payment', payment.id) }}>
             {{ ux_icon('tabler:arrow-back-up-double') }} {{ 'sylius.ui.refund'|trans }}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/shipments/item/actions/resend_confirmation.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/shipments/item/actions/resend_confirmation.html.twig
@@ -1,7 +1,7 @@
 {% set shipment = hookable_metadata.context.shipment %}
 
 {% if shipment.state == 'shipped' %}
-    {% set resend_path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, '_csrf_token': sylius_csrf_protection_enabled () ? csrf_token(shipment.id) : null}) %}
+    {% set resend_path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, (sylius_resource_csrf_parameter()): sylius_csrf_protection_enabled() ? csrf_token(shipment.id) : null}) %}
     <a href="{{ resend_path }}" class="btn btn-icon" data-bs-toggle="tooltip" data-bs-title="{{ 'sylius.ui.resend_the_shipment_confirmation_email'|trans }}" {{ sylius_test_html_attribute('resend-shipment-confirmation-email') }}>
         {{ ux_icon('tabler:send') }}
     </a>

--- a/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/login/page/content/form.html.twig
@@ -5,6 +5,6 @@
 {{ form_start(form, {'action': path('sylius_admin_login_check'), 'attr': {'class': 'ui large loadable form', 'novalidate': 'novalidate'}}) }}
     {% hook 'form' with { form } %}
     {% if sylius_csrf_protection_enabled() %}
-        <input type="hidden" name="_csrf_admin_security_token" value="{{ csrf_token('admin_authenticate') }}">
+        <input type="hidden" name="{{ sylius_security_csrf_parameter('admin') }}" value="{{ csrf_token(sylius_security_csrf_token_id('admin')) }}">
     {% endif %}
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/components/delete_modal.html.twig
@@ -17,7 +17,7 @@
     <form action="{{ path }}" method="post" {{ form_attr }}>
         <input type="hidden" name="_method" value="DELETE">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(id) }}" />
         {% endif %}
 
         {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/apply_transition.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/grid/action/apply_transition.html.twig
@@ -4,7 +4,7 @@
 {% if sylius_sm_can(data, options.graph, options.transition) %}
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post" {{ sylius_test_html_attribute('action', action.name) }}>
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(data.id) }}">
         {% endif %}
         <input type="hidden" name="_method" value="PUT">
         <button class="btn {{ options.class|default }}" {% if labeled and 'btn-icon' in options.class|default %}data-bs-toggle="tooltip" data-bs-title="{{ action.label|trans }}"{% endif %}>

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
@@ -25,7 +25,7 @@
                     <div class="modal-footer">
                         <form action="{{ path('sylius_admin_taxon_delete', {id: id}) }}" method="post">
                             <input type="hidden" name="_method" value="DELETE">
-                            <input type="hidden" name="_csrf_token" {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'csrfToken') }}/>
+                            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'csrfToken') }}/>
 
                             {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}
                             {{ button.default({ text: 'sylius.ui.delete'|trans, type: 'submit', class: 'btn-danger', attr: sylius_test_html_attribute('confirm-button') }) }}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -48,5 +48,10 @@
             <argument type="service" id="service_container" />
             <tag name="twig.extension" />
         </service>
+
+        <service id="sylius.twig.extension.security_csrf" class="Sylius\Bundle\CoreBundle\Twig\SecurityCsrfExtension" public="false">
+            <argument type="service" id="service_container" />
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/SecurityCsrfExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SecurityCsrfExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_security_csrf_parameter', [$this, 'getCsrfParameter']),
+            new TwigFunction('sylius_security_csrf_token_id', [$this, 'getCsrfTokenId']),
+        ];
+    }
+
+    public function getCsrfParameter(string $section): string
+    {
+        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_parameter', $section));
+    }
+
+    public function getCsrfTokenId(string $section): string
+    {
+        return (string) $this->container->getParameter(sprintf('sylius_%s.security.csrf_token_id', $section));
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -11,6 +11,8 @@ imports:
 
 parameters:
     sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius_shop.security.csrf_parameter: '_csrf_shop_security_token'
+    sylius_shop.security.csrf_token_id: 'shop_authenticate'
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/login/content/login_container/form/csrf_token.html.twig
@@ -1,3 +1,3 @@
 {% if sylius_csrf_protection_enabled() %}
-    <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}">
+    <input type="hidden" name="{{ sylius_security_csrf_parameter('shop') }}" value="{{ csrf_token(sylius_security_csrf_token_id('shop')) }}">
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
@@ -12,7 +12,7 @@
                 <button class="btn btn-primary" type="button" {{ stimulus_action('@sylius/shop-bundle/api-login', 'login') }} {{ sylius_test_html_attribute('login-button') }}>{{ 'sylius.ui.sign_in'|trans }}</button>
             </div>
             {% if sylius_csrf_protection_enabled() %}
-                <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
+                <input type="hidden" name="{{ sylius_security_csrf_parameter('shop') }}" value="{{ csrf_token(sylius_security_csrf_token_id('shop')) }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
             {% endif %}
             <div {{ stimulus_target('@sylius/shop-bundle/api-login', 'error') }} {{ sylius_test_html_attribute('login-validation-error') }}></div>
         {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/buttons.html.twig
@@ -58,7 +58,7 @@
             {{ ux_icon('tabler:trash', {'class': 'icon icon-xs'})}} {{ ((message is empty and labeled) ? 'sylius.ui.delete' : message)|trans }}
         </button>
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(resourceId) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(resourceId) }}" />
         {% endif %}
     </form>
 {% endmacro %}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
@@ -14,7 +14,7 @@
     <form action="{{ path }}" method="post" {{ form_attr }}>
         <input type="hidden" name="_method" value="DELETE">
         {% if sylius_csrf_protection_enabled() %}
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+            <input type="hidden" name="{{ sylius_resource_csrf_parameter() }}" value="{{ csrf_token(id) }}" />
         {% endif %}
 
         <button type="button" class="btn btn-sm" data-bs-dismiss="modal">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/pull/19144, https://github.com/Sylius/Sylius/pull/19001, https://github.com/Sylius/SyliusResourceBundle/pull/1163
| License         | MIT

PR to work require changes from above PR from  Sylius/SyliusResourceBundle

## Summary
Replaces hardcoded _csrf_token field name across resource action templates
and admin actions with a configurable parameter, allowing projects to customize
the CSRF field name via configuration.

## Motivation
The CSRF field name for resource actions (delete, cancel, refund, resend email,
avatar removal, etc.) was hardcoded to _csrf_token in 18 templates and
3 PHP actions. Projects requiring custom CSRF field names (for security
conventions or framework compliance) had no way to override it.
