### PR TITLE
fix: CommandArgumentsDenormalizer & CommandDenormalizer: getSupportedTypes re...

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/Denormalizer/CommandArgumentsDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Denormalizer/CommandArgumentsDenormalizer.php
@@ -51,7 +51,7 @@ final class CommandArgumentsDenormalizer implements DenormalizerInterface
 
     public function getSupportedTypes(?string $format): array
     {
-        return ['object' => true];
+        return ['object' => false];
     }
 
     private function getInputClassName(array $context): ?string

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Denormalizer/CommandDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Denormalizer/CommandDenormalizer.php
@@ -65,7 +65,7 @@ final class CommandDenormalizer implements DenormalizerInterface
 
     public function getSupportedTypes(?string $format): array
     {
-        return ['object' => true];
+        return ['object' => false];
     }
 
     private function normalizeFieldName(string $field, string $class): string

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/Denormalizer/CommandArgumentsDenormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/Denormalizer/CommandArgumentsDenormalizerTest.php
@@ -69,6 +69,11 @@ final class CommandArgumentsDenormalizerTest extends TestCase
             ));
     }
 
+    public function testDoesNotAllowCachingSupportsDenormalizationResult(): void
+    {
+        self::assertSame(['object' => false], $this->commandArgumentsDenormalizer->getSupportedTypes(null));
+    }
+
     public function testDenormalizesAddProductReviewAndConvertsProductFieldFromIriToCode(): void
     {
         $context = ['input' => ['class' => AddProductReview::class]];

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/Denormalizer/CommandDenormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/Denormalizer/CommandDenormalizerTest.php
@@ -68,6 +68,11 @@ final class CommandDenormalizerTest extends TestCase
         self::assertFalse($this->commandDenormalizer->supportsDenormalization(null, ''));
     }
 
+    public function testDoesNotAllowCachingSupportsDenormalizationResult(): void
+    {
+        self::assertSame(['object' => false], $this->commandDenormalizer->getSupportedTypes(null));
+    }
+
     public function testThrowsExceptionIfNotAllRequiredParametersArePresentInTheContext(): void
     {
         $exception = new MissingConstructorArgumentsException(


### PR DESCRIPTION
Fixes #18883

## Root cause

Command denormalizers advertise cacheable support for all objects

## Changes

- Return ['object' => false] from getSupportedTypes() in CommandArgumentsDenormalizer and CommandDenormalizer so supportsDenormalization() is re-evaluated per call with the actual context (matching the existing convention in CommandNormalizer and the other context-aware Sylius denormalizers), plus unit regression tests.