### PR TITLE
fix: Changes to shop page templates also apply to admin pages

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -646,6 +646,14 @@ For a complete overview of the Grid component, see the [Grid documentation](http
    Existing subclasses overriding this method with the `RedirectResponse` return type remain valid thanks to
    return type covariance and require no changes.
 
+2. The `state` field of the `sylius_shop_account_order` grid is rendered with `@SyliusShop/grid/field/label.html.twig`
+   instead of the shared `@SyliusUi/grid/field/label.html.twig`. ([#18298](https://github.com/Sylius/Sylius/issues/18298))
+
+   Shop grid templates no longer share files with the admin ones, so overriding them does not affect admin pages anymore.
+   If you have overridden `@SyliusUi/grid/field/label.html.twig` to customise the shop, move your customisation to
+   `@SyliusShop/grid/field/label.html.twig`. The fallback label template used when no label template matches the value
+   is now `@SyliusShop/grid/field/label/default.html.twig`.
+
 ## New Features
 
 1. New post-flush cart events have been added to `Sylius\Component\Order\SyliusCartEvents`.

--- a/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGrid.php
+++ b/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGrid.php
@@ -43,7 +43,7 @@ final class OrderGrid implements OrderGridInterface
                     ->setLabel('sylius.ui.total')
                     ->setPath('.')
                     ->setSortable(true, 'total'),
-                TwigField::create('state', '@SyliusUi/grid/field/label.html.twig')
+                TwigField::create('state', '@SyliusShop/grid/field/label.html.twig')
                     ->setLabel('sylius.ui.state')
                     ->setSortable(true)
                     ->addOptions([

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/grids/account/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/grids/account/order.yml
@@ -45,7 +45,7 @@ sylius_grid:
                     label: sylius.ui.state
                     sortable: ~
                     options:
-                        template: "@SyliusUi/grid/field/label.html.twig"
+                        template: "@SyliusShop/grid/field/label.html.twig"
                         vars:
                             labels: "@SyliusShop/account/order/label/state"
             actions:


### PR DESCRIPTION
Fixes #18298

## Root cause

Shop grid label field reuses the shared @SyliusUi grid template

## Changes

- Added shop-owned grid label templates (@SyliusShop/grid/field/label.html.twig plus its default fallback) and pointed both the YAML and PHP definitions of the sylius_shop_account_order grid at them, so shop grid templates no longer share files with admin. Documented the change in UPGRADE-2.3.md. Tests were not executed: Composer dependencies are not installed in this checkout.