### PR TITLE
Preload order item unit adjustments in one query before order processing

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -580,6 +580,34 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    `getItemsSubtotal()`/`getSubtotal()`, switch them to `getOrderAndItemPromotionTotal()` to avoid the same
    double-counting. `getOrderPromotionTotal()` is unchanged and still returns the promotion's full effect.
 
+3. A new `preloadAdjustments(array $orderItemUnits): void` method has been added to
+   `Sylius\Component\Core\Repository\OrderItemUnitRepositoryInterface` and implemented in
+   `Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderItemUnitRepository`.
+
+   ```php
+   public function preloadAdjustments(array $orderItemUnits): void;
+   ```
+
+   If you have a custom class implementing this interface without extending the default repository, you must
+   add this method (it may be a no-op if your persistence layer does not lazy-load associations).
+
+   A new order processor, `sylius.order_processing.order_item_unit_adjustments_preloader`
+   (`Sylius\Component\Core\OrderProcessing\OrderItemUnitAdjustmentsPreloader`, priority 70), calls it at the start
+   of every order recalculation, before `sylius.order_processing.order_adjustments_clearer` (priority 60) or any
+   other processor touches order item unit adjustments.
+
+   Previously, the first access to each unit's `adjustments` collection - e.g. while clearing or recalculating
+   adjustments recursively per unit - triggered its own lazy-load query, one `SELECT` per unit. For an order item
+   held at a large quantity, this alone could add one query per unit to every recalculation (changing the
+   shipping address, applying a coupon, ...), regardless of how many adjustments actually existed. The new
+   processor loads every unit's adjustments in a single query up front, so that per-unit `SELECT` no longer
+   happens.
+
+   If you have decorated or replaced `sylius.order_processing.order_adjustments_clearer`,
+   `sylius.order_processing.order_taxes_processor`, or another processor that iterates over order item units'
+   adjustments, no changes are required - the preloading is transparent as long as the same `EntityManager`
+   instance is used within the request.
+
 ## Promotion
 
 1. New **opt-in per-channel** promotion rule and action types have been added. They let a single

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderItemUnitRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderItemUnitRepository.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Repository\OrderItemUnitRepositoryInterface;
+use Sylius\Component\Order\Model\OrderItemUnitInterface as BaseOrderItemUnitInterface;
 
 /**
  * @template T of OrderItemUnitInterface
@@ -37,6 +38,25 @@ class OrderItemUnitRepository extends EntityRepository implements OrderItemUnitR
             ->setParameter('customer', $customer)
             ->getQuery()
             ->getOneOrNullResult()
+        ;
+    }
+
+    /**
+     * @param BaseOrderItemUnitInterface[] $orderItemUnits
+     */
+    public function preloadAdjustments(array $orderItemUnits): void
+    {
+        if ([] === $orderItemUnits) {
+            return;
+        }
+
+        $this->createQueryBuilder('o')
+            ->addSelect('adjustment')
+            ->leftJoin('o.adjustments', 'adjustment')
+            ->andWhere('o IN (:orderItemUnits)')
+            ->setParameter('orderItemUnits', $orderItemUnits)
+            ->getQuery()
+            ->getResult()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\OrderProcessing\OrderAdjustmentsClearer;
+use Sylius\Component\Core\OrderProcessing\OrderItemUnitAdjustmentsPreloader;
 use Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor;
 use Sylius\Component\Core\OrderProcessing\OrderPricesRecalculator;
 use Sylius\Component\Core\OrderProcessing\OrderPromotionProcessor;
@@ -30,6 +31,12 @@ return static function (ContainerConfigurator $container) {
     $parameters->set('sylius.order_payment_processor.checkout.unsupported_states', [OrderInterface::STATE_CANCELLED, OrderInterface::STATE_FULFILLED]);
     $parameters->set('sylius.order_payment_processor.after_checkout.unsupported_states', [OrderInterface::STATE_CANCELLED, OrderInterface::STATE_FULFILLED]);
     $parameters->set('sylius.order_processing.adjustment_clearing_types', [AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT, AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT, AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT, AdjustmentInterface::SHIPPING_ADJUSTMENT, AdjustmentInterface::TAX_ADJUSTMENT]);
+
+    $services
+        ->set('sylius.order_processing.order_item_unit_adjustments_preloader', OrderItemUnitAdjustmentsPreloader::class)
+        ->args([service('sylius.repository.order_item_unit')])
+        ->tag('sylius.order_processor', ['priority' => 70])
+    ;
 
     $services
         ->set('sylius.order_processing.order_adjustments_clearer', OrderAdjustmentsClearer::class)

--- a/src/Sylius/Component/Core/OrderProcessing/OrderItemUnitAdjustmentsPreloader.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderItemUnitAdjustmentsPreloader.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\OrderProcessing;
+
+use Sylius\Component\Core\Repository\OrderItemUnitRepositoryInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+
+final class OrderItemUnitAdjustmentsPreloader implements OrderProcessorInterface
+{
+    public function __construct(private OrderItemUnitRepositoryInterface $orderItemUnitRepository)
+    {
+    }
+
+    public function process(OrderInterface $order): void
+    {
+        if (!$order->canBeProcessed()) {
+            return;
+        }
+
+        $units = [];
+        foreach ($order->getItems() as $item) {
+            foreach ($item->getUnits() as $unit) {
+                if (null === $unit->getId()) {
+                    continue;
+                }
+
+                $units[] = $unit;
+            }
+        }
+
+        $this->orderItemUnitRepository->preloadAdjustments($units);
+    }
+}

--- a/src/Sylius/Component/Core/Repository/OrderItemUnitRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderItemUnitRepositoryInterface.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\Repository;
 
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Order\Model\OrderItemUnitInterface as BaseOrderItemUnitInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 
 /**
@@ -25,4 +26,9 @@ use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 interface OrderItemUnitRepositoryInterface extends RepositoryInterface
 {
     public function findOneByCustomer(mixed $id, CustomerInterface $customer): ?OrderItemUnitInterface;
+
+    /**
+     * @param BaseOrderItemUnitInterface[] $orderItemUnits
+     */
+    public function preloadAdjustments(array $orderItemUnits): void;
 }

--- a/src/Sylius/Component/Core/tests/OrderProcessing/OrderItemUnitAdjustmentsPreloaderTest.php
+++ b/src/Sylius/Component/Core/tests/OrderProcessing/OrderItemUnitAdjustmentsPreloaderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Core\OrderProcessing;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\OrderProcessing\OrderItemUnitAdjustmentsPreloader;
+use Sylius\Component\Core\Repository\OrderItemUnitRepositoryInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+final class OrderItemUnitAdjustmentsPreloaderTest extends TestCase
+{
+    private MockObject&OrderItemUnitRepositoryInterface $orderItemUnitRepository;
+
+    private MockObject&OrderInterface $order;
+
+    private OrderItemUnitAdjustmentsPreloader $orderItemUnitAdjustmentsPreloader;
+
+    protected function setUp(): void
+    {
+        $this->orderItemUnitRepository = $this->createMock(OrderItemUnitRepositoryInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->orderItemUnitAdjustmentsPreloader = new OrderItemUnitAdjustmentsPreloader($this->orderItemUnitRepository);
+    }
+
+    public function testShouldImplementOrderProcessorInterface(): void
+    {
+        $this->assertInstanceOf(OrderProcessorInterface::class, $this->orderItemUnitAdjustmentsPreloader);
+    }
+
+    public function testShouldPreloadAdjustmentsOfEveryUnitOfEveryOrderItemInOneCall(): void
+    {
+        $firstUnit = $this->createMock(OrderItemUnitInterface::class);
+        $firstUnit->method('getId')->willReturn(1);
+
+        $secondUnit = $this->createMock(OrderItemUnitInterface::class);
+        $secondUnit->method('getId')->willReturn(2);
+
+        $thirdUnit = $this->createMock(OrderItemUnitInterface::class);
+        $thirdUnit->method('getId')->willReturn(3);
+
+        $firstItem = $this->createMock(OrderItemInterface::class);
+        $firstItem->method('getUnits')->willReturn(new ArrayCollection([$firstUnit, $secondUnit]));
+
+        $secondItem = $this->createMock(OrderItemInterface::class);
+        $secondItem->method('getUnits')->willReturn(new ArrayCollection([$thirdUnit]));
+
+        $this->order->expects($this->once())->method('canBeProcessed')->willReturn(true);
+        $this->order->method('getItems')->willReturn(new ArrayCollection([$firstItem, $secondItem]));
+
+        $this->orderItemUnitRepository->expects($this->once())
+            ->method('preloadAdjustments')
+            ->with([$firstUnit, $secondUnit, $thirdUnit])
+        ;
+
+        $this->orderItemUnitAdjustmentsPreloader->process($this->order);
+    }
+
+    public function testShouldSkipUnitsWithoutAnIdYet(): void
+    {
+        $persistedUnit = $this->createMock(OrderItemUnitInterface::class);
+        $persistedUnit->method('getId')->willReturn(1);
+
+        $newUnit = $this->createMock(OrderItemUnitInterface::class);
+        $newUnit->method('getId')->willReturn(null);
+
+        $item = $this->createMock(OrderItemInterface::class);
+        $item->method('getUnits')->willReturn(new ArrayCollection([$persistedUnit, $newUnit]));
+
+        $this->order->expects($this->once())->method('canBeProcessed')->willReturn(true);
+        $this->order->method('getItems')->willReturn(new ArrayCollection([$item]));
+
+        $this->orderItemUnitRepository->expects($this->once())
+            ->method('preloadAdjustments')
+            ->with([$persistedUnit])
+        ;
+
+        $this->orderItemUnitAdjustmentsPreloader->process($this->order);
+    }
+
+    public function testShouldDoNothingIfTheOrderCannotBeProcessed(): void
+    {
+        $this->order->expects($this->once())->method('canBeProcessed')->willReturn(false);
+
+        $this->order->expects($this->never())->method('getItems');
+        $this->orderItemUnitRepository->expects($this->never())->method('preloadAdjustments');
+
+        $this->orderItemUnitAdjustmentsPreloader->process($this->order);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes, additive only (see UPGRADE-2.3.md)
| Deprecations?   | no
| Related tickets |
| License         | MIT

## Problem

Every order recalculation (checkout address change, coupon application, ...) clears and re-applies adjustments on each order item's units. `Sylius\Component\Order\Model\OrderItemUnit::$adjustments` is a lazily loaded `OneToMany` collection, so the first per-unit access — inside `OrderAdjustmentsClearer` or `OrderTaxesProcessor::clearTaxes()` — triggers its own `SELECT`. For an order item held at a large quantity this adds one query per unit on every recalculation, regardless of how many adjustments actually exist.

For example, for a single order item with quantity 100, one recalculation pass generates:

| Query | Before | After |
|---|---|---|
| `SELECT` (lazy-load `adjustments` per unit) | 100 | **1** |
| `INSERT` (new adjustment per unit) | 100 | 100 |
| `UPDATE` (`adjustmentsTotal` per unit) | 100 | 100 |
| **Total** | **300** | **201** |

## Solution

Added `OrderItemUnitAdjustmentsPreloader`, a new order processor (priority 70, runs before `order_adjustments_clearer` at 60) that loads every unit's adjustments for the order in a single query via a new `OrderItemUnitRepositoryInterface::preloadAdjustments()` method. Later per-unit access on those same managed instances reuses the already initialized collection instead of issuing its own query.

This removes only the per-unit `SELECT` side of the problem. The per-unit `INSERT`/`UPDATE` queries remain, since each is a real row tied to a real `OrderItemUnit` entity — that part is unrelated to lazy loading and would need a benchmark of its own.

See `UPGRADE-2.3.md` for BC notes on the new interface method.
