### PR TITLE
[BUG] [Admin] [Translation] Wrong german translation for "Select" type in Product Attributes Grid

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
@@ -805,7 +805,7 @@ sylius:
         search_products: 'Artikel suchen'
         security_settings: 'Sicherheitseinstellungen'
         see_issue: 'Fehler gefunden'
-        select: 'Land auswählen'
+        select: 'Auswahl'
         select_address_from_book: 'Adresse aus Adressbuch auswählen'
         select_products: 'Produkt auswählen'
         select_taxon: 'Klassifizierung wählen'


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #19177
| License         | MIT

This PR fixes the german translation for the select type in the Product attributes grid.

<img width="1890" height="215" alt="image" src="https://github.com/user-attachments/assets/bb673145-37d8-4cff-9796-db4fef7240aa" />
