### PR TITLE
[CI] Increase build timeout

### DIFF
--- a/.github/workflows/ci__full_1_14.yaml
+++ b/.github/workflows/ci__full_1_14.yaml
@@ -78,7 +78,7 @@ jobs:
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, frontend, packages]
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 30
 
         steps:
             -   name: "Process data"

--- a/.github/workflows/ci__full_2_1.yaml
+++ b/.github/workflows/ci__full_2_1.yaml
@@ -88,7 +88,7 @@ jobs:
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-js, frontend, packages]
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 30
 
         steps:
             -   name: "Process data"

--- a/.github/workflows/ci__full_2_2.yaml
+++ b/.github/workflows/ci__full_2_2.yaml
@@ -88,7 +88,7 @@ jobs:
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-js, frontend, packages]
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 30
 
         steps:
             -   name: "Process data"

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -158,7 +158,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -144,7 +144,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -132,7 +132,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -17,7 +17,7 @@ jobs:
     behat-no-js-unstable:
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         strategy:
             fail-fast: false
@@ -98,7 +98,7 @@ jobs:
     behat-ui-js-chromedriver-unstable:
         runs-on: ubuntu-latest
         name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix:
@@ -180,7 +180,7 @@ jobs:
     behat-ui-js-panther-unstable:
         runs-on: ubuntu-latest
         name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ci_js.yaml
+++ b/.github/workflows/ci_js.yaml
@@ -53,7 +53,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "[${{ matrix.group }}] [PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}]"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -134,7 +134,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.panther-matrix) }}

--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -21,7 +21,7 @@ jobs:
     test_unstable:
         runs-on: ubuntu-latest
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (Unstable Dependencies)"
-        timeout-minutes: 15
+        timeout-minutes: 30
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci_packages.yaml
+++ b/.github/workflows/ci_packages.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
-        timeout-minutes: 15
+        timeout-minutes: 30
 
         strategy:
             fail-fast: false

--- a/.github/workflows/refactor.yaml
+++ b/.github/workflows/refactor.yaml
@@ -16,7 +16,7 @@ jobs:
 
         name: "Coding standard refactor"
 
-        timeout-minutes: 15
+        timeout-minutes: 30
 
         if: github.repository == 'Sylius/Sylius'
 

--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository == 'Sylius/Sylius'
         name: "Upmerge PR"
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

## Increase CI job timeouts to 30 minutes

Behat jobs (especially `Javascript Tests (MySQL) / [Remaining]`) were intermittently
failing with `The operation was canceled` - caused by hitting the job `timeout-minutes`
limit, not by an actual test failure. When the JS suite flakes and the rerun chain kicks
in (`BEHAT_STEP_DELAY=5000`, 5s per step), the job exceeds the limit and GitHub cancels it.

Bumps `timeout-minutes` to `30` across all workflow jobs to give reruns enough headroom.

No logic changes - CI config only.