### PR TITLE
Fix/grid legacy switch 2.3

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/grid.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/grid.php
@@ -156,7 +156,7 @@ return static function (ContainerConfigurator $container) {
     ;
     $services->alias(ProductAssociationTypeGridInterface::class, 'sylius_admin.grid.product_association_type');
 
-    $services->set('syllabus_admin.grid.taxon', TaxonGrid::class)
+    $services->set('sylius_admin.grid.taxon', TaxonGrid::class)
         ->tag('sylius.invokable_grid')
     ;
     $services->alias(TaxonGridInterface::class, 'sylius_admin.grid.taxon');

--- a/src/Sylius/Bundle/CoreBundle/Grid/Provider/OverrideGridProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Grid/Provider/OverrideGridProvider.php
@@ -35,7 +35,7 @@ final class OverrideGridProvider implements GridProviderInterface
 
     public function get(string $code): Grid
     {
-        $useYamlGrid = $this->configuration['use_legacy_config'] ?? $this->configuration['grids'][$code]['use_legacy_config'] ?? true;
+        $useYamlGrid = $this->configuration['grids'][$code]['use_legacy_config'] ?? $this->configuration['use_legacy_config'] ?? true;
         if ($useYamlGrid) {
             try {
                 return $this->arrayGridProvider->get($code);

--- a/src/Sylius/Bundle/CoreBundle/tests/Grid/Provider/OverrideGridProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Grid/Provider/OverrideGridProviderTest.php
@@ -88,6 +88,64 @@ final class OverrideGridProviderTest extends TestCase
         self::assertEquals($this->gridDefinition, $gridDefinition);
     }
 
+    public function test_per_grid_configuration_takes_precedence_over_the_global_one(): void
+    {
+        $this->arrayProvider
+            ->expects($this->once())
+            ->method('get')
+            ->with('app_book')
+            ->willReturn($this->gridDefinition)
+        ;
+        $this->chainProvider
+            ->expects($this->never())
+            ->method('get')
+        ;
+
+        $configurableProvider = new OverrideGridProvider(
+            [
+                'use_legacy_config' => false,
+                'grids' => [
+                    'app_book' => ['use_legacy_config' => true],
+                ],
+            ],
+            $this->chainProvider,
+            $this->arrayProvider,
+        );
+
+        $gridDefinition = $configurableProvider->get('app_book');
+
+        self::assertEquals($this->gridDefinition, $gridDefinition);
+    }
+
+    public function test_grids_without_their_own_configuration_follow_the_global_one(): void
+    {
+        $this->arrayProvider
+            ->expects($this->never())
+            ->method('get')
+        ;
+        $this->chainProvider
+            ->expects($this->once())
+            ->method('get')
+            ->with('app_author')
+            ->willReturn($this->gridDefinition)
+        ;
+
+        $configurableProvider = new OverrideGridProvider(
+            [
+                'use_legacy_config' => false,
+                'grids' => [
+                    'app_book' => ['use_legacy_config' => true],
+                ],
+            ],
+            $this->chainProvider,
+            $this->arrayProvider,
+        );
+
+        $gridDefinition = $configurableProvider->get('app_author');
+
+        self::assertEquals($this->gridDefinition, $gridDefinition);
+    }
+
     public function test_using_the_array_provider_by_default(): void
     {
         $this->arrayProvider


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 2.2 branch
 - Features and deprecations must be submitted against the 2.3 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

## Per-grid configuration was ignored whenever the global one was set

`OverrideGridProvider` read the global key first:

```php
$useYamlGrid = $this->configuration['use_legacy_config']
    ?? $this->configuration['grids'][$code]['use_legacy_config']
    ?? true;
```

`??` stops at the first non-null value, so any explicit global value made every per-grid entry
unreachable. Per-grid settings only worked as long as nobody wrote the global key at all.

## Upgrade notes

- The stated default was wrong. The notes said `(default: false)`, but the global node is `defaultNull()`
  and `OverrideGridProvider` falls back to `true`, so the effective default is YAML.
  `OverrideGridProviderTest::test_using_the_array_provider_by_default` asserts exactly that.
- Added a short "Customising a grid" note pointing at grid mutators, which are applied by both providers
  and therefore keep working after a grid moves to PHP, unlike a YAML override.
- Linked the mutator and "creating a grid in PHP" pages next to the existing grid documentation link.
- Dropped a stray `?utm_source=chatgpt.com` from the Grid Config Converter link.
