### PR TITLE
[Behat] Do not assume the first row of a table is its header row

### DIFF
--- a/src/Sylius/Behat/Service/Accessor/TableAccessor.php
+++ b/src/Sylius/Behat/Service/Accessor/TableAccessor.php
@@ -165,12 +165,7 @@ final class TableAccessor implements TableAccessorInterface
      */
     private function getColumnIndex(NodeElement $table, $fieldName)
     {
-        $rows = $table->findAll('css', 'tr');
-        Assert::notEmpty($rows, 'There are no rows!');
-
-        /** @var NodeElement $headerRow */
-        $headerRow = $rows[0];
-        $headers = $headerRow->findAll('css', 'th,td');
+        $headers = $this->getHeaderRow($table)->findAll('css', 'th,td');
 
         /** @var NodeElement $column */
         foreach ($headers as $index => $column) {
@@ -181,6 +176,22 @@ final class TableAccessor implements TableAccessorInterface
         }
 
         throw new \InvalidArgumentException(sprintf('Column with name "%s" not found!', $fieldName));
+    }
+
+    private function getHeaderRow(NodeElement $table): NodeElement
+    {
+        /** @var NodeElement[] $headRows */
+        $headRows = $table->findAll('css', 'thead tr');
+        foreach ($headRows as $headRow) {
+            if ([] !== $headRow->findAll('css', 'th')) {
+                return $headRow;
+            }
+        }
+
+        $rows = $table->findAll('css', 'tr');
+        Assert::notEmpty($rows, 'There are no rows!');
+
+        return $rows[0];
     }
 
     /**
@@ -198,7 +209,7 @@ final class TableAccessor implements TableAccessorInterface
     {
         return
             $column->getAttribute('data-test-table') ??
-            preg_replace('/.*sylius-table-column-([^ ]+).*$/', '\1', $column->getAttribute('class'))
+            preg_replace('/.*sylius-table-column-([^ ]+).*$/', '\1', $column->getAttribute('class') ?? '')
         ;
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

`TableAccessor` resolves column indexes by reading the **first `<tr>` of the table** as the header row:

```php
$rows = $table->findAll('css', 'tr');
$headerRow = $rows[0];
```

Since 2.2.9 that assumption no longer holds. `data_table#pre_header` is rendered **inside `<thead>`, above the header row**, so any row a plugin injects there becomes `$rows[0]`:

```twig
{# shared/crud/index/content/grid/data_table.html.twig #}
<thead>
{% hook 'data_table#pre_header' %}
<tr>
    {{ table.headers(resources, resources.definition, app.request.attributes) }}
</tr>
</thead>
```

Column names are then looked up in the injected row instead of the real header, and on any cell without a `class` attribute it fatals:

```
Type error: preg_replace(): Argument #3 ($subject) must be of type array|string, null given
  in src/Sylius/Behat/Service/Accessor/TableAccessor.php:201
```

This is not caught by our own suite because nothing in `src/` hooks into `data_table#pre_header` — it is an extension point shipped without a consumer or a test.

### What this changes

1. `getColumnIndex()` now takes the first `<tr>` in `<thead>` that contains a `<th>`, falling back to `$rows[0]`. The header macro emits only `<th>` cells (in both the sortable and non-sortable branch), while injected rows use `<td>`, so they no longer shadow the header. The fallback preserves the current behaviour for tables without a `<thead>` and for headers built from `<td>`.
2. `getColumnFieldName()` guards against a missing `class` attribute. `NodeElement::getAttribute()` returns `?string`, so today *any* cell without a `class` raises a `TypeError` instead of a readable exception — independent of the hook.

### How it was found

Reported from [Sylius/MolliePlugin#364](https://github.com/Sylius/MolliePlugin/pull/364), which is the first consumer of this hook anywhere. The suggested-payment-method row only renders when that gateway is **not** configured, so it breaks the Behat suite of every shop that lists payment methods without it — and the same applies to any other payment plugin using the hook it was added for.

Verified against that plugin: the failing scenario passes with this patch and fails without it, with the exact stack trace above.
