### PR TITLE
[2.1] Add JwtAudienceListener to enforce JWT audience and principal validation 

### DIFF
--- a/UPGRADE-API-2.1.md
+++ b/UPGRADE-API-2.1.md
@@ -1,3 +1,39 @@
+# UPGRADE FROM `2.1.15` TO `2.1.16`
+
+## Security
+
+### JWTs are now bound to the API section they have been issued for
+
+Tokens are stamped with an `aud` claim (`sylius-api-admin` or `sylius-api-shop`) and a
+`principal_type` claim, and they are rejected by the other API section. This closes the case where
+an administrator and a shop customer share an e-mail address, in which a shop token was accepted by
+the admin API and resolved to that administrator.
+
+The expectations are keyed by firewall name, `api_admin` and `api_shop` by default, and are
+configured under `sylius_api.jwt.firewall_expectations`. If your application renamed either firewall, or serves
+the API through an additional JWT firewall (e.g. a marketplace vendor API), add an entry for it, otherwise the
+tokens of that firewall are rejected:
+
+```yaml
+sylius_api:
+    jwt:
+        firewall_expectations:
+            api_admin:
+                audience: sylius-api-admin
+                principal: Sylius\Component\Core\Model\AdminUserInterface
+            api_shop:
+                audience: sylius-api-shop
+                principal: Sylius\Component\Core\Model\ShopUserInterface
+            api_vendor:
+                audience: sylius-api-vendor
+                principal: App\Entity\VendorUserInterface
+```
+
+This map is replaced, not merged, when configured — keep the built-in `api_admin`/`api_shop`
+entries alongside your own. Configuring an entry here only affects JWT validation; the referenced firewall must
+still be defined in `security.yaml`, and the `principal` must be an existing class or interface implemented by
+the corresponding user.
+
 # UPGRADE FROM `2.1.14` TO `2.1.15`
 
 ## Security

--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/Configuration.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DependencyInjection;
 
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -54,6 +56,35 @@ final readonly class Configuration implements ConfigurationInterface
                                             ->children()
                                                 ->booleanNode('enabled')->defaultTrue()->end()
                                             ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('jwt')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('firewall_expectations')
+                            ->info('Maps a firewall name to the JWT "aud" claim and the user principal interface expected on that firewall.')
+                            ->useAttributeAsKey('name')
+                            ->defaultValue([
+                                'api_admin' => ['audience' => 'sylius-api-admin', 'principal' => AdminUserInterface::class],
+                                'api_shop' => ['audience' => 'sylius-api-shop', 'principal' => ShopUserInterface::class],
+                            ])
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('audience')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('principal')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                        ->validate()
+                                            ->ifTrue(static fn (string $principal): bool => !interface_exists($principal) && !class_exists($principal))
+                                            ->thenInvalid('The principal "%s" is not an existing class or interface.')
                                         ->end()
                                     ->end()
                                 ->end()

--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -37,6 +37,7 @@ final class SyliusApiExtension extends Extension implements PrependExtensionInte
         );
         $container->setParameter('sylius_api.order_states_to_filter_out', $config['order_states_to_filter_out']);
         $container->setParameter('sylius_api.operations_to_remove', $config['operations_to_remove']);
+        $container->setParameter('sylius_api.jwt.firewall_expectations', $config['jwt']['firewall_expectations']);
 
         $loader->load('services.xml');
 

--- a/src/Sylius/Bundle/ApiBundle/EventListener/JwtAudienceListener.php
+++ b/src/Sylius/Bundle/ApiBundle/EventListener/JwtAudienceListener.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/** @internal */
+final readonly class JwtAudienceListener
+{
+    /** @param array<string, array{audience: string, principal: class-string}> $firewallExpectations */
+    public function __construct(
+        private FirewallMap $firewallMap,
+        private RequestStack $requestStack,
+        private LoggerInterface $logger,
+        private array $firewallExpectations,
+    ) {
+    }
+
+    public function onJwtCreated(JWTCreatedEvent $event): void
+    {
+        $user = $event->getUser();
+
+        foreach ($this->firewallExpectations as $expectation) {
+            if (!$user instanceof $expectation['principal']) {
+                continue;
+            }
+
+            $event->setData([
+                ...$event->getData(),
+                'aud' => $expectation['audience'],
+                'principal_type' => $expectation['principal'],
+            ]);
+
+            return;
+        }
+    }
+
+    public function onJwtDecoded(JWTDecodedEvent $event): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $firewallName = null !== $request ? $this->firewallMap->getFirewallConfig($request)?->getName() : null;
+
+        $expectations = $this->firewallExpectations[$firewallName] ?? null;
+        $payload = $event->getPayload();
+
+        $audience = (array) ($payload['aud'] ?? []);
+
+        if (
+            null === $expectations ||
+            !in_array($expectations['audience'], $audience, true) ||
+            ($payload['principal_type'] ?? null) !== $expectations['principal']
+        ) {
+            $this->logger->warning('Rejected JWT due to audience/principal-type mismatch.', [
+                'firewall' => $firewallName,
+                'aud' => $payload['aud'] ?? null,
+                'principal_type' => $payload['principal_type'] ?? null,
+            ]);
+
+            $event->markAsInvalid();
+        }
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -81,5 +81,14 @@
             <argument type="service" id="api_platform.symfony.iri_converter" />
             <tag name="kernel.event_listener" event="lexik_jwt_authentication.on_authentication_success" method="onAuthenticationSuccessResponse" />
         </service>
+
+        <service id="sylius_api.listener.jwt_audience" class="Sylius\Bundle\ApiBundle\EventListener\JwtAudienceListener">
+            <argument type="service" id="security.firewall.map" />
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="logger" />
+            <argument>%sylius_api.jwt.firewall_expectations%</argument>
+            <tag name="kernel.event_listener" event="lexik_jwt_authentication.on_jwt_created" method="onJwtCreated" />
+            <tag name="kernel.event_listener" event="lexik_jwt_authentication.on_jwt_decoded" method="onJwtDecoded" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/tests/EventListener/JwtAudienceListenerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/EventListener/JwtAudienceListenerTest.php
@@ -1,0 +1,283 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\ApiBundle\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sylius\Bundle\ApiBundle\EventListener\JwtAudienceListener;
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class JwtAudienceListenerTest extends TestCase
+{
+    private const ADMIN_AUDIENCE = 'sylius-api-admin';
+
+    private const SHOP_AUDIENCE = 'sylius-api-shop';
+
+    /** @var array<string, array{audience: string, principal: class-string}> */
+    private const FIREWALL_EXPECTATIONS = [
+        'api_admin' => ['audience' => self::ADMIN_AUDIENCE, 'principal' => AdminUserInterface::class],
+        'api_shop' => ['audience' => self::SHOP_AUDIENCE, 'principal' => ShopUserInterface::class],
+    ];
+
+    private FirewallMap&MockObject $firewallMap;
+
+    private RequestStack $requestStack;
+
+    private LoggerInterface&MockObject $logger;
+
+    private JwtAudienceListener $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->firewallMap = $this->createMock(FirewallMap::class);
+        $this->requestStack = new RequestStack();
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->listener = new JwtAudienceListener(
+            $this->firewallMap,
+            $this->requestStack,
+            $this->logger,
+            self::FIREWALL_EXPECTATIONS,
+        );
+    }
+
+    public function testStampsAdminClaimsOnTokenCreatedForAdminUser(): void
+    {
+        $event = new JWTCreatedEvent(['username' => 'shared@example.com'], $this->createMock(AdminUserInterface::class));
+
+        $this->listener->onJwtCreated($event);
+
+        self::assertSame([
+            'username' => 'shared@example.com',
+            'aud' => self::ADMIN_AUDIENCE,
+            'principal_type' => AdminUserInterface::class,
+        ], $event->getData());
+    }
+
+    public function testStampsShopClaimsOnTokenCreatedForShopUser(): void
+    {
+        $event = new JWTCreatedEvent(['username' => 'shared@example.com'], $this->createMock(ShopUserInterface::class));
+
+        $this->listener->onJwtCreated($event);
+
+        self::assertSame([
+            'username' => 'shared@example.com',
+            'aud' => self::SHOP_AUDIENCE,
+            'principal_type' => ShopUserInterface::class,
+        ], $event->getData());
+    }
+
+    public function testDoesNotStampAnyClaimsForUnsupportedUser(): void
+    {
+        $event = new JWTCreatedEvent(['username' => 'other@example.com'], $this->createMock(UserInterface::class));
+
+        $this->listener->onJwtCreated($event);
+
+        self::assertSame(['username' => 'other@example.com'], $event->getData());
+    }
+
+    public function testAcceptsTokenWhoseAudienceClaimHasBeenDecodedAsAnArray(): void
+    {
+        $this->useFirewall('api_admin');
+
+        $event = new JWTDecodedEvent([
+            'aud' => [self::ADMIN_AUDIENCE],
+            'principal_type' => AdminUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertTrue($event->isValid());
+    }
+
+    public function testAcceptsTokenWhoseAudienceClaimHasBeenDecodedAsAString(): void
+    {
+        $this->useFirewall('api_shop');
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::SHOP_AUDIENCE,
+            'principal_type' => ShopUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertTrue($event->isValid());
+    }
+
+    public function testAcceptsTokenWhenAStaleRequestIsLeftAtTheBottomOfTheRequestStack(): void
+    {
+        $staleRequest = new Request();
+        $this->requestStack->push($staleRequest);
+
+        $apiRequest = Request::create('/api/v2/shop/orders/nAWw2945');
+        $this->requestStack->push($apiRequest);
+
+        $this->firewallMap
+            ->method('getFirewallConfig')
+            ->willReturnCallback(fn (Request $request) => new FirewallConfig(
+                $request === $apiRequest ? 'api_shop' : 'shop',
+                'security.user_checker',
+            ))
+        ;
+
+        $event = new JWTDecodedEvent([
+            'aud' => [self::SHOP_AUDIENCE],
+            'principal_type' => ShopUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertTrue($event->isValid());
+    }
+
+    public function testRejectsShopTokenSentToTheAdminFirewall(): void
+    {
+        $this->useFirewall('api_admin');
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::SHOP_AUDIENCE,
+            'principal_type' => ShopUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertFalse($event->isValid());
+    }
+
+    public function testRejectsAdminTokenSentToTheShopFirewall(): void
+    {
+        $this->useFirewall('api_shop');
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::ADMIN_AUDIENCE,
+            'principal_type' => AdminUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertFalse($event->isValid());
+    }
+
+    public function testRejectsTokenWithMatchingAudienceButMismatchedPrincipalType(): void
+    {
+        $this->useFirewall('api_admin');
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::ADMIN_AUDIENCE,
+            'principal_type' => ShopUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertFalse($event->isValid());
+    }
+
+    public function testRejectsTokenIssuedBeforeTheAudienceClaimsHaveBeenIntroduced(): void
+    {
+        $this->useFirewall('api_admin');
+
+        $event = new JWTDecodedEvent(['username' => 'shared@example.com']);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertFalse($event->isValid());
+    }
+
+    public function testRejectsTokenWhenTheRequestIsHandledByAnUnknownFirewall(): void
+    {
+        $this->useFirewall('main');
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::ADMIN_AUDIENCE,
+            'principal_type' => AdminUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertFalse($event->isValid());
+    }
+
+    public function testRejectsTokenWhenThereIsNoRequest(): void
+    {
+        $this->firewallMap->expects(self::never())->method('getFirewallConfig');
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::ADMIN_AUDIENCE,
+            'principal_type' => AdminUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->listener->onJwtDecoded($event);
+
+        self::assertFalse($event->isValid());
+    }
+
+    public function testUsesTheFirewallExpectationsGivenInConfiguration(): void
+    {
+        $this->useFirewall('custom_admin_api');
+
+        $listener = new JwtAudienceListener($this->firewallMap, $this->requestStack, $this->logger, [
+            'custom_admin_api' => ['audience' => self::ADMIN_AUDIENCE, 'principal' => AdminUserInterface::class],
+        ]);
+
+        $event = new JWTDecodedEvent([
+            'aud' => self::ADMIN_AUDIENCE,
+            'principal_type' => AdminUserInterface::class,
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $listener->onJwtDecoded($event);
+
+        self::assertTrue($event->isValid());
+    }
+
+    private function useFirewall(string $name): void
+    {
+        $this->requestStack->push(new Request());
+
+        $this->firewallMap
+            ->method('getFirewallConfig')
+            ->willReturn(new FirewallConfig($name, 'security.user_checker'))
+        ;
+    }
+}

--- a/tests/Api/DataFixtures/ORM/authentication/admin_and_shop_user_sharing_an_email.yaml
+++ b/tests/Api/DataFixtures/ORM/authentication/admin_and_shop_user_sharing_an_email.yaml
@@ -1,0 +1,24 @@
+Sylius\Component\Core\Model\AdminUser:
+    admin_sharing_an_email:
+        plainPassword: sylius
+        roles: [ROLE_API_ACCESS]
+        enabled: true
+        email: shared@example.com
+        username: shared
+        localeCode: en
+
+Sylius\Component\Core\Model\Customer:
+    customer_sharing_an_email:
+        firstName: "Shared"
+        lastName: "Doe"
+        email: "shared@example.com"
+        emailCanonical: "shared@example.com"
+
+Sylius\Component\Core\Model\ShopUser:
+    shop_user_sharing_an_email:
+        plainPassword: "sylius"
+        roles: [ROLE_USER]
+        enabled: true
+        customer: "@customer_sharing_an_email"
+        username: "shared@example.com"
+        usernameCanonical: "shared@example.com"

--- a/tests/Api/Security/JwtAudienceTest.php
+++ b/tests/Api/Security/JwtAudienceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api\Security;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Tests\Api\JsonApiTestCase;
+use Sylius\Tests\Api\Utils\UserLoginTrait;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * An administrator and a shop customer may legitimately share an e-mail address, as they live in
+ * separate tables. A token must therefore only be accepted by the API section it has been issued for.
+ */
+final class JwtAudienceTest extends JsonApiTestCase
+{
+    use UserLoginTrait;
+
+    private const SHARED_EMAIL = 'shared@example.com';
+
+    private const FIXTURES = ['authentication/admin_and_shop_user_sharing_an_email.yaml'];
+
+    #[Test]
+    public function it_accepts_an_administrator_token_on_the_admin_api(): void
+    {
+        $this->loadFixturesFromFiles(self::FIXTURES);
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/admin/orders',
+            server: array_merge($this->logInUser('admin', self::SHARED_EMAIL), self::CONTENT_TYPE_HEADER),
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_OK);
+    }
+
+    #[Test]
+    public function it_accepts_a_shop_user_token_on_the_shop_api(): void
+    {
+        $this->loadFixturesFromFiles(self::FIXTURES);
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/addresses',
+            server: array_merge($this->logInUser('shop', self::SHARED_EMAIL), self::CONTENT_TYPE_HEADER),
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_OK);
+    }
+
+    #[Test]
+    public function it_denies_a_shop_user_token_used_on_the_admin_api(): void
+    {
+        $this->loadFixturesFromFiles(self::FIXTURES);
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/admin/orders',
+            server: array_merge($this->logInUser('shop', self::SHARED_EMAIL), self::CONTENT_TYPE_HEADER),
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function it_denies_an_administrator_token_used_on_the_shop_api(): void
+    {
+        $this->loadFixturesFromFiles(self::FIXTURES);
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/addresses',
+            server: array_merge($this->logInUser('admin', self::SHARED_EMAIL), self::CONTENT_TYPE_HEADER),
+        );
+
+        $this->assertResponseCode($this->client->getResponse(), Response::HTTP_UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | yes
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
