### PR TITLE
[Composer] Conflict with doctrine/orm 3.6.8 breaking schema generation

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -32,3 +32,13 @@ This document explains why certain conflicts were added to `composer.json` and r
   The conflict is temporary and keeps the integration on 4.3.15 until a fixed `api-platform/symfony` release is tagged.
 
   References: https://github.com/api-platform/core/pull/8386
+
+- `doctrine/orm:3.6.8`:
+
+  This version adds `GenerateSchemaEventArgs::setSchema()`, which throws a `BadMethodCallException` unless
+  `doctrine/dbal` provides the `Schema::edit()` API. That API requires `doctrine/dbal` ^4.5, which has not been
+  released yet. The `SchemaListener` classes shipped with `symfony/doctrine-bridge` guard the call only with
+  `method_exists($event, 'setSchema')`, so starting from this version they always hit the exception and every
+  `doctrine:schema:create`, `doctrine:schema:update` and `doctrine:migrations:diff` call fails.
+
+  References: https://github.com/doctrine/orm/issues/12547

--- a/composer.json
+++ b/composer.json
@@ -241,7 +241,7 @@
     "conflict": {
         "api-platform/serializer": "4.2.17",
         "api-platform/symfony": "4.3.16",
-        "doctrine/orm": "2.20.7 || 3.5.3",
+        "doctrine/orm": "2.20.7 || 3.5.3 || 3.6.8",
         "symfony/ux-live-component": "2.28.0 || 2.28.1"
     },
     "config": {

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -70,6 +70,7 @@
         "php-http/discovery": "^1.20"
     },
     "conflict": {
+        "doctrine/orm": "3.6.8",
         "phpstan/phpdoc-parser": ">= 2.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Fixes failing builds for ApiBundle: https://github.com/Sylius/Sylius/actions/runs/31067342985/job/92519431732?pr=19173#step:11:1

References: https://github.com/doctrine/orm/issues/12547

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
