### PR TITLE
 Fix cart offcanvas losing Bootstrap state on live re-render

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/styles/_offcanvas.scss
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/styles/_offcanvas.scss
@@ -16,6 +16,10 @@
     }
 }
 
+.offcanvas-cart-live-region {
+    display: contents;
+}
+
 .offcanvas {
     .navbar-nav {
         overflow-x: hidden;

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/layout/base/offcanvas/cart.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/layout/base/offcanvas/cart.html.twig
@@ -1,5 +1,7 @@
 {# Rendered with \Sylius\Bundle\ShopBundle\Twig\Component\Common\CartComponent #}
 
-<div class="offcanvas offcanvas-end offcanvas-wide" tabindex="-1" id="offcanvasCart" {{ attributes }}>
-    {% hook 'cart' with { cart } %}
+<div class="offcanvas offcanvas-end offcanvas-wide" tabindex="-1" id="offcanvasCart">
+    <div class="offcanvas-cart-live-region" {{ attributes }}>
+        {% hook 'cart' with { cart } %}
+    </div>
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

  When a Live Component inside the cart offcanvas emits SYLIUS_SHOP_CART_CHANGED while the offcanvas is open, the offcanvas visually closes but the backdrop stays on screen.                             
                                                                                                                                                                                                          
  #offcanvasCart was the LiveComponent root, so Idiomorph re-synced its attributes against the plain PHP template on every re-render, wiping the show class, aria-modal, role and inline style that Bootstrap adds at runtime — without calling Bootstrap's hide(), so the backdrop was left orphaned.                                                                                                      
                                                                                                                                                                                                          
  Fix: move the LiveComponent root to a nested .offcanvas-cart-live-region wrapper (display: contents) instead of #offcanvasCart itself. The offcanvas root is now static and untouched by Idiomorph, while cart contents still update in place. 
  
 Before (off-canvas is closed, leaving gray screen):
 
<img width="1434" height="781" alt="image" src="https://github.com/user-attachments/assets/d8cd3304-9915-4f73-bf98-0de3da3960fe" />

After (emit SYLIUS_SHOP_CART_CHANGED, off-canvas stay)
<img width="1554" height="1048" alt="image" src="https://github.com/user-attachments/assets/ac2ae2b3-423f-464b-8ab5-7502fc03c7bc" />
