### PR TITLE
[1.14] Fix Host header injection in the admin password-reset e-mail link 

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -1,3 +1,36 @@
+# UPGRADE FROM `v1.14.19` TO `v1.14.20`
+
+This is a **security release**. Updating is strongly recommended.
+
+## Security fixes
+
+### [Admin] Host header injection in the administrator password-reset e-mail link (High)
+
+The link in the administrator password-reset e-mail was built with Twig's `url()` helper, which derives the scheme
+and host from the incoming request. Anyone able to trigger such an e-mail — which requires nothing but the
+administrator's e-mail address and a single unauthenticated request to `/admin/forgotten-password` or
+`POST /api/v2/admin/administrators/reset-password` — could therefore make the link point at a domain of their choosing
+by sending a spoofed `Host` (or `X-Forwarded-Host`) header, and capture the reset token when the administrator clicked
+it. The shop-side password reset was never affected, as it builds its link from the channel's configured hostname.
+
+The URL is now built in PHP from the current channel's `hostname`, which comes from the database. When no channel can
+be resolved, the channel has no hostname set, or the admin route is not registered (headless installations), the
+e-mail contains the bare reset token instead, which the administrator pastes into the shop manually.
+
+**Changes in `Sylius\Bundle\CoreBundle\Mailer\ResetPasswordEmailManager`:**
+
+```diff
+ public function __construct(
+     private SenderInterface $emailSender,
++    private RouterInterface $router,
++    private ChannelContextInterface $channelContext,
++    private bool $unsecuredUrls = false,
+ )
+```
+
+If you have overwritten the `sylius.mailer.reset_password_email_manager` service or its arguments, check the correct
+functioning.
+
 # UPGRADE FROM `v1.14.18` TO `v1.14.19`
 
 ### Telemetry improvements

--- a/src/Sylius/Bundle/CoreBundle/Mailer/ResetPasswordEmailManager.php
+++ b/src/Sylius/Bundle/CoreBundle/Mailer/ResetPasswordEmailManager.php
@@ -13,14 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Mailer;
 
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Model\UserInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 final class ResetPasswordEmailManager implements ResetPasswordEmailManagerInterface
 {
-    public function __construct(private SenderInterface $emailSender)
-    {
+    public function __construct(
+        private SenderInterface $emailSender,
+        private RouterInterface $router,
+        private ChannelContextInterface $channelContext,
+        private bool $unsecuredUrls = false,
+    ) {
     }
 
     public function sendAdminResetPasswordEmail(UserInterface $user, string $localCode): void
@@ -31,6 +40,7 @@ final class ResetPasswordEmailManager implements ResetPasswordEmailManagerInterf
             data: [
                 'adminUser' => $user,
                 'localeCode' => $localCode,
+                'resetUrl' => $this->generateAdminResetPasswordUrl($user),
             ],
         );
     }
@@ -46,5 +56,29 @@ final class ResetPasswordEmailManager implements ResetPasswordEmailManagerInterf
                 'channel' => $channel,
             ],
         );
+    }
+
+    private function generateAdminResetPasswordUrl(UserInterface $user): ?string
+    {
+        try {
+            $hostname = $this->channelContext->getChannel()->getHostname();
+        } catch (ChannelNotFoundException) {
+            return null;
+        }
+
+        if (null === $hostname) {
+            return null;
+        }
+
+        try {
+            $path = $this->router->generate(
+                'sylius_admin_render_password_reset',
+                ['token' => (string) $user->getPasswordResetToken()]
+            );
+        } catch (RouteNotFoundException) {
+            return null;
+        }
+
+        return ($this->unsecuredUrls ? 'http://' : 'https://') . $hostname . $path;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/mailer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/mailer.xml
@@ -47,6 +47,9 @@
 
         <service id="sylius.mailer.reset_password_email_manager" class="Sylius\Bundle\CoreBundle\Mailer\ResetPasswordEmailManager">
             <argument type="service" id="sylius.email_sender" />
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius.context.channel" />
+            <argument>%sylius.unsecured_urls%</argument>
         </service>
         <service id="Sylius\Bundle\CoreBundle\Mailer\ResetPasswordEmailManagerInterface" alias="sylius.mailer.reset_password_email_manager" />
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/adminPasswordReset.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/adminPasswordReset.html.twig
@@ -33,7 +33,7 @@
         <div style="font-size: 24px;">
             {{ 'sylius.email.admin_password_reset.hello'|trans({}, null, localeCode) }} <strong>{{ adminUser.firstName }} {{ adminUser.lastName }}</strong><br>
         </div>
-        {% if sylius_bundle_loaded_checker('SyliusAdminBundle') %}
+        {% if resetUrl is not null %}
             {{ 'sylius.email.password_reset.to_reset_your_password'|trans({}, null, localeCode) }}:
         {% else %}
             {{ 'sylius.email.admin_password_reset.to_reset_your_password_token'|trans({}, null, localeCode) }}:
@@ -41,9 +41,8 @@
     </div>
 
     <div style="text-align: center;">
-        {% if sylius_bundle_loaded_checker('SyliusAdminBundle') %}
-            {% set url = url('sylius_admin_render_password_reset', {'token': adminUser.passwordResetToken}) %}
-            <a href="{{ url|raw }}" style="display: inline-block; text-align: center; background: #1abb9c; padding: 18px 28px; color: #fff; text-decoration: none; border-radius: 3px;">
+        {% if resetUrl is not null %}
+            <a href="{{ resetUrl }}" style="display: inline-block; text-align: center; background: #1abb9c; padding: 18px 28px; color: #fff; text-decoration: none; border-radius: 3px;">
                 {{ 'sylius.email.admin_password_reset.reset_your_password'|trans({}, null, localeCode) }}
             </a>
         {% else %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | yes
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
