### PR TITLE
Exclude pre-release versions from the "new version available" hub notification

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
+++ b/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
@@ -53,7 +53,8 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
 
         if (
             $latestVersion === null ||
-            $latestVersion === SyliusCoreBundle::VERSION
+            $latestVersion === SyliusCoreBundle::VERSION ||
+            !$this->isStableVersion($latestVersion)
         ) {
             return [];
         }
@@ -105,5 +106,19 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
         }
 
         return strtoupper($responseContent['version']);
+    }
+
+    /**
+     * The hub at $this->hubUri returns the latest version it has ever built,
+     * including pre-releases (e.g. "2.3.0-ALPHA.1") — it is not aware of
+     * Composer stability flags or this installation's own constraints. A
+     * pre-release compared against a stable installed version is always
+     * "different", so without this check every stable installation would
+     * be told to upgrade to an unreleased, untested build as soon as one
+     * enters the pipeline, for the entire time it stays in pre-release.
+     */
+    private function isStableVersion(string $version): bool
+    {
+        return preg_match('/-(dev|alpha|beta|rc)\b/i', $version) !== 1;
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\AdminBundle\Notification;
 
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -84,6 +85,33 @@ final class HubNotificationProviderTest extends TestCase
         $provider = $this->createProvider(hubResponse: ['foo' => 'bar']);
 
         $this->assertEmpty($provider->getNotifications());
+    }
+
+    /**
+     * @return iterable<array-key, array{0: string}>
+     */
+    public static function preReleaseVersionProvider(): iterable
+    {
+        yield ['2.3.0-ALPHA.1'];
+        yield ['2.3.0-alpha.1'];
+        yield ['2.3.0-BETA.2'];
+        yield ['2.3.0-RC.1'];
+        yield ['2.3.0-DEV'];
+    }
+
+    #[DataProvider('preReleaseVersionProvider')]
+    public function testDoesNotReturnNotificationIfLatestVersionIsAPreRelease(string $preReleaseVersion): void
+    {
+        $provider = $this->createProvider(hubResponse: ['version' => $preReleaseVersion]);
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    public function testReturnsNotificationIfLatestVersionIsAStableReleaseContainingAHyphen(): void
+    {
+        $provider = $this->createProvider(hubResponse: ['version' => 'NEW-VERSION']);
+
+        $this->assertNotEmpty($provider->getNotifications());
     }
 
     public function testDoesNotCallHubWhenCacheExists(): void


### PR DESCRIPTION
## Summary

Closes #10919.

The Hub notification (`sylius_admin.provider.notification.hub`) tells every admin "a new version of Sylius is available" as soon as *any* newer version has ever been built — including pre-releases. The hub at `gus.sylius.com/version` returns the latest version it has ever produced, with no concept of Composer stability flags, so a pre-release like `2.3.0-ALPHA.1` reads as "different" from an installed stable `2.2.9` and triggers the notification, even though a normal `composer update` (respecting the default stable-only constraint) would never actually install it.

Reproduced fresh today:
```
$ curl https://gus.sylius.com/version -d '{"version":"2.2.9",...}'
{"version":"2.3.0-alpha.1"}
```
— on a shop pinned to `sylius/sylius: v2.2.9` with nothing newer available under its own constraint, the admin dashboard still shows "Eine neue Version von Sylius ist verfügbar. Kontaktieren Sie Ihren Administrator, um ein Upgrade durchzuführen."

This is exactly what was reported in #10919 back in 2019 (`1.7.0-ALPHA.2` at the time) — still unresolved six years later, so it isn't specific to one release cycle.

## What changed

`HubNotificationProvider::getNotifications()` now also checks the returned version for the standard pre-release markers (`dev`, `alpha`, `beta`, `rc`) before returning a notification, and suppresses it if one is present — same effect as the "exclude alpha/beta version" suggestion in the original issue.

Deliberately not using `composer/semver`'s stability parser: it isn't currently a dependency of this package, and adding one for a single regex-equivalent check felt like the wrong trade-off. Open to switching to it if maintainers would prefer that instead.

## Testing performed

- Added a `#[DataProvider]`-driven test covering `ALPHA`/`alpha` (both cases, since the existing code uppercases the hub's response before comparing), `BETA`, `RC`, and `DEV` suffixes — all correctly suppress the notification.
- Added a test confirming a stable version string that merely *contains* a hyphen (`NEW-VERSION`, already used by an existing test) still triggers the notification — the new check doesn't accidentally reject ordinary stable version strings.
- Full existing test file still passes (15 tests total, 9 pre-existing + 6 new, 22 assertions).
- `vendor/bin/ecs check` on both changed files: clean.
- `vendor/bin/phpstan analyse` on both changed files: no errors.

## Type of change
- [x] Bug fix (non-breaking)

## Related issues
- Closes #10919
