### PR TITLE
Remove upmerges to 2.2 and symfony 8 branches

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -21,14 +21,8 @@ jobs:
             matrix:
                 include:
                     -
-                        base_branch: "2.1"
-                        target_branch: "2.2"
-                    -
                         base_branch: "2.2"
                         target_branch: "2.3"
-                    -
-                        base_branch: "2.3"
-                        target_branch: "symfony-8"
         steps:
             -
                 uses: actions/checkout@v4


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
