### PR TITLE
Allow translatable autocomplete results without a translation in the current locale

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
@@ -95,7 +95,7 @@ final class TranslatableAutocompleteType extends AbstractType
             $translationConditions = self::getComparisons($expr, $options['translation_fields']);
 
             $builder
-                ->innerJoin(
+                ->leftJoin(
                     sprintf('%s.translations', self::ENTITY_ALIAS),
                     self::TRANSLATION_ALIAS,
                     Expr\Join::WITH,


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

# What does this PR do?

This PR changes the translation join in `TranslatableAutocompleteType` from an inner join to a left join.

# Why?

The current inner join excludes entities that do not have a translation for the active locale, even when the search query matches a non-translatable field such as the entity code.

For example, a product without an English translation cannot currently be found by its code when the administration locale is English. This makes it difficult to locate and manage partially translated catalog data.

# Solution

Using a left join keeps entities without a translation in the current locale in the autocomplete query.

As a result:

- entities can still be found through configured entity fields, such as `code`;
- translated fields are still searched when the translation exists;
- existing custom `choice_label` callables can provide an appropriate display fallback when the translated label is unavailable;
- the form type remains model-agnostic and does not make assumptions about the entities it handles.

# Backward compatibility

This change does not modify the public API or existing form options. It only broadens the autocomplete results to include entities without a translation in the requested locale.

# How to test

1. Create a product with a code and without a translation for the current administration locale.
2. Open an autocomplete field using `TranslatableAutocompleteType`.
3. Search for the product using its code.
4. Verify that the product is returned.
5. Verify that products with translations can still be searched by their translated name.