### PR TITLE
Resolve the picked checkout address from the customer address book

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,3 +1,15 @@
+# UPGRADE FROM `2.2.9` TO `2.2.10`
+
+## Deprecations
+
+1. The `$addressRepository` argument of `Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address\FormComponent`
+   is no longer used. It is now nullable and optional, passing it triggers a deprecation, and the Sylius service
+   definition no longer passes it.
+
+   Drop it from your own service definitions. Classes extending the component must stop reading the
+   `$addressRepository` property: it is `null` unless your own definition passes it. Both the argument and the
+   property will be removed in Sylius `3.0`.
+
 # UPGRADE FROM `2.2.8` TO `2.2.9`
 
 This is a **security release**. Updating is strongly recommended.

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/checkout.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/checkout.xml
@@ -23,7 +23,7 @@
             <argument>Sylius\Bundle\ShopBundle\Form\Type\Checkout\AddressType</argument>
             <argument type="service" id="sylius.context.customer" />
             <argument type="service" id="sylius.repository.shop_user" />
-            <argument type="service" id="sylius.repository.address" />
+            <argument type="constant">null</argument>
             <argument type="tagged_iterator" tag="sylius_shop.modifier.address_form_values" />
 
             <tag name="sylius.live_component.shop" key="sylius_shop:checkout:address:form" />

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -54,11 +54,21 @@ class FormComponent
         string $formClass,
         protected readonly CustomerContextInterface $customerContext,
         protected readonly UserRepositoryInterface $shopUserRepository,
-        protected readonly AddressRepositoryInterface $addressRepository,
+        protected readonly ?AddressRepositoryInterface $addressRepository = null,
         /** @var iterable<AddressFormValuesModifierInterface> */
         protected readonly ?iterable $addressFormValuesModifiers = null,
     ) {
         $this->initialize($repository, $formFactory, $resourceClass, $formClass);
+        if (null !== $this->addressRepository) {
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '2.2.10',
+                'Passing an instance of "%s" as the seventh argument to "%s" is deprecated and the argument will be removed in Sylius 3.0.',
+                AddressRepositoryInterface::class,
+                self::class,
+            );
+        }
+
         if (null === $this->addressFormValuesModifiers) {
             trigger_deprecation(
                 'sylius/shop-bundle',
@@ -87,7 +97,7 @@ class FormComponent
             return;
         }
 
-        $address = $this->addressRepository->findOneByCustomer((string) $addressId, $customer);
+        $address = $this->findAddressAvailableToCustomer($customer, $addressId);
         if (null === $address) {
             return;
         }
@@ -111,6 +121,21 @@ class FormComponent
             $this->resource,
             ['customer' => $this->customerContext->getCustomer()],
         );
+    }
+
+    private function findAddressAvailableToCustomer(CustomerInterface $customer, mixed $addressId): ?AddressInterface
+    {
+        if (!is_scalar($addressId)) {
+            return null;
+        }
+
+        foreach ($customer->getAddresses() as $address) {
+            if ((string) $address->getId() === (string) $addressId) {
+                return $address;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Sylius/Bundle/ShopBundle/tests/Twig/Component/Checkout/Address/FormComponentTest.php
+++ b/src/Sylius/Bundle/ShopBundle/tests/Twig/Component/Checkout/Address/FormComponentTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ShopBundle\Modifier\DefaultAddressFormValuesModifier;
+use Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address\FormComponent;
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\AddressRepositoryInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Customer\Context\CustomerContextInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+final class FormComponentTest extends TestCase
+{
+    private CustomerContextInterface&MockObject $customerContext;
+
+    private AddressRepositoryInterface&MockObject $addressRepository;
+
+    private FormComponent $formComponent;
+
+    protected function setUp(): void
+    {
+        $this->customerContext = $this->createMock(CustomerContextInterface::class);
+        $this->addressRepository = $this->createMock(AddressRepositoryInterface::class);
+
+        $this->formComponent = new FormComponent(
+            $this->createMock(OrderRepositoryInterface::class),
+            $this->createMock(FormFactoryInterface::class),
+            OrderInterface::class,
+            'form_type',
+            $this->customerContext,
+            $this->createMock(UserRepositoryInterface::class),
+            $this->addressRepository,
+            [new DefaultAddressFormValuesModifier()],
+        );
+    }
+
+    public function testFillsTheFormWithAnAddressFromTheCustomerAddressBook(): void
+    {
+        $address = $this->createAddress(1);
+        $this->customerContext->method('getCustomer')->willReturn($this->createCustomer($address));
+        $this->addressRepository->expects($this->never())->method('findOneByCustomer');
+
+        $this->formComponent->formValues = ['shippingAddress' => []];
+        $this->formComponent->addressFieldUpdated('1', 'shippingAddress');
+
+        $this->assertSame(
+            [
+                'firstName' => 'Lucius',
+                'lastName' => 'Fox',
+                'phoneNumber' => '555-0100',
+                'company' => 'Wayne Enterprises',
+                'countryCode' => 'US',
+                'street' => '1007 Mountain Drive',
+                'city' => 'Gotham',
+                'postcode' => '53701',
+            ],
+            $this->formComponent->formValues['shippingAddress'],
+        );
+    }
+
+    public function testDoesNothingWhenTheAddressIsNotInTheCustomerAddressBook(): void
+    {
+        $this->customerContext->method('getCustomer')->willReturn($this->createCustomer($this->createAddress(1)));
+
+        $this->formComponent->formValues = ['shippingAddress' => []];
+        $this->formComponent->addressFieldUpdated('2', 'shippingAddress');
+
+        $this->assertSame([], $this->formComponent->formValues['shippingAddress']);
+    }
+
+    public function testDoesNothingWhenThereIsNoCustomer(): void
+    {
+        $this->customerContext->method('getCustomer')->willReturn(null);
+
+        $this->formComponent->formValues = ['shippingAddress' => []];
+        $this->formComponent->addressFieldUpdated('1', 'shippingAddress');
+
+        $this->assertSame([], $this->formComponent->formValues['shippingAddress']);
+    }
+
+    public function testWorksWithoutTheDeprecatedAddressRepository(): void
+    {
+        $address = $this->createAddress(1);
+        $this->customerContext->method('getCustomer')->willReturn($this->createCustomer($address));
+
+        $formComponent = new FormComponent(
+            $this->createMock(OrderRepositoryInterface::class),
+            $this->createMock(FormFactoryInterface::class),
+            OrderInterface::class,
+            'form_type',
+            $this->customerContext,
+            $this->createMock(UserRepositoryInterface::class),
+            null,
+            [new DefaultAddressFormValuesModifier()],
+        );
+
+        $formComponent->formValues = ['shippingAddress' => []];
+        $formComponent->addressFieldUpdated('1', 'shippingAddress');
+
+        $this->assertSame('1007 Mountain Drive', $formComponent->formValues['shippingAddress']['street']);
+    }
+
+    public function testDoesNothingWhenTheAddressIdentifierIsNotScalar(): void
+    {
+        $this->customerContext->method('getCustomer')->willReturn($this->createCustomer($this->createAddress(1)));
+
+        $this->formComponent->formValues = ['shippingAddress' => []];
+        $this->formComponent->addressFieldUpdated(['1'], 'shippingAddress');
+
+        $this->assertSame([], $this->formComponent->formValues['shippingAddress']);
+    }
+
+    private function createCustomer(AddressInterface ...$addresses): CustomerInterface&MockObject
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getAddresses')->willReturn(new ArrayCollection($addresses));
+
+        return $customer;
+    }
+
+    private function createAddress(int $id): AddressInterface&MockObject
+    {
+        $address = $this->createMock(AddressInterface::class);
+        $address->method('getId')->willReturn($id);
+        $address->method('getFirstName')->willReturn('Lucius');
+        $address->method('getLastName')->willReturn('Fox');
+        $address->method('getPhoneNumber')->willReturn('555-0100');
+        $address->method('getCompany')->willReturn('Wayne Enterprises');
+        $address->method('getCountryCode')->willReturn('US');
+        $address->method('getProvinceCode')->willReturn(null);
+        $address->method('getProvinceName')->willReturn(null);
+        $address->method('getStreet')->willReturn('1007 Mountain Drive');
+        $address->method('getCity')->willReturn('Gotham');
+        $address->method('getPostcode')->willReturn('53701');
+
+        return $address;
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets |
| License         | MIT

## Problem

The checkout address book describes one rule — which addresses the customer may use — in two places:

| | source |
|---|---|
| `AddressBookComponent::getAddresses()` | `CustomerInterface::getAddresses()` |
| `FormComponent::addressFieldUpdated()` | `AddressRepositoryInterface::findOneByCustomer()` |

They agree only as long as `getAddresses()` returns exactly the addresses whose `customer` column points back at the customer. In plain Sylius it does, so nothing is visible.

An application that widens `getAddresses()` breaks the agreement, and the failure is silent: the picker offers an address, `findOneByCustomer()` inner joins on `o.customer` and finds nothing, the listener returns early, and the form stays as it was. No error, no log entry, the select simply looks broken.


## Fix

Resolve the picked address from the list the picker rendered, so a single source describes what the customer may use:

```php
$address = $this->findAddressAvailableToCustomer($customer, $addressId);
```

The scoping added in f4c9bf0 stays in place — the lookup is still restricted to the current customer, just to the same set the component offered. A non-scalar `#[LiveArg]` is now rejected before it reaches a string cast, which also removes an `Array to string conversion` warning reachable from a manipulated payload.

`$customer->getAddresses()` is a `PersistentCollection` that the same request loads anyway when the address book child component re-renders, so this does not add a query in the common path.

## Tests

`src/Sylius/Bundle/ShopBundle/tests/Twig/Component/Checkout/Address/FormComponentTest.php`, four cases. The first asserts `expects($this->never())->method('findOneByCustomer')`, which is what guards the change; the middle two pass before the change as well, so they hold the IDOR scoping in place rather than merely following it.

Against the unpatched component:

```
✘ Fills the form with an address from the customer address book
  findOneByCustomer('1', ...) was not expected to be called.
✔ Does nothing when the address is not in the customer address book
✔ Does nothing when there is no customer
⚠ Does nothing when the address identifier is not scalar
```

ECS and PHPStan are clean on both files.

## Deprecation

`$addressRepository` is no longer used by this class. It becomes nullable and optional, passing it triggers a deprecation, and the Sylius service definition stops passing it:

```xml
-            <argument type="service" id="sylius.repository.address" />
+            <argument type="constant">null</argument>
```

so the notice reaches only the applications that define the service themselves and can act on it. A stock installation sees nothing.

The guard on the trigger matters for the same reason — without it the notice would also fire for anyone who already stopped passing the argument, which is the behaviour `DashboardController` shipped with in `1.14`.

The trade-off worth a maintainer's eye: a class extending the component and reading the `protected $addressRepository` property now receives `null` unless its own definition passes the argument. Keeping the argument in the definition instead would protect those classes, at the cost of raising a deprecation on every installation that cannot act on it. `UPGRADE-2.2.md` states the consequence. Both the argument and the property can go in `3.0`.
