### PR TITLE
Fix shipping tax total calculation

### DIFF
--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -409,8 +409,10 @@ class Order extends BaseOrder implements OrderInterface
     {
         $shippingTaxTotal = 0;
 
-        foreach ($this->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT) as $shippingAdjustment) {
-            $shippingTaxTotal += $shippingAdjustment->getAmount();
+        foreach ($this->getShipments() as $shipment) {
+            foreach ($shipment->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+                $shippingTaxTotal += $taxAdjustment->getAmount();
+            }
         }
 
         return $shippingTaxTotal;

--- a/tests/Api/Responses/admin/order/get_order.json
+++ b/tests/Api/Responses/admin/order/get_order.json
@@ -83,7 +83,7 @@
     "state": "new",
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/admin/order/get_orders_before_date.json
+++ b/tests/Api/Responses/admin/order/get_orders_before_date.json
@@ -87,7 +87,7 @@
             "state": "new",
             "itemsSubtotal": 6000,
             "taxTotal": 0,
-            "shippingTaxTotal": 500,
+            "shippingTaxTotal": 0,
             "taxExcludedTotal": 0,
             "taxIncludedTotal": 0,
             "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/cart/add_item.json
+++ b/tests/Api/Responses/shop/checkout/cart/add_item.json
@@ -52,7 +52,7 @@
     "total": 8500,
     "itemsSubtotal": 8000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/cart/get_cart.json
+++ b/tests/Api/Responses/shop/checkout/cart/get_cart.json
@@ -52,7 +52,7 @@
     "total": 6500,
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_as_guest.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_as_guest.json
@@ -86,7 +86,7 @@
     "state": "cart",
     "itemsSubtotal": 5700,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_as_shop_user.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_as_shop_user.json
@@ -86,7 +86,7 @@
     "state": "cart",
     "itemsSubtotal": 5700,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_with_province_name_only.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_with_province_name_only.json
@@ -82,7 +82,7 @@
     "state": "cart",
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/cart/update_item_quantity.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_item_quantity.json
@@ -52,7 +52,7 @@
     "total": 10500,
     "itemsSubtotal": 10000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/checkout/completion/order_with_shippable_and_non_shippable_items.json
+++ b/tests/Api/Responses/shop/checkout/completion/order_with_shippable_and_non_shippable_items.json
@@ -96,7 +96,7 @@
     "state": "new",
     "itemsSubtotal": 9000,
     "taxTotal": 0,
-    "shippingTaxTotal": 1000,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,

--- a/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_guest.json
+++ b/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_guest.json
@@ -82,7 +82,7 @@
     "state": "cart",
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 1000,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,

--- a/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_user.json
+++ b/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_by_user.json
@@ -82,7 +82,7 @@
     "state": "cart",
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 1000,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,

--- a/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method.json
+++ b/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method.json
@@ -82,7 +82,7 @@
     "state": "cart",
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 1000,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 1000,

--- a/tests/Api/Responses/shop/order/change_payment_method_as_guest.json
+++ b/tests/Api/Responses/shop/order/change_payment_method_as_guest.json
@@ -82,7 +82,7 @@
     "total": 6500,
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/order/change_payment_method_as_user.json
+++ b/tests/Api/Responses/shop/order/change_payment_method_as_user.json
@@ -82,7 +82,7 @@
     "total": 6500,
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/order/get_order_by_guest.json
+++ b/tests/Api/Responses/shop/order/get_order_by_guest.json
@@ -82,7 +82,7 @@
     "total": 6500,
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/order/get_order_by_user.json
+++ b/tests/Api/Responses/shop/order/get_order_by_user.json
@@ -82,7 +82,7 @@
     "total": 6500,
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,

--- a/tests/Api/Responses/shop/order/update_payment_method.json
+++ b/tests/Api/Responses/shop/order/update_payment_method.json
@@ -65,7 +65,7 @@
     "total": 6500,
     "itemsSubtotal": 6000,
     "taxTotal": 0,
-    "shippingTaxTotal": 500,
+    "shippingTaxTotal": 0,
     "taxExcludedTotal": 0,
     "taxIncludedTotal": 0,
     "shippingTotal": 500,


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

getShippingTaxTotal() summed SHIPPING_ADJUSTMENT amounts, which are the shipping fees themselves, not their taxes. The order therefore reported the shipping cost as shipping tax, inflating the taxes total shown in the checkout summary.

Shipping taxes are applied as TAX_ADJUSTMENT on shipments, so sum those adjustments from the order's shipments instead.