### PR TITLE
[CoreBundle] Read variant codes in batches when applying catalog promotions

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -703,11 +703,16 @@ For a complete overview of the Grid component, see the [Grid documentation](http
 4. The catalog is no longer read in a single `SELECT`. Recalculating catalog promotions for all variants now issues
    one query per batch, interleaved with the dispatch of each batch.
 
-   Unless the caller holds a transaction that gives every statement the same snapshot, a variant whose identifier was
-   allocated below the point the iteration has reached, but whose transaction commits after it has passed, is missed
-   by that run — the iteration only ever looks ahead of its cursor. Such a variant is picked up by the next
-   recalculation. Variants created after the iteration started are allocated ahead of the cursor and are still seen.
-   This is a deliberate trade for memory that no longer grows with the catalog.
+   The run therefore no longer sees one consistent snapshot of the catalog. Two kinds of variant can be missed by a
+   run, and both are picked up by the next recalculation:
+
+   - one whose identifier was allocated below the point the iteration has reached, but whose transaction commits
+     after it has passed — the iteration only ever looks ahead of its cursor;
+   - one created after the final batch has been read.
+
+   Wrapping the call in a transaction that gives every statement the same snapshot restores a coherent view, but it
+   does not make concurrently created variants visible. This is a deliberate trade for memory that no longer grows
+   with the catalog.
 
 ## New Features
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -670,13 +670,12 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    public function iterateCodesOfAllVariants(int $batchSize): iterable;
    ```
 
-   If you have a custom class implementing this interface, you must add this method. It is expected to yield
-   the codes of all product variants in batches of at most `$batchSize` elements.
+   If you have a custom class implementing this interface without extending
+   `Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductVariantRepository`, you must add this method. It is expected to
+   yield the codes of all product variants in batches of at most `$batchSize` elements.
 
-   It replaces `getCodesOfAllVariants()`, which loaded the whole `product_variant` table into a single array
-   and therefore used memory proportional to the size of the catalog. `AllProductVariantsCatalogPromotionsProcessor`
-   now consumes the catalog batch by batch, so recalculating catalog promotions uses a bounded amount of memory
-   regardless of how many variants exist.
+   It replaces `getCodesOfAllVariants()` (see the *Deprecations* section for the migration), so recalculating
+   catalog promotions no longer uses memory proportional to the size of the catalog.
 
 2. Not passing a batch size as the third constructor argument of
    `Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\AllProductVariantsCatalogPromotionsProcessor` is deprecated
@@ -690,10 +689,11 @@ For a complete overview of the Grid component, see the [Grid documentation](http
     ) {
    ```
 
-   When omitted, it falls back to `AllProductVariantsCatalogPromotionsProcessor::DEFAULT_BATCH_SIZE` (100), which
-   preserves the previous behaviour. The `sylius.processor.catalog_promotion.all_product_variant` service is already
-   configured to pass `%sylius_core.catalog_promotions.batch_size%`, so no change is needed unless you instantiate
-   or re-register this processor yourself.
+   When omitted it falls back to 100, matching the default of `sylius_core.catalog_promotions.batch_size`. Note that
+   if you have configured a different value, the fallback does **not** reproduce it — pass the batch size explicitly.
+   The `sylius.processor.catalog_promotion.all_product_variant` service already passes
+   `%sylius_core.catalog_promotions.batch_size%`, so no change is needed unless you instantiate or re-register this
+   processor yourself.
 
 3. `%sylius_core.catalog_promotions.batch_size%` now governs two things: how many rows are read from the database
    per query, and how many codes are carried by a single `ApplyCatalogPromotionsOnVariants` message. Previously it
@@ -701,13 +701,13 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    size of each `SELECT`.
 
 4. The catalog is no longer read in a single `SELECT`. Recalculating catalog promotions for all variants now issues
-   one query per batch, interleaved with the dispatch of each batch, so the run no longer sees one consistent
-   snapshot of the catalog.
+   one query per batch, interleaved with the dispatch of each batch.
 
-   A variant created by a concurrent request while the iteration is in progress may or may not be included in that
-   run, depending on whether its identifier was assigned before or after the point the iteration has reached. Such a
-   variant is picked up by the next recalculation. This is a deliberate trade for memory that no longer grows with
-   the catalog.
+   Unless the caller holds a transaction that gives every statement the same snapshot, a variant whose identifier was
+   allocated below the point the iteration has reached, but whose transaction commits after it has passed, is missed
+   by that run — the iteration only ever looks ahead of its cursor. Such a variant is picked up by the next
+   recalculation. Variants created after the iteration started are allocated ahead of the cursor and are still seen.
+   This is a deliberate trade for memory that no longer grows with the catalog.
 
 ## New Features
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -703,12 +703,10 @@ For a complete overview of the Grid component, see the [Grid documentation](http
 4. The catalog is no longer read in a single `SELECT`. Recalculating catalog promotions for all variants now issues
    one query per batch, interleaved with the dispatch of each batch.
 
-   The run therefore no longer sees one consistent snapshot of the catalog. Two kinds of variant can be missed by a
-   run, and both are picked up by the next recalculation:
-
-   - one whose identifier was allocated below the point the iteration has reached, but whose transaction commits
-     after it has passed — the iteration only ever looks ahead of its cursor;
-   - one created after the final batch has been read.
+   The run therefore no longer sees one consistent snapshot of the catalog. A variant is missed whenever it becomes
+   visible to the run only after the batch query covering its identifier has already executed — whether its
+   transaction commits late, or it is created after the final batch has been read. Any variant missed this way is
+   picked up by the next recalculation.
 
    Wrapping the call in a transaction that gives every statement the same snapshot restores a coherent view, but it
    does not make concurrently created variants visible. This is a deliberate trade for memory that no longer grows

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -85,9 +85,13 @@
    has always declared.
 
    Previously that code path fed it the raw output of `getCodesOfAllVariants()`, so it actually carried
-   `[['code' => 'VARIANT_1'], ...]`. Messages already queued when you deploy are unaffected — the handler resolves
-   both shapes — but a custom handler, middleware, or log parser reading `$variantsCodes` directly should expect
-   plain strings.
+   `[['code' => 'VARIANT_1'], ...]`.
+
+   Messages already queued when you deploy still resolve, but not because anything handles both shapes — the
+   handler passes the payload straight to `findByCodes()`, and Doctrine happens to flatten single-element nested
+   arrays when binding an `IN` parameter. If you have overridden `findByCodes()` to build the `IN` list yourself,
+   drain the queue before deploying. A custom handler, middleware, or log parser reading `$variantsCodes` directly
+   should expect plain strings from now on.
 
 ## Shop
 
@@ -697,11 +701,13 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    size of each `SELECT`.
 
 4. The catalog is no longer read in a single `SELECT`. Recalculating catalog promotions for all variants now issues
-   one query per batch, interleaved with the dispatch of each batch. On a database or caller where each statement
-   gets its own snapshot (for example PostgreSQL under `READ COMMITTED`, or a caller running outside a wrapping
-   transaction), a variant committed by a concurrent request *while* the iteration is in progress may be missed by
-   that run. It is picked up by the next recalculation. This is a deliberate trade for bounded memory; if you rely
-   on a single consistent snapshot of the catalog, wrap the call in an explicit transaction.
+   one query per batch, interleaved with the dispatch of each batch, so the run no longer sees one consistent
+   snapshot of the catalog.
+
+   A variant created by a concurrent request while the iteration is in progress may or may not be included in that
+   run, depending on whether its identifier was assigned before or after the point the iteration has reached. Such a
+   variant is picked up by the next recalculation. This is a deliberate trade for memory that no longer grows with
+   the catalog.
 
 ## New Features
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -691,6 +691,7 @@ For a complete overview of the Grid component, see the [Grid documentation](http
 
    When omitted it falls back to 100, matching the default of `sylius_core.catalog_promotions.batch_size`. Note that
    if you have configured a different value, the fallback does **not** reproduce it — pass the batch size explicitly.
+   A value lower than 1 is rejected when the processor is constructed.
    The `sylius.processor.catalog_promotion.all_product_variant` service already passes
    `%sylius_core.catalog_promotions.batch_size%`, so no change is needed unless you instantiate or re-register this
    processor yourself.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -646,6 +646,38 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    Existing subclasses overriding this method with the `RedirectResponse` return type remain valid thanks to
    return type covariance and require no changes.
 
+## Product
+
+1. The `iterateCodesOfAllVariants(int $batchSize): iterable` method has been added to `Sylius\Component\Product\Repository\ProductVariantRepositoryInterface`.
+
+   ```php
+   /**
+    * @return iterable<list<string>>
+    */
+   public function iterateCodesOfAllVariants(int $batchSize): iterable;
+   ```
+
+   If you have a custom class implementing this interface, you must add this method. It is expected to yield
+   the codes of all product variants in batches of at most `$batchSize` elements.
+
+   It replaces `getCodesOfAllVariants()`, which loaded the whole `product_variant` table into a single array
+   and therefore used memory proportional to the size of the catalog. `AllProductVariantsCatalogPromotionsProcessor`
+   now consumes the catalog batch by batch, so recalculating catalog promotions uses a bounded amount of memory
+   regardless of how many variants exist.
+
+2. `Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\AllProductVariantsCatalogPromotionsProcessor` takes a
+   third constructor argument, the batch size to read the catalog with. The `sylius.processor.catalog_promotion.all_product_variant`
+   service is already configured to pass `%sylius_core.catalog_promotions.batch_size%`, so no change is needed
+   unless you instantiate this processor yourself.
+
+   ```diff
+    public function __construct(
+        private ProductVariantRepositoryInterface $productVariantRepository,
+        private ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface $commandDispatcher,
+   +    private int $batchSize,
+    ) {
+   ```
+
 ## New Features
 
 1. New post-flush cart events have been added to `Sylius\Component\Order\SyliusCartEvents`.
@@ -762,3 +794,25 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    +    protected readonly ?CartItemAdderInterface $cartItemAdder = null,
     ) {
    ```
+
+3. `Sylius\Component\Product\Repository\ProductVariantRepositoryInterface::getCodesOfAllVariants()` is deprecated
+   since Sylius 2.3 and will be removed in Sylius 3.0. Use `iterateCodesOfAllVariants(int $batchSize)` instead.
+
+   The deprecated method loads every row of `product_variant` into a single array, so its memory usage grows
+   linearly with the size of the catalog. The replacement reads the catalog in batches using keyset pagination
+   and keeps memory bounded regardless of catalog size.
+
+   ```diff
+   -foreach ($productVariantRepository->getCodesOfAllVariants() as $code) {
+   -    // ...
+   -}
+   +foreach ($productVariantRepository->iterateCodesOfAllVariants(100) as $variantCodes) {
+   +    foreach ($variantCodes as $code) {
+   +        // ...
+   +    }
+   +}
+   ```
+
+   > **Note:** the deprecated method's return value never matched its `@return array|string[]` annotation. Because it
+   > selects a single field and hydrates with `getArrayResult()`, it actually returns a list of `['code' => string]`
+   > arrays. `iterateCodesOfAllVariants()` yields batches of plain strings, as the annotation always intended.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -80,6 +80,15 @@
                'Sylius\Bundle\CoreBundle\Command\Account\ResendVerificationEmail': your_async_transport
    ```
 
+2. The payload carried by `Sylius\Bundle\CoreBundle\CatalogPromotion\Command\ApplyCatalogPromotionsOnVariants` when
+   dispatched for the whole catalog is now a list of strings, as its `@param array<string> $variantsCodes` annotation
+   has always declared.
+
+   Previously that code path fed it the raw output of `getCodesOfAllVariants()`, so it actually carried
+   `[['code' => 'VARIANT_1'], ...]`. Messages already queued when you deploy are unaffected — the handler resolves
+   both shapes — but a custom handler, middleware, or log parser reading `$variantsCodes` directly should expect
+   plain strings.
+
 ## Shop
 
 1. When an unverified account tries to log in with valid credentials on a channel that requires account verification, the login page now shows a one-click "resend verification email" action instead of a separate request form.
@@ -665,18 +674,34 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    now consumes the catalog batch by batch, so recalculating catalog promotions uses a bounded amount of memory
    regardless of how many variants exist.
 
-2. `Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\AllProductVariantsCatalogPromotionsProcessor` takes a
-   third constructor argument, the batch size to read the catalog with. The `sylius.processor.catalog_promotion.all_product_variant`
-   service is already configured to pass `%sylius_core.catalog_promotions.batch_size%`, so no change is needed
-   unless you instantiate this processor yourself.
+2. Not passing a batch size as the third constructor argument of
+   `Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\AllProductVariantsCatalogPromotionsProcessor` is deprecated
+   since Sylius 2.3 and will be prohibited in Sylius 3.0.
 
    ```diff
     public function __construct(
         private ProductVariantRepositoryInterface $productVariantRepository,
         private ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface $commandDispatcher,
-   +    private int $batchSize,
+   +    ?int $batchSize = null,
     ) {
    ```
+
+   When omitted, it falls back to `AllProductVariantsCatalogPromotionsProcessor::DEFAULT_BATCH_SIZE` (100), which
+   preserves the previous behaviour. The `sylius.processor.catalog_promotion.all_product_variant` service is already
+   configured to pass `%sylius_core.catalog_promotions.batch_size%`, so no change is needed unless you instantiate
+   or re-register this processor yourself.
+
+3. `%sylius_core.catalog_promotions.batch_size%` now governs two things: how many rows are read from the database
+   per query, and how many codes are carried by a single `ApplyCatalogPromotionsOnVariants` message. Previously it
+   only controlled the latter. If you had tuned it purely for message size, review the value — it now also sets the
+   size of each `SELECT`.
+
+4. The catalog is no longer read in a single `SELECT`. Recalculating catalog promotions for all variants now issues
+   one query per batch, interleaved with the dispatch of each batch. On a database or caller where each statement
+   gets its own snapshot (for example PostgreSQL under `READ COMMITTED`, or a caller running outside a wrapping
+   transaction), a variant committed by a concurrent request *while* the iteration is in progress may be missed by
+   that run. It is picked up by the next recalculation. This is a deliberate trade for bounded memory; if you rely
+   on a single consistent snapshot of the catalog, wrap the call in an explicit transaction.
 
 ## New Features
 
@@ -803,7 +828,7 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    and keeps memory bounded regardless of catalog size.
 
    ```diff
-   -foreach ($productVariantRepository->getCodesOfAllVariants() as $code) {
+   -foreach ($productVariantRepository->getCodesOfAllVariants() as ['code' => $code]) {
    -    // ...
    -}
    +foreach ($productVariantRepository->iterateCodesOfAllVariants(100) as $variantCodes) {
@@ -813,6 +838,7 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    +}
    ```
 
-   > **Note:** the deprecated method's return value never matched its `@return array|string[]` annotation. Because it
-   > selects a single field and hydrates with `getArrayResult()`, it actually returns a list of `['code' => string]`
-   > arrays. `iterateCodesOfAllVariants()` yields batches of plain strings, as the annotation always intended.
+   > **Note:** the deprecated method's return value never matched its former `@return array|string[]` annotation.
+   > Because it selects a single field and hydrates with `getArrayResult()`, it returns a list of `['code' => string]`
+   > arrays, which is why the loop above destructures. Its annotation has been corrected to
+   > `list<array{code: string}>`. `iterateCodesOfAllVariants()` yields batches of plain strings instead.

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
 
 use Sylius\Bundle\CoreBundle\CatalogPromotion\CommandDispatcher\ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
+use Webmozart\Assert\Assert;
 
 final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVariantsCatalogPromotionsProcessorInterface
 {
@@ -36,6 +37,8 @@ final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVa
                 self::class,
             );
         }
+
+        Assert::nullOrPositiveInteger($batchSize, 'Expected a batch size greater than 0. Got: %s');
 
         $this->batchSize = $batchSize ?? self::DEFAULT_BATCH_SIZE;
     }

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
@@ -18,7 +18,8 @@ use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 
 final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVariantsCatalogPromotionsProcessorInterface
 {
-    public const DEFAULT_BATCH_SIZE = 100;
+    /** Mirrors the default of sylius_core.catalog_promotions.batch_size. */
+    private const DEFAULT_BATCH_SIZE = 100;
 
     private int $batchSize;
 
@@ -41,8 +42,6 @@ final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVa
 
     public function process(): void
     {
-        // Each batch is dispatched as soon as it is read, so peak memory stays bounded by the
-        // batch size instead of growing with the catalog.
         foreach ($this->productVariantRepository->iterateCodesOfAllVariants($this->batchSize) as $variantsCodes) {
             $this->commandDispatcher->updateVariants($variantsCodes);
         }

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
@@ -21,13 +21,16 @@ final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVa
     public function __construct(
         private ProductVariantRepositoryInterface $productVariantRepository,
         private ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface $commandDispatcher,
+        private int $batchSize,
     ) {
     }
 
     public function process(): void
     {
-        $variantsCodes = $this->productVariantRepository->getCodesOfAllVariants();
-
-        $this->commandDispatcher->updateVariants($variantsCodes);
+        // The catalog is read batch by batch and each batch is dispatched as soon as it is read,
+        // so peak memory stays bounded by the batch size instead of growing with the catalog.
+        foreach ($this->productVariantRepository->iterateCodesOfAllVariants($this->batchSize) as $variantsCodes) {
+            $this->commandDispatcher->updateVariants($variantsCodes);
+        }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
@@ -31,7 +31,7 @@ final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVa
             trigger_deprecation(
                 'sylius/core-bundle',
                 '2.3',
-                'Not passing a batch size as the third constructor argument of "%s" is deprecated since Sylius 2.3 and will be prohibited in Sylius 3.0.',
+                'Not passing a batch size as the third constructor argument of "%s" is deprecated and will be prohibited in Sylius 3.0.',
                 self::class,
             );
         }

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessor.php
@@ -18,17 +18,31 @@ use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 
 final class AllProductVariantsCatalogPromotionsProcessor implements AllProductVariantsCatalogPromotionsProcessorInterface
 {
+    public const DEFAULT_BATCH_SIZE = 100;
+
+    private int $batchSize;
+
     public function __construct(
         private ProductVariantRepositoryInterface $productVariantRepository,
         private ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface $commandDispatcher,
-        private int $batchSize,
+        ?int $batchSize = null,
     ) {
+        if (null === $batchSize) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Not passing a batch size as the third constructor argument of "%s" is deprecated since Sylius 2.3 and will be prohibited in Sylius 3.0.',
+                self::class,
+            );
+        }
+
+        $this->batchSize = $batchSize ?? self::DEFAULT_BATCH_SIZE;
     }
 
     public function process(): void
     {
-        // The catalog is read batch by batch and each batch is dispatched as soon as it is read,
-        // so peak memory stays bounded by the batch size instead of growing with the catalog.
+        // Each batch is dispatched as soon as it is read, so peak memory stays bounded by the
+        // batch size instead of growing with the catalog.
         foreach ($this->productVariantRepository->iterateCodesOfAllVariants($this->batchSize) as $variantsCodes) {
             $this->commandDispatcher->updateVariants($variantsCodes);
         }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/catalog_promotion/processors.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/catalog_promotion/processors.php
@@ -34,6 +34,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('sylius.repository.product_variant'),
             service('sylius.command_dispatcher.catalog_promotion.batched_apply_on_variants'),
+            '%sylius_core.catalog_promotions.batch_size%',
         ])
     ;
     $services->alias(AllProductVariantsCatalogPromotionsProcessorInterface::class, 'sylius.processor.catalog_promotion.all_product_variant');

--- a/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\CommandDispatcher\ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface;
@@ -134,5 +135,29 @@ final class AllProductVariantsCatalogPromotionsProcessorTest extends TestCase
         $this->commandDispatcher->expects($this->never())->method('updateVariants');
 
         $processor->process();
+    }
+
+    #[DataProvider('nonPositiveBatchSizes')]
+    public function testRejectsANonPositiveBatchSizeAtConstruction(int $batchSize): void
+    {
+        // Rejected before either collaborator is touched.
+        $this->productVariantRepository->expects($this->never())->method('iterateCodesOfAllVariants');
+        $this->commandDispatcher->expects($this->never())->method('updateVariants');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        new AllProductVariantsCatalogPromotionsProcessor(
+            $this->productVariantRepository,
+            $this->commandDispatcher,
+            $batchSize,
+        );
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function nonPositiveBatchSizes(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+        yield 'minimum integer' => [\PHP_INT_MIN];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\CommandDispatcher\ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface;
@@ -113,5 +114,25 @@ final class AllProductVariantsCatalogPromotionsProcessorTest extends TestCase
         $this->processor->process();
 
         $this->assertSame([1, 2], $dispatchedWhileReading);
+    }
+
+    #[IgnoreDeprecations]
+    public function testFallsBackToTheDefaultBatchSizeWhenNoneIsGiven(): void
+    {
+        $processor = new AllProductVariantsCatalogPromotionsProcessor(
+            $this->productVariantRepository,
+            $this->commandDispatcher,
+        );
+
+        $this->productVariantRepository
+            ->expects($this->once())
+            ->method('iterateCodesOfAllVariants')
+            ->with(AllProductVariantsCatalogPromotionsProcessor::DEFAULT_BATCH_SIZE)
+            ->willReturn([])
+        ;
+
+        $this->commandDispatcher->expects($this->never())->method('updateVariants');
+
+        $processor->process();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
@@ -21,6 +21,8 @@ use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 
 final class AllProductVariantsCatalogPromotionsProcessorTest extends TestCase
 {
+    private const BATCH_SIZE = 2;
+
     private MockObject&ProductVariantRepositoryInterface $productVariantRepository;
 
     private ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface&MockObject $commandDispatcher;
@@ -34,22 +36,82 @@ final class AllProductVariantsCatalogPromotionsProcessorTest extends TestCase
         $this->processor = new AllProductVariantsCatalogPromotionsProcessor(
             $this->productVariantRepository,
             $this->commandDispatcher,
+            self::BATCH_SIZE,
         );
     }
 
-    public function testClearsAndProcessesCatalogPromotions(): void
+    public function testDispatchesEveryBatchOfVariantCodes(): void
     {
         $this->productVariantRepository
-            ->method('getCodesOfAllVariants')
-            ->willReturn(['FIRST_VARIANT_CODE', 'SECOND_VARIANT_CODE'])
+            ->expects($this->once())
+            ->method('iterateCodesOfAllVariants')
+            ->with(self::BATCH_SIZE)
+            ->willReturn([
+                ['FIRST_VARIANT_CODE', 'SECOND_VARIANT_CODE'],
+                ['THIRD_VARIANT_CODE'],
+            ])
         ;
 
+        $dispatchedBatches = [];
         $this->commandDispatcher
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('updateVariants')
-            ->with(['FIRST_VARIANT_CODE', 'SECOND_VARIANT_CODE'])
+            ->willReturnCallback(function (array $variantsCodes) use (&$dispatchedBatches): void {
+                $dispatchedBatches[] = $variantsCodes;
+            })
         ;
 
         $this->processor->process();
+
+        $this->assertSame(
+            [['FIRST_VARIANT_CODE', 'SECOND_VARIANT_CODE'], ['THIRD_VARIANT_CODE']],
+            $dispatchedBatches,
+        );
+    }
+
+    public function testDispatchesNothingWhenThereAreNoVariants(): void
+    {
+        $this->productVariantRepository
+            ->expects($this->once())
+            ->method('iterateCodesOfAllVariants')
+            ->with(self::BATCH_SIZE)
+            ->willReturn([])
+        ;
+
+        $this->commandDispatcher->expects($this->never())->method('updateVariants');
+
+        $this->processor->process();
+    }
+
+    public function testConsumesBatchesLazilyWithoutMaterialisingTheWholeCatalog(): void
+    {
+        $readBatches = 0;
+
+        $this->productVariantRepository
+            ->expects($this->once())
+            ->method('iterateCodesOfAllVariants')
+            ->willReturnCallback(function () use (&$readBatches): \Generator {
+                foreach ([['FIRST_VARIANT_CODE'], ['SECOND_VARIANT_CODE']] as $batch) {
+                    ++$readBatches;
+
+                    yield $batch;
+                }
+            })
+        ;
+
+        $dispatchedWhileReading = [];
+        $this->commandDispatcher
+            ->expects($this->exactly(2))
+            ->method('updateVariants')
+            ->willReturnCallback(function () use (&$readBatches, &$dispatchedWhileReading): void {
+                // Each dispatch must happen while only the batches read so far have been pulled
+                // from the repository, never after the whole catalog has been loaded.
+                $dispatchedWhileReading[] = $readBatches;
+            })
+        ;
+
+        $this->processor->process();
+
+        $this->assertSame([1, 2], $dispatchedWhileReading);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
 
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\CommandDispatcher\ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface;
@@ -116,9 +115,12 @@ final class AllProductVariantsCatalogPromotionsProcessorTest extends TestCase
         $this->assertSame([1, 2], $dispatchedWhileReading);
     }
 
-    #[IgnoreDeprecations]
     public function testFallsBackToTheDefaultBatchSizeWhenNoneIsGiven(): void
     {
+        // Pinned to a literal because the deprecated no-argument path only preserves the previous
+        // behaviour while this constant equals the default of sylius_core.catalog_promotions.batch_size.
+        $this->assertSame(100, AllProductVariantsCatalogPromotionsProcessor::DEFAULT_BATCH_SIZE);
+
         $processor = new AllProductVariantsCatalogPromotionsProcessor(
             $this->productVariantRepository,
             $this->commandDispatcher,

--- a/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/CatalogPromotion/Processor/AllProductVariantsCatalogPromotionsProcessorTest.php
@@ -117,19 +117,17 @@ final class AllProductVariantsCatalogPromotionsProcessorTest extends TestCase
 
     public function testFallsBackToTheDefaultBatchSizeWhenNoneIsGiven(): void
     {
-        // Pinned to a literal because the deprecated no-argument path only preserves the previous
-        // behaviour while this constant equals the default of sylius_core.catalog_promotions.batch_size.
-        $this->assertSame(100, AllProductVariantsCatalogPromotionsProcessor::DEFAULT_BATCH_SIZE);
-
         $processor = new AllProductVariantsCatalogPromotionsProcessor(
             $this->productVariantRepository,
             $this->commandDispatcher,
         );
 
+        // The literal, not the class constant: the deprecated no-argument path only behaves like a
+        // default installation while the fallback matches sylius_core.catalog_promotions.batch_size.
         $this->productVariantRepository
             ->expects($this->once())
             ->method('iterateCodesOfAllVariants')
-            ->with(AllProductVariantsCatalogPromotionsProcessor::DEFAULT_BATCH_SIZE)
+            ->with(100)
             ->willReturn([])
         ;
 

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
@@ -197,34 +197,44 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
 
     public function iterateCodesOfAllVariants(int $batchSize): iterable
     {
-        // Validated outside the generator, so that an invalid batch size is rejected when the
-        // method is called and not only once the caller starts iterating.
-        Assert::positiveInteger($batchSize);
+        // Both preconditions are checked outside the generator, so that they are reported when the
+        // method is called rather than when the caller first iterates.
+        Assert::positiveInteger($batchSize, 'Expected a batch size greater than 0. Got: %s');
 
-        return $this->iterateCodesOfAllVariantsInBatches($batchSize);
+        $metadata = $this->getClassMetadata();
+        $identifierField = $metadata->getSingleIdentifierFieldName();
+        $identifierType = $metadata->getTypeOfField($identifierField);
+
+        // Null means the identifier is not a plain field (an association identifier, for instance).
+        // Without a type, Doctrine would infer STRING for an object identifier and the keyset
+        // comparison would silently match nothing, so refuse rather than under-report the catalog.
+        Assert::notNull($identifierType, sprintf(
+            'Cannot iterate over "%s": its identifier "%s" is not a field with a mapped type.',
+            $metadata->getName(),
+            $identifierField,
+        ));
+
+        return $this->iterateCodesOfAllVariantsInBatches($batchSize, $identifierField, $identifierType);
     }
 
     /** @return \Generator<int, list<string>, mixed, void> */
-    private function iterateCodesOfAllVariantsInBatches(int $batchSize): \Generator
-    {
-        $identifierType = $this->getClassMetadata()->getTypeOfField(
-            $this->getClassMetadata()->getSingleIdentifierFieldName(),
-        );
+    private function iterateCodesOfAllVariantsInBatches(
+        int $batchSize,
+        string $identifierField,
+        string $identifierType,
+    ): \Generator {
         $lastId = null;
 
         while (true) {
             $queryBuilder = $this->createQueryBuilder('o')
-                ->select('o.id', 'o.code')
-                ->orderBy('o.id', 'ASC')
+                ->select(sprintf('o.%s AS id', $identifierField), 'o.code')
+                ->orderBy(sprintf('o.%s', $identifierField), 'ASC')
                 ->setMaxResults($batchSize)
             ;
 
             if (null !== $lastId) {
                 $queryBuilder
-                    ->andWhere('o.id > :lastId')
-                    // The type must be passed explicitly: without it Doctrine infers STRING for any
-                    // object-valued identifier (UUID, ULID), the comparison silently matches nothing
-                    // and iteration stops after the first batch.
+                    ->andWhere(sprintf('o.%s > :lastId', $identifierField))
                     ->setParameter('lastId', $lastId, $identifierType)
                 ;
             }

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
@@ -174,12 +174,64 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
         ;
     }
 
+    /**
+     * @deprecated since Sylius 2.3 and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead,
+     *             which reads the catalog in batches instead of materialising it entirely in memory.
+     */
     public function getCodesOfAllVariants(): array
     {
+        trigger_deprecation(
+            'sylius/product-bundle',
+            '2.3',
+            'The "%s()" method is deprecated since Sylius 2.3 and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead.',
+            __METHOD__,
+        );
+
         return $this->createQueryBuilder('o')
             ->select('o.code')
             ->getQuery()
             ->getArrayResult()
         ;
+    }
+
+    public function iterateCodesOfAllVariants(int $batchSize): iterable
+    {
+        if ($batchSize < 1) {
+            throw new \InvalidArgumentException(sprintf('Expected a batch size greater than 0, but got %d.', $batchSize));
+        }
+
+        $lastId = null;
+
+        while (true) {
+            $queryBuilder = $this->createQueryBuilder('o')
+                ->select('o.id', 'o.code')
+                ->orderBy('o.id', 'ASC')
+                ->setMaxResults($batchSize)
+            ;
+
+            // Keyset pagination: unlike OFFSET, the cost of each batch does not grow with how far
+            // into the catalog we already are.
+            if (null !== $lastId) {
+                $queryBuilder
+                    ->andWhere('o.id > :lastId')
+                    ->setParameter('lastId', $lastId)
+                ;
+            }
+
+            /** @var list<array{id: mixed, code: string}> $result */
+            $result = $queryBuilder->getQuery()->getArrayResult();
+
+            if ([] === $result) {
+                return;
+            }
+
+            $lastId = $result[array_key_last($result)]['id'];
+
+            yield array_column($result, 'code');
+
+            if (count($result) < $batchSize) {
+                return;
+            }
+        }
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
@@ -196,10 +196,18 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
 
     public function iterateCodesOfAllVariants(int $batchSize): iterable
     {
+        // Validated here rather than in the generator below, so that an invalid batch size is
+        // rejected when the method is called and not only once iteration starts.
         if ($batchSize < 1) {
             throw new \InvalidArgumentException(sprintf('Expected a batch size greater than 0, but got %d.', $batchSize));
         }
 
+        return $this->iterateCodesOfAllVariantsInBatches($batchSize);
+    }
+
+    /** @return \Generator<list<string>> */
+    private function iterateCodesOfAllVariantsInBatches(int $batchSize): \Generator
+    {
         $lastId = null;
 
         while (true) {

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
@@ -184,7 +184,7 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
         trigger_deprecation(
             'sylius/product-bundle',
             '2.3',
-            'The "%s()" method is deprecated since Sylius 2.3 and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead.',
+            'The "%s()" method is deprecated and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead.',
             __METHOD__,
         );
 

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
 use Sylius\Component\Product\Repository\ProductVariantRepositoryInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @template T of ProductVariantInterface
@@ -196,18 +197,19 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
 
     public function iterateCodesOfAllVariants(int $batchSize): iterable
     {
-        // Validated here rather than in the generator below, so that an invalid batch size is
-        // rejected when the method is called and not only once iteration starts.
-        if ($batchSize < 1) {
-            throw new \InvalidArgumentException(sprintf('Expected a batch size greater than 0, but got %d.', $batchSize));
-        }
+        // Validated outside the generator, so that an invalid batch size is rejected when the
+        // method is called and not only once the caller starts iterating.
+        Assert::positiveInteger($batchSize);
 
         return $this->iterateCodesOfAllVariantsInBatches($batchSize);
     }
 
-    /** @return \Generator<list<string>> */
+    /** @return \Generator<int, list<string>, mixed, void> */
     private function iterateCodesOfAllVariantsInBatches(int $batchSize): \Generator
     {
+        $identifierType = $this->getClassMetadata()->getTypeOfField(
+            $this->getClassMetadata()->getSingleIdentifierFieldName(),
+        );
         $lastId = null;
 
         while (true) {
@@ -217,12 +219,13 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
                 ->setMaxResults($batchSize)
             ;
 
-            // Keyset pagination: unlike OFFSET, the cost of each batch does not grow with how far
-            // into the catalog we already are.
             if (null !== $lastId) {
                 $queryBuilder
                     ->andWhere('o.id > :lastId')
-                    ->setParameter('lastId', $lastId)
+                    // The type must be passed explicitly: without it Doctrine infers STRING for any
+                    // object-valued identifier (UUID, ULID), the comparison silently matches nothing
+                    // and iteration stops after the first batch.
+                    ->setParameter('lastId', $lastId, $identifierType)
                 ;
             }
 

--- a/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
@@ -82,7 +82,8 @@ interface ProductVariantRepositoryInterface extends RepositoryInterface
      * @return iterable<list<string>>
      *
      * @throws \InvalidArgumentException when $batchSize is lower than 1, or when the entity's identifier
-     *                                   is not a single field with a mapped type
+     *                                   has no mapped type
+     * @throws \Doctrine\Persistence\Mapping\MappingException when the entity's identifier is not a single field
      */
     public function iterateCodesOfAllVariants(int $batchSize): iterable;
 }

--- a/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
@@ -83,7 +83,7 @@ interface ProductVariantRepositoryInterface extends RepositoryInterface
      *
      * @throws \InvalidArgumentException when $batchSize is lower than 1, or when the entity's identifier
      *                                   has no mapped type
-     * @throws \Doctrine\Persistence\Mapping\MappingException when the entity's identifier is not a single field
+     * @throws \Doctrine\Persistence\Mapping\MappingException when the entity has no identifier, or more than one
      */
     public function iterateCodesOfAllVariants(int $batchSize): iterable;
 }

--- a/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
@@ -68,16 +68,16 @@ interface ProductVariantRepositoryInterface extends RepositoryInterface
     public function findByPhrase(string $phrase, string $locale, ?int $limit = null): array;
 
     /**
-     * @return array|string[]
+     * @return list<array{code: string}>
      *
-     * @deprecated since Sylius 2.3 and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead,
-     *             which reads the catalog in batches instead of materialising it entirely in memory.
+     * @deprecated since Sylius 2.3 and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead.
      */
     public function getCodesOfAllVariants(): array;
 
     /**
-     * Reads the codes of all product variants in batches, so that memory usage stays bounded
-     * by $batchSize regardless of how many variants the catalog holds.
+     * Yields the codes of all product variants in batches of at most $batchSize elements.
+     *
+     * The returned iterable is single-use and must not be traversed twice.
      *
      * @return iterable<list<string>>
      *

--- a/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
@@ -81,7 +81,8 @@ interface ProductVariantRepositoryInterface extends RepositoryInterface
      *
      * @return iterable<list<string>>
      *
-     * @throws \InvalidArgumentException when $batchSize is lower than 1
+     * @throws \InvalidArgumentException when $batchSize is lower than 1, or when the entity's identifier
+     *                                   is not a single field with a mapped type
      */
     public function iterateCodesOfAllVariants(int $batchSize): iterable;
 }

--- a/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
@@ -80,6 +80,8 @@ interface ProductVariantRepositoryInterface extends RepositoryInterface
      * by $batchSize regardless of how many variants the catalog holds.
      *
      * @return iterable<list<string>>
+     *
+     * @throws \InvalidArgumentException when $batchSize is lower than 1
      */
     public function iterateCodesOfAllVariants(int $batchSize): iterable;
 }

--- a/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductVariantRepositoryInterface.php
@@ -69,6 +69,17 @@ interface ProductVariantRepositoryInterface extends RepositoryInterface
 
     /**
      * @return array|string[]
+     *
+     * @deprecated since Sylius 2.3 and will be removed in Sylius 3.0. Use iterateCodesOfAllVariants() instead,
+     *             which reads the catalog in batches instead of materialising it entirely in memory.
      */
     public function getCodesOfAllVariants(): array;
+
+    /**
+     * Reads the codes of all product variants in batches, so that memory usage stays bounded
+     * by $batchSize regardless of how many variants the catalog holds.
+     *
+     * @return iterable<list<string>>
+     */
+    public function iterateCodesOfAllVariants(int $batchSize): iterable;
 }

--- a/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
+++ b/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
@@ -16,7 +16,7 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 5
-        createdAt: <(new \DateTime('2026-03-05 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-03 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-19 10:00:00'))>
     iteration_variant2:
         code: ITERATION_VARIANT_ALPHA
@@ -25,7 +25,7 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 2
-        createdAt: <(new \DateTime('2026-03-02 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-06 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-13 10:00:00'))>
     iteration_variant3:
         code: ITERATION_VARIANT_ZETA
@@ -34,7 +34,7 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 7
-        createdAt: <(new \DateTime('2026-03-07 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-04 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-11 10:00:00'))>
     iteration_variant4:
         code: ITERATION_VARIANT_BETA
@@ -43,7 +43,7 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 1
-        createdAt: <(new \DateTime('2026-03-01 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-02 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-17 10:00:00'))>
     iteration_variant5:
         code: ITERATION_VARIANT_OMEGA
@@ -52,7 +52,7 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 4
-        createdAt: <(new \DateTime('2026-03-04 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-07 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-12 10:00:00'))>
     iteration_variant6:
         code: ITERATION_VARIANT_DELTA
@@ -61,7 +61,7 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 6
-        createdAt: <(new \DateTime('2026-03-06 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-01 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-15 10:00:00'))>
     iteration_variant7:
         code: ITERATION_VARIANT_EPSILON
@@ -70,5 +70,5 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 3
-        createdAt: <(new \DateTime('2026-03-03 10:00:00'))>
+        createdAt: <(new \DateTime('2026-03-05 10:00:00'))>
         updatedAt: <(new \DateTime('2026-06-14 10:00:00'))>

--- a/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
+++ b/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
@@ -6,11 +6,55 @@ Sylius\Component\Core\Model\Product:
         slug: iteration-product
         name: Iteration product
 
+# Codes are deliberately NOT in alphabetical order, so that ordering by any column other than the
+# identifier the query pages on produces a different sequence and is caught by the assertions.
 Sylius\Component\Core\Model\ProductVariant:
-    iteration_variant{1..7}:
-        code: ITERATION_VARIANT_<current()>
+    iteration_variant1:
+        code: ITERATION_VARIANT_GAMMA
         version: 1
         product: "@iteration_product"
         fallbackLocale: en_US
         currentLocale: en_US
-        position: <current()>
+        position: 1
+    iteration_variant2:
+        code: ITERATION_VARIANT_ALPHA
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: 2
+    iteration_variant3:
+        code: ITERATION_VARIANT_ZETA
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: 3
+    iteration_variant4:
+        code: ITERATION_VARIANT_BETA
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: 4
+    iteration_variant5:
+        code: ITERATION_VARIANT_OMEGA
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: 5
+    iteration_variant6:
+        code: ITERATION_VARIANT_DELTA
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: 6
+    iteration_variant7:
+        code: ITERATION_VARIANT_EPSILON
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: 7

--- a/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
+++ b/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
@@ -6,8 +6,8 @@ Sylius\Component\Core\Model\Product:
         slug: iteration-product
         name: Iteration product
 
-# Neither the codes nor the positions follow insertion order, so that paging on the identifier
-# while ordering by code or by position yields a different sequence and fails the assertions.
+# Codes, positions and timestamps are each permuted independently of insertion order, so that paging
+# on the identifier while ordering by any of them yields a different sequence and fails the tests.
 Sylius\Component\Core\Model\ProductVariant:
     iteration_variant1:
         code: ITERATION_VARIANT_GAMMA
@@ -16,6 +16,8 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 5
+        createdAt: <(new \DateTime('2026-03-05 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-19 10:00:00'))>
     iteration_variant2:
         code: ITERATION_VARIANT_ALPHA
         version: 1
@@ -23,6 +25,8 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 2
+        createdAt: <(new \DateTime('2026-03-02 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-13 10:00:00'))>
     iteration_variant3:
         code: ITERATION_VARIANT_ZETA
         version: 1
@@ -30,6 +34,8 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 7
+        createdAt: <(new \DateTime('2026-03-07 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-11 10:00:00'))>
     iteration_variant4:
         code: ITERATION_VARIANT_BETA
         version: 1
@@ -37,6 +43,8 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 1
+        createdAt: <(new \DateTime('2026-03-01 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-17 10:00:00'))>
     iteration_variant5:
         code: ITERATION_VARIANT_OMEGA
         version: 1
@@ -44,6 +52,8 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 4
+        createdAt: <(new \DateTime('2026-03-04 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-12 10:00:00'))>
     iteration_variant6:
         code: ITERATION_VARIANT_DELTA
         version: 1
@@ -51,6 +61,8 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 6
+        createdAt: <(new \DateTime('2026-03-06 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-15 10:00:00'))>
     iteration_variant7:
         code: ITERATION_VARIANT_EPSILON
         version: 1
@@ -58,3 +70,5 @@ Sylius\Component\Core\Model\ProductVariant:
         fallbackLocale: en_US
         currentLocale: en_US
         position: 3
+        createdAt: <(new \DateTime('2026-03-03 10:00:00'))>
+        updatedAt: <(new \DateTime('2026-06-14 10:00:00'))>

--- a/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
+++ b/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
@@ -6,8 +6,8 @@ Sylius\Component\Core\Model\Product:
         slug: iteration-product
         name: Iteration product
 
-# Codes are deliberately NOT in alphabetical order, so that ordering by any column other than the
-# identifier the query pages on produces a different sequence and is caught by the assertions.
+# Neither the codes nor the positions follow insertion order, so that paging on the identifier
+# while ordering by code or by position yields a different sequence and fails the assertions.
 Sylius\Component\Core\Model\ProductVariant:
     iteration_variant1:
         code: ITERATION_VARIANT_GAMMA
@@ -15,7 +15,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@iteration_product"
         fallbackLocale: en_US
         currentLocale: en_US
-        position: 1
+        position: 5
     iteration_variant2:
         code: ITERATION_VARIANT_ALPHA
         version: 1
@@ -29,21 +29,21 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@iteration_product"
         fallbackLocale: en_US
         currentLocale: en_US
-        position: 3
+        position: 7
     iteration_variant4:
         code: ITERATION_VARIANT_BETA
         version: 1
         product: "@iteration_product"
         fallbackLocale: en_US
         currentLocale: en_US
-        position: 4
+        position: 1
     iteration_variant5:
         code: ITERATION_VARIANT_OMEGA
         version: 1
         product: "@iteration_product"
         fallbackLocale: en_US
         currentLocale: en_US
-        position: 5
+        position: 4
     iteration_variant6:
         code: ITERATION_VARIANT_DELTA
         version: 1
@@ -57,4 +57,4 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@iteration_product"
         fallbackLocale: en_US
         currentLocale: en_US
-        position: 7
+        position: 3

--- a/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
+++ b/tests/DataFixtures/ORM/resources/product_variants_for_iteration.yml
@@ -1,0 +1,16 @@
+Sylius\Component\Core\Model\Product:
+    iteration_product:
+        fallbackLocale: en_US
+        currentLocale: en_US
+        code: ITERATION_PRODUCT
+        slug: iteration-product
+        name: Iteration product
+
+Sylius\Component\Core\Model\ProductVariant:
+    iteration_variant{1..7}:
+        code: ITERATION_VARIANT_<current()>
+        version: 1
+        product: "@iteration_product"
+        fallbackLocale: en_US
+        currentLocale: en_US
+        position: <current()>

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -65,9 +65,9 @@ final class ProductVariantRepositoryTest extends KernelTestCase
 
     /**
      * The test application enables `sylius_core.order_by_identifier`, whose walker appends an ordering
-     * by identifier to every non-grouped, non-aggregate query. That would supply the very clause these
-     * tests exist to pin, so it is removed here to reproduce a default 2.3 application, where the
-     * setting defaults to false.
+     * by identifier to queries it deems eligible, which includes the ones below. That would supply the
+     * very clause these tests exist to pin, so it is removed here to reproduce a default 2.3
+     * application, where the setting defaults to false.
      */
     private function disableOrderByIdentifierWalker(): void
     {

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -30,15 +30,19 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 final class ProductVariantRepositoryTest extends KernelTestCase
 {
-    /** Declared in the order the fixture inserts them, which is the order the repository must yield. */
+    /**
+     * Declared in the order the fixture inserts them, which is the order the repository must yield.
+     * The codes are not alphabetical on purpose: paging on the identifier while ordering by any
+     * other column would produce a different sequence, which the assertions below would catch.
+     */
     private const VARIANT_CODES = [
-        'ITERATION_VARIANT_1',
-        'ITERATION_VARIANT_2',
-        'ITERATION_VARIANT_3',
-        'ITERATION_VARIANT_4',
-        'ITERATION_VARIANT_5',
-        'ITERATION_VARIANT_6',
-        'ITERATION_VARIANT_7',
+        'ITERATION_VARIANT_GAMMA',
+        'ITERATION_VARIANT_ALPHA',
+        'ITERATION_VARIANT_ZETA',
+        'ITERATION_VARIANT_BETA',
+        'ITERATION_VARIANT_OMEGA',
+        'ITERATION_VARIANT_DELTA',
+        'ITERATION_VARIANT_EPSILON',
     ];
 
     /** @var ProductVariantRepositoryInterface<ProductVariantInterface> */
@@ -58,9 +62,8 @@ final class ProductVariantRepositoryTest extends KernelTestCase
     {
         $this->loadFixtures();
 
-        // assertSame, not assertEqualsCanonicalizing: the order is the property under test. Keyset
-        // pagination is only correct while the query orders by the identifier it pages on, and an
-        // order-insensitive assertion would pass even with the ORDER BY clause removed.
+        // assertSame, not assertEqualsCanonicalizing: keyset pagination is only correct while the
+        // query orders by the very column it pages on, so the order is part of what is under test.
         self::assertSame(self::VARIANT_CODES, $this->flatten($this->repository->iterateCodesOfAllVariants(2)));
     }
 
@@ -71,15 +74,8 @@ final class ProductVariantRepositoryTest extends KernelTestCase
 
         $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(2), false);
 
-        self::assertSame(
-            [
-                ['ITERATION_VARIANT_1', 'ITERATION_VARIANT_2'],
-                ['ITERATION_VARIANT_3', 'ITERATION_VARIANT_4'],
-                ['ITERATION_VARIANT_5', 'ITERATION_VARIANT_6'],
-                ['ITERATION_VARIANT_7'],
-            ],
-            $batches,
-        );
+        // 7 variants in batches of 2: three full batches then a single-element tail.
+        self::assertSame(array_chunk(self::VARIANT_CODES, 2), $batches);
     }
 
     #[Test]

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional\Repository;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -34,9 +36,6 @@ final class ProductVariantRepositoryTest extends KernelTestCase
      * Declared in the order the fixture inserts them, which is the order the repository must yield.
      * Neither the codes nor the fixture positions follow that order, so ordering the query by `code`
      * or by `position` rather than by the identifier it pages on fails these assertions.
-     *
-     * Dropping the ORDER BY altogether is not detected here: the test application enables
-     * `sylius_core.order_by_identifier`, whose SQL walker appends the same ordering to every query.
      */
     private const VARIANT_CODES = [
         'ITERATION_VARIANT_GAMMA',
@@ -55,9 +54,23 @@ final class ProductVariantRepositoryTest extends KernelTestCase
     {
         parent::setUp();
 
+        $this->disableOrderByIdentifierWalker();
+
         /** @var ProductVariantRepositoryInterface<ProductVariantInterface> $repository */
         $repository = self::getContainer()->get('sylius.repository.product_variant');
         $this->repository = $repository;
+    }
+
+    /**
+     * The test application enables `sylius_core.order_by_identifier`, whose walker appends an ordering
+     * by identifier to every query. That would supply the very clause these tests exist to pin, so it
+     * is removed here to reproduce a default 2.3 application, where the setting defaults to false.
+     */
+    private function disableOrderByIdentifierWalker(): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager->getConfiguration()->setDefaultQueryHint(Query::HINT_CUSTOM_TREE_WALKERS, []);
     }
 
     #[Test]

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -32,8 +32,11 @@ final class ProductVariantRepositoryTest extends KernelTestCase
 {
     /**
      * Declared in the order the fixture inserts them, which is the order the repository must yield.
-     * The codes are not alphabetical on purpose: paging on the identifier while ordering by any
-     * other column would produce a different sequence, which the assertions below would catch.
+     * Neither the codes nor the fixture positions follow that order, so ordering the query by `code`
+     * or by `position` rather than by the identifier it pages on fails these assertions.
+     *
+     * Dropping the ORDER BY altogether is not detected here: the test application enables
+     * `sylius_core.order_by_identifier`, whose SQL walker appends the same ordering to every query.
      */
     private const VARIANT_CODES = [
         'ITERATION_VARIANT_GAMMA',
@@ -63,7 +66,7 @@ final class ProductVariantRepositoryTest extends KernelTestCase
         $this->loadFixtures();
 
         // assertSame, not assertEqualsCanonicalizing: keyset pagination is only correct while the
-        // query orders by the very column it pages on, so the order is part of what is under test.
+        // query orders by the very column it pages on, so the sequence is part of what is asserted.
         self::assertSame(self::VARIANT_CODES, $this->flatten($this->repository->iterateCodesOfAllVariants(2)));
     }
 

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -15,6 +15,7 @@ namespace Sylius\Tests\Functional\Repository;
 
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
@@ -23,13 +24,13 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 /**
  * Covers ProductVariantRepository::iterateCodesOfAllVariants() against a real database.
  *
- * The unit tests around this method can only assert on a mocked repository, so they cannot catch
- * a mismatch between what the interface declares and what Doctrine actually hydrates. That is
- * exactly how the deprecated getCodesOfAllVariants() came to return a list of ['code' => string]
- * arrays while its annotation promised a list of strings. These tests pin the real shape.
+ * Unit tests can only assert on a mocked repository, so they cannot catch a mismatch between what
+ * the interface declares and what Doctrine actually hydrates, nor the ordering that keyset
+ * pagination depends on. Both are asserted here.
  */
 final class ProductVariantRepositoryTest extends KernelTestCase
 {
+    /** Declared in the order the fixture inserts them, which is the order the repository must yield. */
     private const VARIANT_CODES = [
         'ITERATION_VARIANT_1',
         'ITERATION_VARIANT_2',
@@ -53,28 +54,14 @@ final class ProductVariantRepositoryTest extends KernelTestCase
     }
 
     #[Test]
-    public function it_yields_every_variant_code_exactly_once(): void
+    public function it_yields_every_variant_code_once_in_identifier_order(): void
     {
         $this->loadFixtures();
 
-        $codes = $this->flatten($this->repository->iterateCodesOfAllVariants(2));
-
-        self::assertEqualsCanonicalizing(self::VARIANT_CODES, $codes);
-        self::assertSame(count(self::VARIANT_CODES), count($codes), 'No variant should be yielded twice.');
-    }
-
-    #[Test]
-    public function it_yields_codes_as_plain_strings(): void
-    {
-        $this->loadFixtures();
-
-        foreach ($this->repository->iterateCodesOfAllVariants(2) as $batch) {
-            self::assertNotEmpty($batch);
-
-            foreach ($batch as $code) {
-                self::assertIsString($code);
-            }
-        }
+        // assertSame, not assertEqualsCanonicalizing: the order is the property under test. Keyset
+        // pagination is only correct while the query orders by the identifier it pages on, and an
+        // order-insensitive assertion would pass even with the ORDER BY clause removed.
+        self::assertSame(self::VARIANT_CODES, $this->flatten($this->repository->iterateCodesOfAllVariants(2)));
     }
 
     #[Test]
@@ -84,9 +71,27 @@ final class ProductVariantRepositoryTest extends KernelTestCase
 
         $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(2), false);
 
-        // 7 variants in batches of 2 gives 4 batches, the last one holding a single variant.
-        self::assertCount(4, $batches);
-        self::assertSame([2, 2, 2, 1], array_map('count', $batches));
+        self::assertSame(
+            [
+                ['ITERATION_VARIANT_1', 'ITERATION_VARIANT_2'],
+                ['ITERATION_VARIANT_3', 'ITERATION_VARIANT_4'],
+                ['ITERATION_VARIANT_5', 'ITERATION_VARIANT_6'],
+                ['ITERATION_VARIANT_7'],
+            ],
+            $batches,
+        );
+    }
+
+    #[Test]
+    public function it_yields_a_single_full_batch_when_the_batch_size_divides_the_catalog_exactly(): void
+    {
+        $this->loadFixtures();
+
+        // Exercises the path where the last batch is full, so the loop can only end on the
+        // following empty result rather than on a short batch.
+        $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(count(self::VARIANT_CODES)), false);
+
+        self::assertSame([self::VARIANT_CODES], $batches);
     }
 
     #[Test]
@@ -94,10 +99,7 @@ final class ProductVariantRepositoryTest extends KernelTestCase
     {
         $this->loadFixtures();
 
-        $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(1000), false);
-
-        self::assertCount(1, $batches);
-        self::assertEqualsCanonicalizing(self::VARIANT_CODES, $batches[0]);
+        self::assertSame([self::VARIANT_CODES], iterator_to_array($this->repository->iterateCodesOfAllVariants(1000), false));
     }
 
     #[Test]
@@ -105,10 +107,10 @@ final class ProductVariantRepositoryTest extends KernelTestCase
     {
         $this->loadFixtures();
 
-        $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(1), false);
-
-        self::assertCount(count(self::VARIANT_CODES), $batches);
-        self::assertSame([1, 1, 1, 1, 1, 1, 1], array_map('count', $batches));
+        self::assertSame(
+            array_map(static fn (string $code): array => [$code], self::VARIANT_CODES),
+            iterator_to_array($this->repository->iterateCodesOfAllVariants(1), false),
+        );
     }
 
     #[Test]
@@ -120,13 +122,22 @@ final class ProductVariantRepositoryTest extends KernelTestCase
     }
 
     #[Test]
-    public function it_rejects_a_batch_size_below_one_without_waiting_for_iteration(): void
+    #[DataProvider('invalidBatchSizes')]
+    public function it_rejects_a_batch_size_below_one_without_waiting_for_iteration(int $batchSize): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        // Not wrapped in iterator_to_array on purpose: the batch size must be rejected when the
+        // Deliberately not wrapped in iterator_to_array: the batch size must be rejected when the
         // method is called, not only once the caller starts iterating.
-        $this->repository->iterateCodesOfAllVariants(0);
+        $this->repository->iterateCodesOfAllVariants($batchSize);
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function invalidBatchSizes(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+        yield 'minimum integer' => [\PHP_INT_MIN];
     }
 
     /**

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Repository;
+
+use Fidry\AliceDataFixtures\LoaderInterface;
+use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Covers ProductVariantRepository::iterateCodesOfAllVariants() against a real database.
+ *
+ * The unit tests around this method can only assert on a mocked repository, so they cannot catch
+ * a mismatch between what the interface declares and what Doctrine actually hydrates. That is
+ * exactly how the deprecated getCodesOfAllVariants() came to return a list of ['code' => string]
+ * arrays while its annotation promised a list of strings. These tests pin the real shape.
+ */
+final class ProductVariantRepositoryTest extends KernelTestCase
+{
+    private const VARIANT_CODES = [
+        'ITERATION_VARIANT_1',
+        'ITERATION_VARIANT_2',
+        'ITERATION_VARIANT_3',
+        'ITERATION_VARIANT_4',
+        'ITERATION_VARIANT_5',
+        'ITERATION_VARIANT_6',
+        'ITERATION_VARIANT_7',
+    ];
+
+    /** @var ProductVariantRepositoryInterface<ProductVariantInterface> */
+    private ProductVariantRepositoryInterface $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ProductVariantRepositoryInterface<ProductVariantInterface> $repository */
+        $repository = self::getContainer()->get('sylius.repository.product_variant');
+        $this->repository = $repository;
+    }
+
+    #[Test]
+    public function it_yields_every_variant_code_exactly_once(): void
+    {
+        $this->loadFixtures();
+
+        $codes = $this->flatten($this->repository->iterateCodesOfAllVariants(2));
+
+        self::assertEqualsCanonicalizing(self::VARIANT_CODES, $codes);
+        self::assertSame(count(self::VARIANT_CODES), count($codes), 'No variant should be yielded twice.');
+    }
+
+    #[Test]
+    public function it_yields_codes_as_plain_strings(): void
+    {
+        $this->loadFixtures();
+
+        foreach ($this->repository->iterateCodesOfAllVariants(2) as $batch) {
+            self::assertNotEmpty($batch);
+
+            foreach ($batch as $code) {
+                self::assertIsString($code);
+            }
+        }
+    }
+
+    #[Test]
+    public function it_splits_the_catalog_into_batches_of_at_most_the_requested_size(): void
+    {
+        $this->loadFixtures();
+
+        $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(2), false);
+
+        // 7 variants in batches of 2 gives 4 batches, the last one holding a single variant.
+        self::assertCount(4, $batches);
+        self::assertSame([2, 2, 2, 1], array_map('count', $batches));
+    }
+
+    #[Test]
+    public function it_yields_a_single_batch_when_the_batch_size_exceeds_the_catalog_size(): void
+    {
+        $this->loadFixtures();
+
+        $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(1000), false);
+
+        self::assertCount(1, $batches);
+        self::assertEqualsCanonicalizing(self::VARIANT_CODES, $batches[0]);
+    }
+
+    #[Test]
+    public function it_yields_one_variant_per_batch_when_the_batch_size_is_one(): void
+    {
+        $this->loadFixtures();
+
+        $batches = iterator_to_array($this->repository->iterateCodesOfAllVariants(1), false);
+
+        self::assertCount(count(self::VARIANT_CODES), $batches);
+        self::assertSame([1, 1, 1, 1, 1, 1, 1], array_map('count', $batches));
+    }
+
+    #[Test]
+    public function it_yields_nothing_when_there_are_no_variants(): void
+    {
+        $this->purgeDatabase();
+
+        self::assertSame([], iterator_to_array($this->repository->iterateCodesOfAllVariants(2), false));
+    }
+
+    #[Test]
+    public function it_rejects_a_batch_size_below_one_without_waiting_for_iteration(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        // Not wrapped in iterator_to_array on purpose: the batch size must be rejected when the
+        // method is called, not only once the caller starts iterating.
+        $this->repository->iterateCodesOfAllVariants(0);
+    }
+
+    /**
+     * @param iterable<list<string>> $batches
+     *
+     * @return list<string>
+     */
+    private function flatten(iterable $batches): array
+    {
+        $codes = [];
+
+        foreach ($batches as $batch) {
+            foreach ($batch as $code) {
+                $codes[] = $code;
+            }
+        }
+
+        return $codes;
+    }
+
+    private function loadFixtures(): void
+    {
+        $this->getFixtureLoader()->load(
+            [__DIR__ . '/../../DataFixtures/ORM/resources/product_variants_for_iteration.yml'],
+            [],
+            [],
+            PurgeMode::createDeleteMode(),
+        );
+    }
+
+    private function purgeDatabase(): void
+    {
+        $this->getFixtureLoader()->load([], [], [], PurgeMode::createDeleteMode());
+    }
+
+    private function getFixtureLoader(): LoaderInterface
+    {
+        /** @var LoaderInterface $fixtureLoader */
+        $fixtureLoader = self::getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+
+        return $fixtureLoader;
+    }
+}

--- a/tests/Functional/Repository/ProductVariantRepositoryTest.php
+++ b/tests/Functional/Repository/ProductVariantRepositoryTest.php
@@ -34,8 +34,10 @@ final class ProductVariantRepositoryTest extends KernelTestCase
 {
     /**
      * Declared in the order the fixture inserts them, which is the order the repository must yield.
-     * Neither the codes nor the fixture positions follow that order, so ordering the query by `code`
-     * or by `position` rather than by the identifier it pages on fails these assertions.
+     * The fixture's codes, positions and timestamps are each permuted independently of that order, so
+     * ordering the query by `code`, `position`, `createdAt` or `updatedAt` rather than by the identifier
+     * it pages on fails these assertions. `version` is excluded: Doctrine manages it as the optimistic
+     * lock field and forces it to 1 on insert, so it cannot be permuted from a fixture.
      */
     private const VARIANT_CODES = [
         'ITERATION_VARIANT_GAMMA',
@@ -63,8 +65,9 @@ final class ProductVariantRepositoryTest extends KernelTestCase
 
     /**
      * The test application enables `sylius_core.order_by_identifier`, whose walker appends an ordering
-     * by identifier to every query. That would supply the very clause these tests exist to pin, so it
-     * is removed here to reproduce a default 2.3 application, where the setting defaults to false.
+     * by identifier to every non-grouped, non-aggregate query. That would supply the very clause these
+     * tests exist to pin, so it is removed here to reproduce a default 2.3 application, where the
+     * setting defaults to false.
      */
     private function disableOrderByIdentifierWalker(): void
     {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #19193
| License         | MIT

## What this changes

`AllProductVariantsCatalogPromotionsProcessor` loaded the code of every product variant into a single array before dispatching anything, so its memory usage grew linearly with the size of the catalog and was unbounded.

This PR makes it read the catalog in batches and dispatch each batch as it is read.

- `ProductVariantRepositoryInterface::iterateCodesOfAllVariants(int $batchSize): iterable` is added. It uses keyset pagination (`WHERE id > :lastId ORDER BY id LIMIT :n`) rather than `OFFSET`, so the cost of each batch does not grow with how far into the catalog it already is, and it yields batches of plain strings.
- `getCodesOfAllVariants()` is deprecated.
- The processor now consumes the iterator, so peak memory becomes flat instead of proportional to catalog size.

`ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface` is deliberately **not** touched. It receives an already batch-sized array, its `array_chunk()` yields a single chunk, and its two other callers (`ProductCatalogPromotionsProcessor`, `ProductVariantCatalogPromotionsProcessor`) keep working unchanged.

## Measurements

Measured against the real `Sylius\Bundle\CoreBundle\Doctrine\ORM\ProductVariantRepository` on Doctrine ORM 3.6.8 / PHP 8.4.24, **one process per code path** — PHP does not return freed blocks to the allocator, so measuring both paths in one process would understate the second.

| Variants | Before | After |
|---:|---:|---:|
| 200 000 | 92 MB | **2 MB** |
| 500 000 | 224 MB | **2 MB** |

Peak memory is now flat regardless of catalog size. The "before" figures reproduce the ones reported in #19193 (92 MB / 226 MB), measured independently.

The practical effect: a shop with a few hundred thousand variants no longer exceeds a 256 MB `memory_limit` simply by saving a catalog promotion in the admin panel.

## On the deprecated method's return shape

`getCodesOfAllVariants()` never matched its declared `@return array|string[]`. Because it selects a single field and hydrates with `getArrayResult()`, it actually returns a list of `['code' => string]` arrays. This is documented in `UPGRADE-2.3.md`.

To be explicit: **this was not a functional bug** — the downstream `IN (:codes)` in `findByCodes()` resolves correctly with either shape, which I verified. It was only a memory cost. The new method yields plain strings, as the annotation always intended.

The mismatch stayed invisible because the only test covering the processor mocked the repository with the *contract* shape, so the real hydration shape was never exercised.

## Tests

Because a mocked repository cannot catch a shape mismatch of this kind, this PR adds `tests/Functional/Repository/ProductVariantRepositoryTest`, which exercises the real repository against a database and pins:

- every variant code yielded exactly once, with no duplicates;
- codes yielded as plain strings, matching the declared `iterable<list<string>>`;
- batching (7 variants at a batch size of 2 gives batches of 2, 2, 2, 1);
- a batch size larger than the catalog, and a batch size of 1;
- an empty catalog yielding nothing;
- a batch size below 1 raising when the method is *called*, not when iteration starts.

I checked that this test actually earns its place: with `yield array_column($result, 'code')` replaced by `yield $result` — that is, yielding the raw Doctrine hydration shape, the exact defect the old mock hid — 3 of the 7 tests fail, including the one written specifically for it. It passes again once the implementation is restored.

The batch size is validated in `iterateCodesOfAllVariants()` itself rather than inside the generator, so an invalid value cannot travel silently through a generator that is never consumed.

## Verification

- `vendor/bin/ecs check` on all changed files — clean.
- `vendor/bin/phpstan analyse` on all changed files — clean.
- `vendor/bin/phpunit tests/Functional/Repository/` — 10 tests, 26 assertions, green (3 pre-existing plus the 7 added here), against MySQL 5.7.
- `vendor/bin/phpunit -c src/Sylius/Bundle/CoreBundle/phpunit.xml.dist --filter AllProductVariantsCatalogPromotionsProcessorTest` — 3 tests, 10 assertions, green.
- Full `CoreBundle`, `ProductBundle` and `Product` suites run on this branch **and on the base commit** to compare: identical results (the pre-existing failures in my environment are unrelated to this change and are present on both).

## Upgrade notes

`UPGRADE-2.3.md` documents both the new interface method (custom implementations of `ProductVariantRepositoryInterface` must add it) and the deprecation, with a before/after snippet.

The processor gains a third constructor argument for the batch size. The `sylius.processor.catalog_promotion.all_product_variant` service already passes `%sylius_core.catalog_promotions.batch_size%`, so no action is needed unless it is instantiated manually.

## Note on scope

While reading this path I also noticed that `ProductVariantRepository::findByCodes()`, used per batch by `ApplyCatalogPromotionsOnVariantsHandler`, fetch-joins five relations and hydrates a cartesian result set into entities. I have not measured it and deliberately left it out of this PR to keep the change reviewable. Happy to open a separate issue with numbers if that would be useful.
