### PR TITLE
[AdminBundle][ShopBundle] Fix production asset build broken by Sass BOM

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -65,6 +65,8 @@ class SyliusAdmin {
             .enableSassLoader((options) => {
                 // eslint-disable-next-line no-param-reassign
                 options.additionalData = `$rootDir: '${rootDir}';`;
+                // eslint-disable-next-line no-param-reassign
+                options.sassOptions = { ...options.sassOptions, charset: false };
             });
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -62,6 +62,8 @@ class SyliusShop {
             .enableSassLoader((options) => {
                 // eslint-disable-next-line no-param-reassign
                 options.additionalData = `$rootDir: '${rootDir}';`;
+                // eslint-disable-next-line no-param-reassign
+                options.sassOptions = { ...options.sassOptions, charset: false };
             });
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #19160
| License         | MIT

Dart Sass prepends a UTF-8 BOM to its compressed output whenever the CSS contains non-ASCII characters (e.g. the '›' glyph in the shop steps style, or Tabler's glyphs in the admin). Since PostCSS 8.5.24 that BOM is no longer silently dropped but faithfully preserved through the build pipeline, where it ends up right before a `/*!` comment and makes cssnano's selector parser throw "Unclosed comment", failing `yarn build:prod`.

Setting `charset: false` on the Sass loader stops Sass from emitting the BOM at the source, which fixes the build independently of the PostCSS version.