### PR TITLE
Add missing kernel.reset tag to ShopBasedCartContext

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/EventListener/ApiCartBlamerListener.php
+++ b/src/Sylius/Bundle/ApiBundle/EventListener/ApiCartBlamerListener.php
@@ -49,7 +49,12 @@ final readonly class ApiCartBlamerListener
             return;
         }
 
-        $this->commandBus->dispatch(new BlameCart($user->getEmail(), $cart->getTokenValue()));
+        $tokenValue = $cart->getTokenValue();
+        if (null === $tokenValue) {
+            return;
+        }
+
+        $this->commandBus->dispatch(new BlameCart($user->getEmail(), $tokenValue));
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/tests/EventListener/ApiCartBlamerListenerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/EventListener/ApiCartBlamerListenerTest.php
@@ -163,6 +163,51 @@ final class ApiCartBlamerListenerTest extends TestCase
         );
     }
 
+    public function testDoesNothingIfGivenCartHasNoTokenValueOnInteractiveLogin(): void
+    {
+        /** @var OrderInterface|MockObject $cartMock */
+        $cartMock = $this->createMock(OrderInterface::class);
+        /** @var Request|MockObject $requestMock */
+        $requestMock = $this->createMock(Request::class);
+        /** @var TokenInterface|MockObject $tokenMock */
+        $tokenMock = $this->createMock(TokenInterface::class);
+        /** @var ShopUserInterface|MockObject $userMock */
+        $userMock = $this->createMock(ShopUserInterface::class);
+        /** @var ShopApiOrdersSubSection|MockObject $shopApiOrdersSubSectionSectionMock */
+        $shopApiOrdersSubSectionSectionMock = $this->createMock(ShopApiOrdersSubSection::class);
+        /** @var AuthenticatorInterface|MockObject $authenticatorMock */
+        $authenticatorMock = $this->createMock(AuthenticatorInterface::class);
+        /** @var Passport|MockObject $passportMock */
+        $passportMock = $this->createMock(Passport::class);
+
+        $this->sectionResolver->expects(self::once())
+            ->method('getSection')
+            ->willReturn($shopApiOrdersSubSectionSectionMock);
+
+        $this->cartContext->expects(self::once())->method('getCart')->willReturn($cartMock);
+
+        $cartMock->expects(self::once())->method('isCreatedByGuest')->willReturn(true);
+
+        $tokenMock->expects(self::once())->method('getUser')->willReturn($userMock);
+
+        $userMock->method('getEmail')->willReturn('email@sylius.com');
+
+        $cartMock->expects(self::once())->method('getTokenValue')->willReturn(null);
+
+        $this->commandBus->expects(self::never())->method('dispatch');
+
+        $this->apiCartBlamerListener->onLoginSuccess(
+            new LoginSuccessEvent(
+                $authenticatorMock,
+                $passportMock,
+                $tokenMock,
+                $requestMock,
+                null,
+                'api_shop',
+            ),
+        );
+    }
+
     public function testDoesNothingIfGivenCartHasBeenBlamedInPast(): void
     {
         /** @var OrderInterface|MockObject $cartMock */

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
@@ -34,6 +34,7 @@
             <argument type="service" id="sylius.context.cart.new_shop_based.inner" />
             <argument type="service" id="sylius.context.shopper" />
             <argument type="service" id="sylius.resolver.cart.created_by_guest_flag" />
+            <tag name="kernel.reset" method="reset" />
         </service>
         <service id="sylius.context.cart.customer_and_channel_based" class="Sylius\Bundle\CoreBundle\Context\CustomerAndChannelBasedCartContext">
             <argument type="service" id="sylius.context.customer" />

--- a/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -149,6 +149,20 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
     }
 
     #[Test]
+    public function it_tags_shop_based_cart_context_with_kernel_reset(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'sylius.context.cart.new_shop_based',
+            'kernel.reset',
+            ['method' => 'reset'],
+        );
+    }
+
+    #[Test]
     public function it_aliases_flysystem_filesystem_adapter_properly(): void
     {
         $this->container->setParameter('kernel.environment', 'dev');

--- a/tests/Api/Shop/CartContextResetBetweenRequestsTest.php
+++ b/tests/Api/Shop/CartContextResetBetweenRequestsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api\Shop;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Tests\Api\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CartContextResetBetweenRequestsTest extends JsonApiTestCase
+{
+    #[Test]
+    public function it_resets_the_cart_context_between_requests_in_the_same_kernel_process(): void
+    {
+        $this->client->disableReboot();
+
+        $this->loadFixturesFromFiles(['channel/channel.yaml', 'cart.yaml', 'authentication/shop_user.yaml']);
+
+        $this->client->request(method: 'GET', uri: '/en_US/cart/');
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_OK);
+
+        $this->setUpDefaultPostHeaders();
+        $this->requestPost(
+            uri: '/api/v2/shop/orders',
+            body: [],
+            headers: $this->headerBuilder()->withShopUserAuthorization('shop@example.com')->build(),
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_CREATED);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | https://github.com/Sylius/Sylius/issues/19155
| License         | MIT

## Summary 
  ShopBasedCartContext decorates sylius.context.cart.new and implements `ResettableCartContextInterface`, but `TagResettableCartContextsPass` runs before decorators are resolved, so it never sees this service and the kernel.reset tag was never applied.                                                                                                                                                                                                      

Tag the service explicitly with kernel.reset, and add a null-check for the cart token in `ApiCartBlamerListener` as a safety guard.        