### PR TITLE
[1.12] Fix Host header injection in the admin password-reset e-mail link 

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,36 @@
+# UPGRADE FROM `v1.12.24` TO `v1.12.25`
+
+This is a **security release**. Updating is strongly recommended.
+
+## Security fixes
+
+### [Admin] Host header injection in the administrator password-reset e-mail link (High)
+
+The link in the administrator password-reset e-mail was built with Twig's `url()` helper, which derives the scheme
+and host from the incoming request. Anyone able to trigger such an e-mail — which requires nothing but the
+administrator's e-mail address and a single unauthenticated request to `/admin/forgotten-password` or
+`POST /api/v2/admin/administrators/reset-password` — could therefore make the link point at a domain of their choosing
+by sending a spoofed `Host` (or `X-Forwarded-Host`) header, and capture the reset token when the administrator clicked
+it. The shop-side password reset was never affected, as it builds its link from the channel's configured hostname.
+
+The URL is now built in PHP from the current channel's `hostname`, which comes from the database. When no channel can
+be resolved, the channel has no hostname set, or the admin route is not registered (headless installations), the
+e-mail contains the bare reset token instead, which the administrator pastes into the shop manually.
+
+**Changes in `Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account\SendResetPasswordEmailHandler`:**
+
+```diff
+ public function __construct(
+     private UserRepositoryInterface $userRepository,
+     private SenderInterface $sender,
++    private RouterInterface $router,
++    private ChannelContextInterface $channelContext,
++    private bool $unsecuredUrls = false,
+ )
+```
+
+If you have overwritten this service or its arguments, check the correct functioning.
+
 # UPGRADE FROM `v1.12.23` TO `v1.12.24`
 
 ### Telemetry improvements

--- a/src/Sylius/Bundle/AdminBundle/Tests/MessageHandler/Admin/SendResetPasswordEmailHandlerTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/MessageHandler/Admin/SendResetPasswordEmailHandlerTest.php
@@ -15,12 +15,15 @@ namespace Sylius\Bundle\AdminBundle\Tests\MessageHandler\Admin;
 
 use Sylius\Bundle\CoreBundle\Message\Admin\Account\SendResetPasswordEmail;
 use Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account\SendResetPasswordEmailHandler;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Core\Model\AdminUser;
 use Sylius\Component\Core\Test\SwiftmailerAssertionTrait;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class SendResetPasswordEmailHandlerTest extends KernelTestCase
@@ -42,6 +45,15 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
         /** @var SenderInterface $emailSender */
         $emailSender = $container->get('sylius.email_sender');
 
+        /** @var RouterInterface $router */
+        $router = $container->get('router');
+
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getHostname')->willReturn('sylius.example.com');
+
+        $channelContext = $this->createMock(ChannelContextInterface::class);
+        $channelContext->method('getChannel')->willReturn($channel);
+
         $adminUser = new AdminUser();
         $adminUser->setEmail('sylius@example.com');
         $adminUser->setPasswordResetToken('my_reset_token');
@@ -53,7 +65,7 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
             ->willReturn($adminUser)
         ;
 
-        $resetPasswordEmailHandler = new SendResetPasswordEmailHandler($adminUserRepository, $emailSender);
+        $resetPasswordEmailHandler = new SendResetPasswordEmailHandler($adminUserRepository, $emailSender, $router, $channelContext);
         $resetPasswordEmailHandler(new SendResetPasswordEmail(
             'sylius@example.com',
             'en_US',
@@ -90,6 +102,15 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
         /** @var SenderInterface $emailSender */
         $emailSender = $container->get('sylius.email_sender');
 
+        /** @var RouterInterface $router */
+        $router = $container->get('router');
+
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getHostname')->willReturn('sylius.example.com');
+
+        $channelContext = $this->createMock(ChannelContextInterface::class);
+        $channelContext->method('getChannel')->willReturn($channel);
+
         $adminUser = new AdminUser();
         $adminUser->setEmail('sylius@example.com');
         $adminUser->setPasswordResetToken('my_reset_token');
@@ -101,7 +122,7 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
             ->willReturn($adminUser)
         ;
 
-        $resetPasswordEmailHandler = new SendResetPasswordEmailHandler($adminUserRepository, $emailSender);
+        $resetPasswordEmailHandler = new SendResetPasswordEmailHandler($adminUserRepository, $emailSender, $router, $channelContext);
         $resetPasswordEmailHandler(new SendResetPasswordEmail(
             'sylius@example.com',
             'en_US',

--- a/src/Sylius/Bundle/ApiBundle/Tests/MessageHandler/Admin/SendResetPasswordEmailHandlerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/MessageHandler/Admin/SendResetPasswordEmailHandlerTest.php
@@ -15,11 +15,14 @@ namespace Sylius\Bundle\ApiBundle\Tests\MessageHandler\Admin;
 
 use Sylius\Bundle\CoreBundle\Message\Admin\Account\SendResetPasswordEmail;
 use Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account\SendResetPasswordEmailHandler;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Core\Model\AdminUser;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class SendResetPasswordEmailHandlerTest extends KernelTestCase
@@ -41,6 +44,15 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
         /** @var SenderInterface $emailSender */
         $emailSender = $container->get('sylius.email_sender');
 
+        /** @var RouterInterface $router */
+        $router = $container->get('router');
+
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getHostname')->willReturn('sylius.example.com');
+
+        $channelContext = $this->createMock(ChannelContextInterface::class);
+        $channelContext->method('getChannel')->willReturn($channel);
+
         $adminUser = new AdminUser();
         $adminUser->setEmail('sylius@example.com');
         $adminUser->setPasswordResetToken('my_reset_token');
@@ -52,7 +64,7 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
             ->willReturn($adminUser)
         ;
 
-        $resetPasswordEmailHandler = new SendResetPasswordEmailHandler($adminUserRepository, $emailSender);
+        $resetPasswordEmailHandler = new SendResetPasswordEmailHandler($adminUserRepository, $emailSender, $router, $channelContext);
         $resetPasswordEmailHandler(new SendResetPasswordEmail(
             'sylius@example.com',
             'en_US',
@@ -63,7 +75,7 @@ final class SendResetPasswordEmailHandlerTest extends KernelTestCase
         self::assertEmailAddressContains($email, 'To', 'sylius@example.com');
         self::assertEmailHtmlBodyContains(
             $email,
-            $translator->trans('sylius.email.admin_password_reset.to_reset_your_password_token', [], null, 'en_US'),
+            $translator->trans('sylius.email.password_reset.to_reset_your_password', [], null, 'en_US'),
         );
     }
 

--- a/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/SendResetPasswordEmailHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/SendResetPasswordEmailHandler.php
@@ -15,9 +15,14 @@ namespace Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account;
 
 use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Bundle\CoreBundle\Message\Admin\Account\SendResetPasswordEmail;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Mailer\Sender\SenderInterface;
+use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\RouterInterface;
 use Webmozart\Assert\Assert;
 
 final class SendResetPasswordEmailHandler implements MessageHandlerInterface
@@ -25,6 +30,9 @@ final class SendResetPasswordEmailHandler implements MessageHandlerInterface
     public function __construct(
         private UserRepositoryInterface $userRepository,
         private SenderInterface $sender,
+        private RouterInterface $router,
+        private ChannelContextInterface $channelContext,
+        private bool $unsecuredUrls = false,
     ) {
     }
 
@@ -39,7 +47,32 @@ final class SendResetPasswordEmailHandler implements MessageHandlerInterface
             [
                 'adminUser' => $adminUser,
                 'localeCode' => $sendResetPasswordEmail->localeCode,
+                'resetUrl' => $this->generateAdminResetPasswordUrl($adminUser),
             ],
         );
+    }
+
+    private function generateAdminResetPasswordUrl(UserInterface $adminUser): ?string
+    {
+        try {
+            $hostname = $this->channelContext->getChannel()->getHostname();
+        } catch (ChannelNotFoundException) {
+            return null;
+        }
+
+        if (null === $hostname) {
+            return null;
+        }
+
+        try {
+            $path = $this->router->generate(
+                'sylius_admin_render_password_reset',
+                ['token' => (string) $adminUser->getPasswordResetToken()],
+            );
+        } catch (RouteNotFoundException) {
+            return null;
+        }
+
+        return ($this->unsecuredUrls ? 'http://' : 'https://') . $hostname . $path;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/message_handlers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/message_handlers.xml
@@ -38,6 +38,9 @@
         <service id="Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account\SendResetPasswordEmailHandler">
             <argument type="service" id="sylius.repository.admin_user"/>
             <argument type="service" id="sylius.email_sender"/>
+            <argument type="service" id="router"/>
+            <argument type="service" id="sylius.context.channel"/>
+            <argument>%sylius.unsecured_urls%</argument>
 
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
             <tag name="messenger.message_handler" bus="sylius_default.bus" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/adminPasswordReset.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/adminPasswordReset.html.twig
@@ -33,7 +33,7 @@
         <div style="font-size: 24px;">
             {{ 'sylius.email.admin_password_reset.hello'|trans({}, null, localeCode) }} <strong>{{ adminUser.firstName }} {{ adminUser.lastName }}</strong><br>
         </div>
-        {% if sylius_bundle_loaded_checker('SyliusAdminBundle') %}
+        {% if resetUrl is not null %}
             {{ 'sylius.email.password_reset.to_reset_your_password'|trans({}, null, localeCode) }}:
         {% else %}
             {{ 'sylius.email.admin_password_reset.to_reset_your_password_token'|trans({}, null, localeCode) }}:
@@ -41,9 +41,8 @@
     </div>
 
     <div style="text-align: center;">
-        {% if sylius_bundle_loaded_checker('SyliusAdminBundle') %}
-            {% set url = url('sylius_admin_render_password_reset', {'token': adminUser.passwordResetToken}) %}
-            <a href="{{ url|raw }}" style="display: inline-block; text-align: center; background: #1abb9c; padding: 18px 28px; color: #fff; text-decoration: none; border-radius: 3px;">
+        {% if resetUrl is not null %}
+            <a href="{{ resetUrl }}" style="display: inline-block; text-align: center; background: #1abb9c; padding: 18px 28px; color: #fff; text-decoration: none; border-radius: 3px;">
                 {{ 'sylius.email.admin_password_reset.reset_your_password'|trans({}, null, localeCode) }}
             </a>
         {% else %}

--- a/src/Sylius/Bundle/CoreBundle/spec/MessageHandler/Admin/Account/SendResetPasswordEmailHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/MessageHandler/Admin/Account/SendResetPasswordEmailHandlerSpec.php
@@ -16,18 +16,23 @@ namespace spec\Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Bundle\CoreBundle\Message\Admin\Account\SendResetPasswordEmail;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 final class SendResetPasswordEmailHandlerSpec extends ObjectBehavior
 {
     public function let(
         UserRepositoryInterface $userRepository,
         SenderInterface $sender,
+        RouterInterface $router,
+        ChannelContextInterface $channelContext,
     ): void {
-        $this->beConstructedWith($userRepository, $sender);
+        $this->beConstructedWith($userRepository, $sender, $router, $channelContext, false);
     }
 
     public function it_is_a_message_handler(): void
@@ -38,9 +43,17 @@ final class SendResetPasswordEmailHandlerSpec extends ObjectBehavior
     public function it_handles_sending_reset_password_email(
         UserRepositoryInterface $userRepository,
         SenderInterface $sender,
+        RouterInterface $router,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel,
         AdminUserInterface $adminUser,
     ): void {
         $userRepository->findOneByEmail('admin@example.com')->willReturn($adminUser);
+        $adminUser->getPasswordResetToken()->willReturn('token');
+
+        $channelContext->getChannel()->willReturn($channel);
+        $channel->getHostname()->willReturn('sylius.example.com');
+        $router->generate('sylius_admin_render_password_reset', ['token' => 'token'])->willReturn('/admin/forgotten-password/token');
 
         $sender->send(
             Emails::ADMIN_PASSWORD_RESET,
@@ -48,6 +61,7 @@ final class SendResetPasswordEmailHandlerSpec extends ObjectBehavior
             [
                 'adminUser' => $adminUser,
                 'localeCode' => 'en_US',
+                'resetUrl' => 'https://sylius.example.com/admin/forgotten-password/token',
             ],
         )->shouldBeCalledOnce();
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12 <!-- see the comment below -->
| Bug fix?        | yes
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
