### PR TITLE
[AdminBundle] Dark mode follow-up fixes 

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
@@ -36,6 +36,7 @@
     --tblr-body-bg: #{$dark-body-bg};
     --tblr-body-bg-rgb: #{red($dark-body-bg)}, #{green($dark-body-bg)}, #{blue($dark-body-bg)};
     --tblr-bg-surface: #{$dark-bg-surface};
+    --tblr-bg-surface-tertiary: #{$dark-body-bg};
 
     .btn {
         --tblr-btn-border-color: var(--tblr-border-color);

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
@@ -42,6 +42,11 @@
         --tblr-btn-border-color: var(--tblr-border-color);
     }
 
+    .btn-ghost-dark {
+        --tblr-btn-color: var(--tblr-body-color);
+        --tblr-btn-disabled-color: var(--tblr-body-color);
+    }
+
     .form-control:where(:not(.is-invalid):not(.is-valid):not(:focus)),
     .form-select:where(:not(.is-invalid):not(.is-valid):not(:focus)),
     .form-check-input:where(:not(.is-invalid):not(.is-valid):not(:focus)),

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
@@ -10,6 +10,7 @@
 * {
     --tblr-breadcrumb-item-active-color: var(--tblr-gray-500);
     --tblr-breadcrumb-divider-color: var(--tblr-gray-300);
+    --tblr-breadcrumb-link-color: var(--tblr-body-color);
     --tblr-blue-rgb: 17, 81, 141;
     --tblr-green-rgb: 0, 97, 16;
     --tblr-pagination-border-width: 0;
@@ -19,7 +20,6 @@
 @include color-mode(light) {
     --tblr-body-color: #212529;
     --tblr-code-color: #36393B;
-    --tblr-breadcrumb-link-color: #212529;
 
     body {
         --bs-body-bg: #{$body-bg};

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
@@ -41,9 +41,9 @@
         --tblr-btn-border-color: var(--tblr-border-color);
     }
 
-    .form-control,
-    .form-select,
-    .form-check-input,
+    .form-control:where(:not(.is-invalid):not(.is-valid):not(:focus)),
+    .form-select:where(:not(.is-invalid):not(.is-valid):not(:focus)),
+    .form-check-input:where(:not(.is-invalid):not(.is-valid):not(:focus)),
     .input-group-text {
         border-color: var(--tblr-border-color);
     }

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_body.scss
@@ -38,7 +38,7 @@
     --tblr-bg-surface: #{$dark-bg-surface};
     --tblr-bg-surface-tertiary: #{$dark-body-bg};
 
-    .btn {
+    .btn:where(:not([class*="btn-ghost"])) {
         --tblr-btn-border-color: var(--tblr-border-color);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_tom-select.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_tom-select.scss
@@ -23,8 +23,23 @@
 }
 
 @include color-mode(dark) {
-    .ts-control .item {
+    .ts-wrapper.multi .ts-control > div:where(:not(.active)) {
         color: var(--tblr-body-color);
+        background: var(--tblr-border-color);
+    }
+
+    .ts-wrapper.multi.disabled .ts-control > div {
+        color: var(--tblr-secondary-color);
+        background: var(--tblr-bg-surface-secondary);
+    }
+
+    .ts-wrapper.plugin-remove_button .item .remove,
+    .ts-wrapper.plugin-remove_button.disabled .item .remove {
+        border-inline-start-color: var(--tblr-bg-surface-secondary);
+    }
+
+    .ts-wrapper.plugin-remove_button:not(.disabled) .item .remove:hover {
+        background: rgba(255, 255, 255, 0.1);
     }
 }
 

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/orders_to_process.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/orders_to_process.html.twig
@@ -7,7 +7,7 @@
     <div><strong>{{ 'sylius.ui.orders'|trans }}</strong> {{ 'sylius.ui.to_process'|trans }}</div>
     <div class="d-flex align-items-center gap-4">
         <span
-            class="badge rounded-pill bg-dark-lt text-default-fg py-2 px-3 fs-4 fw-bold my-1"
+            class="badge rounded-pill bg-surface-tertiary text-body py-2 px-3 fs-4 fw-bold my-1"
             {{ sylius_test_html_attribute('orders-to-process-count') }}
         >
             {{ count }}

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/pending_payments.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/pending_payments.html.twig
@@ -7,7 +7,7 @@
     <div>{{ 'sylius.ui.pending'|trans }} <strong>{{ 'sylius.ui.payments'|trans|lower }}</strong></div>
     <div class="d-flex align-items-center gap-4">
         <span
-            class="badge rounded-pill bg-dark-lt text-default-fg py-2 px-3 fs-4 fw-bold my-1"
+            class="badge rounded-pill bg-surface-tertiary text-body py-2 px-3 fs-4 fw-bold my-1"
             {{ sylius_test_html_attribute('pending-payments-count')}}
         >
             {{ count }}

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/product_reviews_to_approve.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/product_reviews_to_approve.html.twig
@@ -7,7 +7,7 @@
     <div><strong>{{ 'sylius.ui.product_reviews'|trans }}</strong> {{ 'sylius.ui.to_approve'|trans }}</div>
     <div class="d-flex align-items-center gap-4">
         <span
-            class="badge rounded-pill bg-dark-lt text-default-fg py-2 px-3 fs-4 fw-bold my-1"
+            class="badge rounded-pill bg-surface-tertiary text-body py-2 px-3 fs-4 fw-bold my-1"
             {{ sylius_test_html_attribute('product-reviews-to-approve-count') }}
         >
             {{ count }}

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/product_variants_out_of_stock.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/product_variants_out_of_stock.html.twig
@@ -7,7 +7,7 @@
     <div><strong>{{ 'sylius.ui.product_variants'|trans }}</strong> {{ 'sylius.ui.out_of_stock'|trans|lower }}</div>
     <div class="d-flex align-items-center gap-4">
         <span
-            class="badge rounded-pill bg-dark-lt text-default-fg py-2 px-3 fs-4 fw-bold my-1"
+            class="badge rounded-pill bg-surface-tertiary text-body py-2 px-3 fs-4 fw-bold my-1"
             {{ sylius_test_html_attribute('product-variants-out-of-stock-count') }}
         >
             {{ count }}

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/shipments_to_ship.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/pending_actions/body/shipments_to_ship.html.twig
@@ -7,7 +7,7 @@
     <div><strong>{{ 'sylius.ui.shipments'|trans }}</strong> {{ 'sylius.ui.to_ship'|trans }}</div>
     <div class="d-flex align-items-center gap-4">
         <span
-            class="badge rounded-pill bg-dark-lt text-default-fg py-2 px-3 fs-4 fw-bold my-1"
+            class="badge rounded-pill bg-surface-tertiary text-body py-2 px-3 fs-4 fw-bold my-1"
             {{ sylius_test_html_attribute('shipments-to-ship-count') }}
         >
             {{ count }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | follows up #18981
| License         | MIT

## Description

Follow-up on #18981, which introduced dark mode in the admin panel. A visual pass over the admin screens surfaced the following regressions:

- Validation borders (`.is-invalid`, `.is-valid`) and the focus ring were flattened on form controls
- Ghost buttons got a border they are not supposed to have
- Disabled `.btn-ghost-dark` buttons (row actions on grid items that cannot be moved) were barely visible
- `--tblr-bg-surface-tertiary` no longer matched the dark page background
- Breadcrumb links rendered in the primary color, in both themes
- The dashboard pending actions counters had almost no contrast between the badge and its text
- Tom Select multi-select items were unreadable, and their remove-button separator showed up in a hardcoded light color
