### PR TITLE
[FIX][2.2] Hide notifications icon when notifications are disabled

### DIFF
--- a/config/packages/test/_sylius.yaml
+++ b/config/packages/test/_sylius.yaml
@@ -1,4 +1,5 @@
 parameters:
+    test_default_admin_notifications_enabled: true
     test_default_state_machine_adapter: 'symfony_workflow'
     test_sylius_state_machine_adapter: '%env(string:default:test_default_state_machine_adapter:TEST_SYLIUS_STATE_MACHINE_ADAPTER)%'
 
@@ -7,6 +8,7 @@ sylius_api:
 
 sylius_admin:
     notifications:
+        enabled: '%env(bool:default:test_default_admin_notifications_enabled:TEST_SYLIUS_ADMIN_NOTIFICATIONS_ENABLED)%'
         hub_enabled: false
 
 sylius_state_machine_abstraction:

--- a/features/admin/navbar_notifications_visibility.feature
+++ b/features/admin/navbar_notifications_visibility.feature
@@ -1,0 +1,19 @@
+@admin_dashboard
+Feature: Displaying the notifications icon in the admin navbar
+    In order to avoid seeing a non-functional icon
+    As an Administrator
+    I want the notifications icon in the navbar to be hidden when notifications are disabled
+
+    Background:
+        Given I am logged in as an administrator
+
+    @ui
+    Scenario: Notifications icon is visible when notifications are enabled
+        When I open administration dashboard
+        Then I should see the notifications icon in the navbar
+
+    @ui @notifications_disabled
+    Scenario: Notifications icon is hidden when notifications are disabled
+        Given the admin notifications are disabled
+        When I open administration dashboard
+        Then I should not see the notifications icon in the navbar

--- a/src/Sylius/Behat/Context/Ui/Admin/NavbarNotificationsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/NavbarNotificationsContext.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Hook\AfterScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Sylius\Behat\Page\Admin\DashboardPageInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;
@@ -28,25 +31,25 @@ final class NavbarNotificationsContext implements Context
     ) {
     }
 
-    /** @Given the admin notifications are disabled */
+    #[Given('the admin notifications are disabled')]
     public function theAdminNotificationsAreDisabled(): void
     {
         $this->overrideNotificationsEnabledEnv('0');
     }
 
-    /** @AfterScenario @notifications_disabled */
+    #[AfterScenario('@notifications_disabled')]
     public function restoreNotificationsEnabledEnv(): void
     {
         $this->overrideNotificationsEnabledEnv(null);
     }
 
-    /** @Then I should see the notifications icon in the navbar */
+    #[Then('I should see the notifications icon in the navbar')]
     public function iShouldSeeTheNotificationsIconInTheNavbar(): void
     {
         Assert::true($this->dashboardPage->hasNotificationsIcon());
     }
 
-    /** @Then I should not see the notifications icon in the navbar */
+    #[Then('I should not see the notifications icon in the navbar')]
     public function iShouldNotSeeTheNotificationsIconInTheNavbar(): void
     {
         Assert::false($this->dashboardPage->hasNotificationsIcon());

--- a/src/Sylius/Behat/Context/Ui/Admin/NavbarNotificationsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/NavbarNotificationsContext.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Ui\Admin;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Page\Admin\DashboardPageInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Webmozart\Assert\Assert;
+
+final class NavbarNotificationsContext implements Context
+{
+    private const NOTIFICATIONS_ENABLED_ENV = 'TEST_SYLIUS_ADMIN_NOTIFICATIONS_ENABLED';
+
+    public function __construct(
+        private readonly DashboardPageInterface $dashboardPage,
+        private readonly KernelInterface $kernel,
+    ) {
+    }
+
+    /** @Given the admin notifications are disabled */
+    public function theAdminNotificationsAreDisabled(): void
+    {
+        $this->overrideNotificationsEnabledEnv('0');
+    }
+
+    /** @AfterScenario @notifications_disabled */
+    public function restoreNotificationsEnabledEnv(): void
+    {
+        $this->overrideNotificationsEnabledEnv(null);
+    }
+
+    /** @Then I should see the notifications icon in the navbar */
+    public function iShouldSeeTheNotificationsIconInTheNavbar(): void
+    {
+        Assert::true($this->dashboardPage->hasNotificationsIcon());
+    }
+
+    /** @Then I should not see the notifications icon in the navbar */
+    public function iShouldNotSeeTheNotificationsIconInTheNavbar(): void
+    {
+        Assert::false($this->dashboardPage->hasNotificationsIcon());
+    }
+
+    /**
+     * Overrides the notifications environment variable in the current process and reboots the kernel,
+     * so that the Symfony session serves the next request with a fresh container re-reading the configuration.
+     */
+    private function overrideNotificationsEnabledEnv(?string $value): void
+    {
+        if (null === $value) {
+            putenv(self::NOTIFICATIONS_ENABLED_ENV);
+            unset($_ENV[self::NOTIFICATIONS_ENABLED_ENV], $_SERVER[self::NOTIFICATIONS_ENABLED_ENV]);
+        } else {
+            putenv(self::NOTIFICATIONS_ENABLED_ENV . '=' . $value);
+            $_ENV[self::NOTIFICATIONS_ENABLED_ENV] = $value;
+            $_SERVER[self::NOTIFICATIONS_ENABLED_ENV] = $value;
+        }
+
+        $this->kernel->reboot(null);
+    }
+}

--- a/src/Sylius/Behat/Page/Admin/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPage.php
@@ -170,6 +170,11 @@ class DashboardPage extends SyliusPage implements DashboardPageInterface
         return 'sylius_admin_dashboard';
     }
 
+    public function hasNotificationsIcon(): bool
+    {
+        return $this->hasElement('notifications_icon');
+    }
+
     /** @return array<string, string> */
     protected function getDefinedElements(): array
     {
@@ -184,6 +189,7 @@ class DashboardPage extends SyliusPage implements DashboardPageInterface
             'month_split_by_days_statistics_button' => 'button[data-stats-button="month"]',
             'new_customers' => '[data-test-new-customers]',
             'next_period' => '[data-test-next-period]',
+            'notifications_icon' => '[data-test-notifications-icon]',
             'order_list' => '[data-test-new-orders]',
             'orders_to_process' => '[data-test-orders-to-process]',
             'orders_to_process_count' => '[data-test-orders-to-process-count]',

--- a/src/Sylius/Behat/Page/Admin/DashboardPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPageInterface.php
@@ -55,4 +55,6 @@ interface DashboardPageInterface extends SyliusPageInterface
     public function getNumberOfProductVariantsOutOfStock(): int;
 
     public function getNumberOfShipmentsToShip(): int;
+
+    public function hasNotificationsIcon(): bool;
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -19,6 +19,11 @@
             <argument type="service" id="sylius.behat.page.admin.dashboard" />
         </service>
 
+        <service id="sylius.behat.context.ui.admin.navbar_notifications" class="Sylius\Behat\Context\Ui\Admin\NavbarNotificationsContext">
+            <argument type="service" id="sylius.behat.page.admin.dashboard" />
+            <argument type="service" id="kernel" />
+        </service>
+
         <service id="sylius.behat.context.ui.admin.error_page" class="Sylius\Behat\Context\Ui\Admin\ErrorPageContext">
             <argument type="service" id="sylius.behat.page.error" />
         </service>

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/dashboard.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/dashboard.yaml
@@ -36,6 +36,7 @@ default:
                 - sylius.behat.context.ui.admin.dashboard
                 - sylius.behat.context.ui.admin.login
                 - sylius.behat.context.ui.admin.managing_products
+                - sylius.behat.context.ui.admin.navbar_notifications
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.browser
                 - sylius.behat.context.ui.save

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Shared/Navbar/NotificationsComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Shared/Navbar/NotificationsComponent.php
@@ -37,4 +37,10 @@ class NotificationsComponent
 
         return $this->notificationProvider->getNotifications();
     }
+
+    #[ExposeInTemplate(name: 'notifications_enabled')]
+    public function areNotificationsEnabled(): bool
+    {
+        return $this->areNotificationsEnabled;
+    }
 }

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/components/navbar/notifications.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/components/navbar/notifications.html.twig
@@ -1,52 +1,54 @@
 {# Rendered by \Sylius\Bundle\AdminBundle\TwigComponent\Shared\Navbar\NotificationsComponent #}
 
-{% import '@SyliusAdmin/shared/helper/dropdown.html.twig' as dropdown %}
+{% if notifications_enabled %}
+    {% import '@SyliusAdmin/shared/helper/dropdown.html.twig' as dropdown %}
 
-<div class="nav-item">
-    {% set dropdown_trigger %}
-        {% if notifications %}
-            <button class="nav-link nav-button justify-content-center px-0 text-body">
-                {{ ux_icon('tabler:bell') }}
-                <span class="badge bg-red" style="transform: translate(-3px, -9px)"></span>
-            </button>
-        {% else %}
-            <div class="nav-link px-0 text-body">
-                {{ ux_icon('tabler:bell') }}
-            </div>
-        {% endif %}
-    {% endset %}
-
-    {% set dropdown_content %}
-        <div class="card" style="min-width: 15rem; max-width: 25rem">
-            {% if notifications is empty %}
-                <div class="card-header">
-                    <h3 class="card-title">{{ 'sylius.ui.no_new_notifications'|trans }}</h3>
-                </div>
+    <div class="nav-item" data-test-notifications-icon>
+        {% set dropdown_trigger %}
+            {% if notifications %}
+                <button class="nav-link nav-button justify-content-center px-0 text-body">
+                    {{ ux_icon('tabler:bell') }}
+                    <span class="badge bg-red" style="transform: translate(-3px, -9px)"></span>
+                </button>
             {% else %}
-                <div class="list-group list-group-flush list-group-hoverable">
-                    {% for notification in notifications %}
-                        <div class="list-group-item">
-                            <div class="row align-items-center">
-                                <div class="col-auto">
-                                    <span class="status-dot status-dot-animated bg-red d-block"></span>
-                                </div>
-                                <div class="col">
-                                    <div class="d-block mt-n1">
-                                        {{ notification.message|trans }}
+                <div class="nav-link px-0 text-body">
+                    {{ ux_icon('tabler:bell') }}
+                </div>
+            {% endif %}
+        {% endset %}
+
+        {% set dropdown_content %}
+            <div class="card" style="min-width: 15rem; max-width: 25rem">
+                {% if notifications is empty %}
+                    <div class="card-header">
+                        <h3 class="card-title">{{ 'sylius.ui.no_new_notifications'|trans }}</h3>
+                    </div>
+                {% else %}
+                    <div class="list-group list-group-flush list-group-hoverable">
+                        {% for notification in notifications %}
+                            <div class="list-group-item">
+                                <div class="row align-items-center">
+                                    <div class="col-auto">
+                                        <span class="status-dot status-dot-animated bg-red d-block"></span>
+                                    </div>
+                                    <div class="col">
+                                        <div class="d-block mt-n1">
+                                            {{ notification.message|trans }}
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    {% endfor %}
-                </div>
-            {% endif %}
-        </div>
-    {% endset %}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            </div>
+        {% endset %}
 
-    {{ dropdown.default({
-        class: 'dropdown-menu-card',
-        custom_trigger: dropdown_trigger,
-        content: dropdown_content,
-        direction: 'down-end'
-    }) }}
-</div>
+        {{ dropdown.default({
+            class: 'dropdown-menu-card',
+            custom_trigger: dropdown_trigger,
+            content: dropdown_content,
+            direction: 'down-end'
+        }) }}
+    </div>
+{% endif %}

--- a/tests/Api/JsonApiTestCase.php
+++ b/tests/Api/JsonApiTestCase.php
@@ -305,6 +305,7 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
         if (preg_match('/@\w+@\./', $value)) {
             return true;
         }
+
         return false;
     }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18713
| License         | MIT

While using:
```yaml
sylius_admin:
  notifications:
    enabled: false
```

The notifications icon in the admin panel is not rendering now.