### PR TITLE
[2.2] Prevent payment amount tampering after a gateway transaction has started 

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\OrderProcessing;
 
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Payment\ClaimedByGatewayCheckerTrait;
 use Sylius\Component\Core\Payment\Exception\NotProvidedOrderPaymentException;
 use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
 use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface;
@@ -24,6 +25,8 @@ use Webmozart\Assert\Assert;
 
 final class OrderPaymentProcessor implements OrderProcessorInterface
 {
+    use ClaimedByGatewayCheckerTrait;
+
     /**
      * @param array<string> $unprocessableOrderStates
      */
@@ -52,10 +55,19 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
 
         $lastPayment = $order->getLastPayment($this->targetState);
         if (null !== $lastPayment) {
-            $lastPayment->setCurrencyCode($order->getCurrencyCode());
-            $lastPayment->setAmount($order->getTotal());
+            if (!$this->isClaimedByGateway($lastPayment)) {
+                $lastPayment->setCurrencyCode($order->getCurrencyCode());
+                $lastPayment->setAmount($order->getTotal());
 
-            return;
+                return;
+            }
+
+            if (
+                $lastPayment->getAmount() === $order->getTotal() &&
+                $lastPayment->getCurrencyCode() === $order->getCurrencyCode()
+            ) {
+                return;
+            }
         }
 
         try {

--- a/src/Sylius/Component/Core/Payment/ClaimedByGatewayCheckerTrait.php
+++ b/src/Sylius/Component/Core/Payment/ClaimedByGatewayCheckerTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Payment;
+
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+trait ClaimedByGatewayCheckerTrait
+{
+    private function isClaimedByGateway(PaymentInterface $payment): bool
+    {
+        $claimingActions = [PaymentRequestInterface::ACTION_CAPTURE, PaymentRequestInterface::ACTION_AUTHORIZE];
+        $nonClaimingStates = [
+            PaymentRequestInterface::STATE_NEW,
+            PaymentRequestInterface::STATE_FAILED,
+            PaymentRequestInterface::STATE_CANCELLED,
+        ];
+
+        $claimingPaymentRequests = $payment->getPaymentRequests()->filter(
+            static function (PaymentRequestInterface $paymentRequest) use ($claimingActions, $nonClaimingStates): bool {
+                return
+                    in_array($paymentRequest->getAction(), $claimingActions, true) &&
+                    !in_array($paymentRequest->getState(), $nonClaimingStates, true);
+            },
+        );
+
+        return !$claimingPaymentRequests->isEmpty();
+    }
+}

--- a/src/Sylius/Component/Core/Payment/Remover/OrderPaymentsRemover.php
+++ b/src/Sylius/Component/Core/Payment/Remover/OrderPaymentsRemover.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\Payment\Remover;
 
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Payment\ClaimedByGatewayCheckerTrait;
 use Sylius\Component\Payment\Model\PaymentInterface;
 
 final class OrderPaymentsRemover implements OrderPaymentsRemoverInterface
 {
+    use ClaimedByGatewayCheckerTrait;
+
     public function canRemovePayments(OrderInterface $order): bool
     {
         return 0 === $order->getTotal();
@@ -26,7 +29,7 @@ final class OrderPaymentsRemover implements OrderPaymentsRemoverInterface
     public function removePayments(OrderInterface $order): void
     {
         $removablePayments = $order->getPayments()->filter(function (PaymentInterface $payment): bool {
-            return $payment->getState() === PaymentInterface::STATE_CART;
+            return $payment->getState() === PaymentInterface::STATE_CART && !$this->isClaimedByGateway($payment);
         });
 
         foreach ($removablePayments as $payment) {

--- a/src/Sylius/Component/Core/tests/OrderProcessing/OrderPaymentProcessorTest.php
+++ b/src/Sylius/Component/Core/tests/OrderProcessing/OrderPaymentProcessorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Core\OrderProcessing;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -23,6 +24,7 @@ use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
 use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
 final class OrderPaymentProcessorTest extends TestCase
 {
@@ -93,6 +95,7 @@ final class OrderPaymentProcessorTest extends TestCase
             ->willReturn(false);
         $this->order->expects($this->once())->method('getCurrencyCode')->willReturn('PLN');
         $this->order->expects($this->once())->method('getTotal')->willReturn(1000);
+        $this->payment->method('getPaymentRequests')->willReturn(new ArrayCollection());
         $this->payment->expects($this->once())->method('setCurrencyCode')->with('PLN');
         $this->payment->expects($this->once())->method('setAmount')->with(1000);
         $this->orderPaymentProvider
@@ -137,6 +140,87 @@ final class OrderPaymentProcessorTest extends TestCase
             ->with($this->order, PaymentInterface::STATE_CART)
             ->willThrowException(new NotProvidedOrderPaymentException());
         $this->order->expects($this->never())->method('addPayment')->with($this->anything());
+
+        $this->orderPaymentProcessor->process($this->order);
+    }
+
+    public function testShouldNotOverwriteAmountOfPaymentClaimedByGatewayAndProvidesNewPaymentInstead(): void
+    {
+        $claimingPaymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $claimingPaymentRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        $claimingPaymentRequest->method('getState')->willReturn(PaymentRequestInterface::STATE_PROCESSING);
+
+        $newPayment = $this->createMock(PaymentInterface::class);
+
+        $this->order->expects($this->once())->method('getState')->willReturn(OrderInterface::STATE_CART);
+        $this->order->expects($this->once())->method('getLastPayment')->with(PaymentInterface::STATE_CART)->willReturn($this->payment);
+        $this->orderPaymentsRemover
+            ->expects($this->once())
+            ->method('canRemovePayments')
+            ->with($this->order)
+            ->willReturn(false);
+        $this->payment->method('getPaymentRequests')->willReturn(new ArrayCollection([$claimingPaymentRequest]));
+        $this->payment->method('getAmount')->willReturn(4796);
+        $this->payment->method('getCurrencyCode')->willReturn('USD');
+        $this->order->method('getTotal')->willReturn(230453);
+        $this->order->method('getCurrencyCode')->willReturn('USD');
+        $this->payment->expects($this->never())->method('setAmount');
+        $this->payment->expects($this->never())->method('setCurrencyCode');
+        $this->orderPaymentProvider
+            ->expects($this->once())
+            ->method('provideOrderPayment')
+            ->with($this->order, PaymentInterface::STATE_CART)
+            ->willReturn($newPayment);
+        $this->order->expects($this->once())->method('addPayment')->with($newPayment);
+
+        $this->orderPaymentProcessor->process($this->order);
+    }
+
+    public function testShouldDoNothingWhenClaimedPaymentAlreadyMatchesOrderTotalAndCurrency(): void
+    {
+        $claimingPaymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $claimingPaymentRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        $claimingPaymentRequest->method('getState')->willReturn(PaymentRequestInterface::STATE_COMPLETED);
+
+        $this->order->expects($this->once())->method('getState')->willReturn(OrderInterface::STATE_CART);
+        $this->order->expects($this->once())->method('getLastPayment')->with(PaymentInterface::STATE_CART)->willReturn($this->payment);
+        $this->orderPaymentsRemover
+            ->expects($this->once())
+            ->method('canRemovePayments')
+            ->with($this->order)
+            ->willReturn(false);
+        $this->payment->method('getPaymentRequests')->willReturn(new ArrayCollection([$claimingPaymentRequest]));
+        $this->payment->method('getAmount')->willReturn(4796);
+        $this->payment->method('getCurrencyCode')->willReturn('USD');
+        $this->order->method('getTotal')->willReturn(4796);
+        $this->order->method('getCurrencyCode')->willReturn('USD');
+        $this->payment->expects($this->never())->method('setAmount');
+        $this->payment->expects($this->never())->method('setCurrencyCode');
+        $this->orderPaymentProvider->expects($this->never())->method('provideOrderPayment');
+        $this->order->expects($this->never())->method('addPayment');
+
+        $this->orderPaymentProcessor->process($this->order);
+    }
+
+    public function testShouldOverwriteAmountWhenPaymentRequestIsNotInClaimingState(): void
+    {
+        $failedPaymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $failedPaymentRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        $failedPaymentRequest->method('getState')->willReturn(PaymentRequestInterface::STATE_FAILED);
+
+        $this->order->expects($this->once())->method('getState')->willReturn(OrderInterface::STATE_CART);
+        $this->order->expects($this->once())->method('getLastPayment')->with(PaymentInterface::STATE_CART)->willReturn($this->payment);
+        $this->orderPaymentsRemover
+            ->expects($this->once())
+            ->method('canRemovePayments')
+            ->with($this->order)
+            ->willReturn(false);
+        $this->payment->method('getPaymentRequests')->willReturn(new ArrayCollection([$failedPaymentRequest]));
+        $this->order->expects($this->once())->method('getCurrencyCode')->willReturn('PLN');
+        $this->order->expects($this->once())->method('getTotal')->willReturn(1000);
+        $this->payment->expects($this->once())->method('setCurrencyCode')->with('PLN');
+        $this->payment->expects($this->once())->method('setAmount')->with(1000);
+        $this->orderPaymentProvider->expects($this->never())->method('provideOrderPayment');
 
         $this->orderPaymentProcessor->process($this->order);
     }

--- a/src/Sylius/Component/Core/tests/Payment/Remover/OrderPaymentsRemoverTest.php
+++ b/src/Sylius/Component/Core/tests/Payment/Remover/OrderPaymentsRemoverTest.php
@@ -20,6 +20,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemover;
 use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
 
 final class OrderPaymentsRemoverTest extends TestCase
 {
@@ -72,6 +73,7 @@ final class OrderPaymentsRemoverTest extends TestCase
         $refundedPayment = $this->createMock(PaymentInterface::class);
         $unknownPayment = $this->createMock(PaymentInterface::class);
         $cartPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_CART);
+        $cartPayment->method('getPaymentRequests')->willReturn(new ArrayCollection());
         $authorizedPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_AUTHORIZED);
         $newPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_NEW);
         $processingPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_PROCESSING);
@@ -92,6 +94,29 @@ final class OrderPaymentsRemoverTest extends TestCase
             $unknownPayment,
         ]));
         $this->order->expects($this->once())->method('removePayment')->with($cartPayment);
+
+        $this->remover->removePayments($this->order);
+    }
+
+    public function testShouldNotRemoveCartPaymentClaimedByGateway(): void
+    {
+        $claimingPaymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $claimingPaymentRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        $claimingPaymentRequest->method('getState')->willReturn(PaymentRequestInterface::STATE_PROCESSING);
+
+        $claimedCartPayment = $this->createMock(PaymentInterface::class);
+        $claimedCartPayment->method('getState')->willReturn(PaymentInterface::STATE_CART);
+        $claimedCartPayment->method('getPaymentRequests')->willReturn(new ArrayCollection([$claimingPaymentRequest]));
+
+        $unclaimedCartPayment = $this->createMock(PaymentInterface::class);
+        $unclaimedCartPayment->method('getState')->willReturn(PaymentInterface::STATE_CART);
+        $unclaimedCartPayment->method('getPaymentRequests')->willReturn(new ArrayCollection());
+
+        $this->order->expects($this->once())->method('getPayments')->willReturn(new ArrayCollection([
+            $claimedCartPayment,
+            $unclaimedCartPayment,
+        ]));
+        $this->order->expects($this->once())->method('removePayment')->with($unclaimedCartPayment);
 
         $this->remover->removePayments($this->order);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2 <!-- see the comment below -->
| Bug fix?        | yes
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
