### PR TITLE
[FIX][2.2] Fix locking icons

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,3 +1,17 @@
+# UPGRADE FROM `2.2.7` TO `2.2.8`
+
+## UX Icons
+
+1. The `ux:icons:lock` command (and the ux-icons cache warmer) imported `0` icons in Sylius applications.
+   Symfony UX's `Symfony\UX\Icons\Twig\IconFinder` discovers icons by traversing the Twig loader, but it only
+   understands Twig's `FilesystemLoader` and `ChainLoader`. Sylius decorates the Twig loader with
+   `Sylius\Bundle\ThemeBundle\Twig\Loader\ThemedTemplateLoader`, which `IconFinder` cannot traverse, so no template
+   was ever scanned.
+   A new `Sylius\Bundle\UiBundle\DependencyInjection\Compiler\UxIconsIconFinderPass` now points the
+   `.ux_icons.icon_finder` service at a dedicated Twig environment (`sylius_ui.ux_icons.twig_environment`) backed by
+   the native filesystem loader (`twig.loader.native_filesystem`), so template scanning works again without affecting
+   runtime template rendering.
+
 # UPGRADE FROM `2.2.6` TO `2.2.7`
 
 ## Behat

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/UxIconsIconFinderPass.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/UxIconsIconFinderPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\Environment;
+
+/**
+ * This pass points the IconFinder at a dedicated Twig environment backed by the native filesystem
+ * loader, so it can discover template files again without affecting runtime template rendering.
+ *
+ * @see https://github.com/Sylius/Sylius/issues/18712
+ */
+final class UxIconsIconFinderPass implements CompilerPassInterface
+{
+    private const ICON_FINDER_ID = '.ux_icons.icon_finder';
+
+    private const NATIVE_FILESYSTEM_LOADER_ID = 'twig.loader.native_filesystem';
+
+    private const ENVIRONMENT_ID = 'sylius_ui.ux_icons.twig_environment';
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(self::ICON_FINDER_ID)) {
+            return;
+        }
+
+        if (!$container->has(self::NATIVE_FILESYSTEM_LOADER_ID)) {
+            return;
+        }
+
+        $environment = (new Definition(Environment::class, [new Reference(self::NATIVE_FILESYSTEM_LOADER_ID)]))
+            ->setPublic(false)
+        ;
+
+        $container->setDefinition(self::ENVIRONMENT_ID, $environment);
+        $container->getDefinition(self::ICON_FINDER_ID)
+            ->replaceArgument(0, new Reference(self::ENVIRONMENT_ID))
+        ;
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/SyliusUiBundle.php
+++ b/src/Sylius/Bundle/UiBundle/SyliusUiBundle.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\UiBundle;
 
 use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\LiveComponentTagPass;
 use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\TwigComponentTagPass;
+use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\UxIconsIconFinderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,5 +28,6 @@ final class SyliusUiBundle extends Bundle
     {
         $container->addCompilerPass(new LiveComponentTagPass(), priority: 50);
         $container->addCompilerPass(new TwigComponentTagPass(), priority: 50);
+        $container->addCompilerPass(new UxIconsIconFinderPass());
     }
 }

--- a/src/Sylius/Bundle/UiBundle/tests/DependencyInjection/Compiler/UxIconsIconFinderPassTest.php
+++ b/src/Sylius/Bundle/UiBundle/tests/DependencyInjection/Compiler/UxIconsIconFinderPassTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\UiBundle\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\UxIconsIconFinderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final class UxIconsIconFinderPassTest extends AbstractCompilerPassTestCase
+{
+    public function testItPointsTheIconFinderAtAnEnvironmentBackedByTheNativeFilesystemLoader(): void
+    {
+        $this->setDefinition('twig.loader.native_filesystem', new Definition(FilesystemLoader::class));
+
+        $iconFinder = new Definition();
+        $iconFinder->setArguments([new Reference('twig'), '/app/assets/icons']);
+        $this->setDefinition('.ux_icons.icon_finder', $iconFinder);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sylius_ui.ux_icons.twig_environment', Environment::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sylius_ui.ux_icons.twig_environment',
+            0,
+            new Reference('twig.loader.native_filesystem'),
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            '.ux_icons.icon_finder',
+            0,
+            new Reference('sylius_ui.ux_icons.twig_environment'),
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            '.ux_icons.icon_finder',
+            1,
+            '/app/assets/icons',
+        );
+    }
+
+    public function testItDoesNothingWhenTheIconFinderIsNotRegistered(): void
+    {
+        $this->setDefinition('twig.loader.native_filesystem', new Definition(FilesystemLoader::class));
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius_ui.ux_icons.twig_environment');
+    }
+
+    public function testItDoesNothingWhenTheNativeFilesystemLoaderIsNotRegistered(): void
+    {
+        $iconFinder = new Definition();
+        $iconFinder->setArguments([new Reference('twig'), '/app/assets/icons']);
+        $this->setDefinition('.ux_icons.icon_finder', $iconFinder);
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius_ui.ux_icons.twig_environment');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            '.ux_icons.icon_finder',
+            0,
+            new Reference('twig'),
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new UxIconsIconFinderPass());
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18712
| License         | MIT

The `ux:icons:lock` command (and the ux-icons cache warmer) imported `0` icons in Sylius applications. Symfony UX's `Symfony\UX\Icons\Twig\IconFinder` discovers icons by traversing the Twig loader, but it only understands Twig's `FilesystemLoader` and `ChainLoader`. Sylius decorates the Twig loader with `Sylius\Bundle\ThemeBundle\Twig\Loader\ThemedTemplateLoader`, which `IconFinder` cannot traverse, so no template was ever scanned.

A new `Sylius\Bundle\UiBundle\DependencyInjection\Compiler\UxIconsIconFinderPass` now points the `.ux_icons.icon_finder` service at a dedicated Twig environment (`sylius_ui.ux_icons.twig_environment`) backed by the native filesystem loader (`twig.loader.native_filesystem`), so template scanning works again without affecting runtime template rendering.
